### PR TITLE
make exit more graceful

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -688,8 +688,6 @@ func (s *Syncer) Close() {
 
 	s.cancel()
 
-	<-s.done
-
 	closeJobChans(s.jobs)
 
 	s.wg.Wait()
@@ -701,6 +699,8 @@ func (s *Syncer) Close() {
 		s.syncer.Close()
 		s.syncer = nil
 	}
+	
+	<-s.done
 
 	s.closed.Set(true)
 }


### PR DESCRIPTION
run() return exit will cause main return
