### PR TITLE
*:add interrupt interaction

### DIFF
--- a/syncer/main.go
+++ b/syncer/main.go
@@ -55,16 +55,19 @@ func main() {
 	syncer := NewSyncer(cfg)
 
 	sc := make(chan os.Signal, 1)
-	signal.Notify(sc,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
 
 	go func() {
-		sig := <-sc
-		log.Infof("Got signal [%d] to exit.", sig)
-		syncer.Close()
+		for {
+			signal.Notify(sc,
+				syscall.SIGHUP,
+				syscall.SIGINT,
+				syscall.SIGTERM,
+				syscall.SIGQUIT)
+
+			sig := <-sc
+			log.Infof("Got signal [%d] to exit.", sig)
+			syncer.Close()
+		}
 	}()
 
 	go func() {


### PR DESCRIPTION
when the amount of data is large,DDL job will take more time to synchronize and can not exit immediately.and this PR add interrupt interaction when run a ddl job.
@siddontang @qiuyesuifeng  PTAL
