### PR TITLE
GI: fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ check:
 
 	$(GO) tool vet . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
 	$(GO) tool vet --shadow . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
-	golint ./... 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
-	gofmt -s -l . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
+	golint ./... 2>&1 | grep -vE 'vendor|loader' | awk '{print} END{if(NR>0) {exit 1}}'
+	gofmt -s -l . 2>&1 | grep -vE 'vendor|loader' | awk '{print} END{if(NR>0) {exit 1}}'
 
 update:
 	which glide >/dev/null || curl https://glide.sh/get | sh

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ check:
 
 	$(GO) tool vet . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
 	$(GO) tool vet --shadow . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
-	golint ./... 2>&1 | grep -vE 'vendor|loader' | awk '{print} END{if(NR>0) {exit 1}}'
-	gofmt -s -l . 2>&1 | grep -vE 'vendor|loader' | awk '{print} END{if(NR>0) {exit 1}}'
+	golint ./... 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
+	gofmt -s -l . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
 
 update:
 	which glide >/dev/null || curl https://glide.sh/get | sh

--- a/pkg/tableroute/trieroute.go
+++ b/pkg/tableroute/trieroute.go
@@ -163,7 +163,7 @@ func (t *trieRouter) insert(root *node, pattern string) (*item, error) {
 }
 
 // Match implements Router's Match()
-// if there are more than two matchs, just return first one
+// if there are more than one matchs, just return one of them
 func (t *trieRouter) Match(schema, table string) (string, string) {
 	if len(schema) == 0 {
 		return "", ""
@@ -189,35 +189,29 @@ func (t *trieRouter) Match(schema, table string) (string, string) {
 	t.Lock()
 	// find matched schemas
 	targetSchemas := &itemList{}
+	targetSchema := ""
 	t.matchNode(t.root, schema, targetSchemas)
-	for _, schema := range targetSchemas.items {
+	for _, s := range targetSchemas.items {
 		targetTables := &itemList{}
 		// if table is empty, just return first matched schema
 		if len(table) == 0 {
+			t.addToCache(targetStr, []string{s.schema, ""})
 			t.Unlock()
-			if len(schema.schema) > 0 {
-				return schema.schema, ""
-			}
-			return "", ""
+			return s.schema, ""
 		}
+		targetSchema = s.schema
 		// find matched tables
-		t.matchNode(schema.child, table, targetTables)
+		t.matchNode(s.child, table, targetTables)
 		if len(targetTables.items) > 0 {
-			t.cache[targetStr] = []string{targetTables.items[0].schema, targetTables.items[0].table}
-			if len(t.cache) > maxCacheNum {
-				for literal := range t.cache {
-					delete(t.cache, literal)
-					break
-				}
-			}
+			t.addToCache(targetStr, []string{targetTables.items[0].schema, targetTables.items[0].table})
 			t.Unlock()
 			return targetTables.items[0].schema, targetTables.items[0].table
 		}
 	}
-
+	// not found table
+	t.addToCache(targetStr, []string{targetSchema, ""})
 	t.Unlock()
-	return "", ""
-
+	return targetSchema, ""
 }
 
 // Remove implements Router's Remove(), but it do nothing now
@@ -250,6 +244,16 @@ func (t *trieRouter) AllRules() map[string]map[string][]string {
 	}
 	t.RUnlock()
 	return rules
+}
+
+func (t *trieRouter) addToCache(key string, targets []string) {
+	t.cache[key] = targets
+	if len(t.cache) > maxCacheNum {
+		for literal := range t.cache {
+			delete(t.cache, literal)
+			break
+		}
+	}
 }
 
 func (t *trieRouter) travel(n *node, characters []byte, rules map[string]*item) {

--- a/pkg/tableroute/trieroute_test.go
+++ b/pkg/tableroute/trieroute_test.go
@@ -24,12 +24,12 @@ func (t *testRouteSuite) TestRoute(c *C) {
 func (t *testRouteSuite) testInsert(c *C, r TableRouter) {
 	var err error
 	cases := map[string]map[string][]string{
-		"?bc":  map[string][]string{"abc*": {"abc", "abc1"}, "xyz*": {"abc", "abc2"}},
-		"a?c":  map[string][]string{"xyz*": {"abc", "abc2"}, "abc*": {"abc", "abc2"}},
-		"ab*":  map[string][]string{"abc*": {"abc", "abc3"}},
-		"a*":   map[string][]string{"": {"abc", ""}},
-		"xyz":  map[string][]string{"xyz*": {"abc", "abc4"}},
-		"xyy*": map[string][]string{"xyz*": {"xyz", "abc5"}},
+		"?bc":  {"abc*": []string{"abc", "abc1"}, "xyz*": []string{"abc", "abc2"}},
+		"a?c":  {"xyz*": {"abc", "abc2"}, "abc*": {"abc", "abc2"}},
+		"ab*":  {"abc*": {"abc", "abc3"}},
+		"a*":   {"": {"abc", ""}},
+		"xyz":  {"xyz*": {"abc", "abc4"}},
+		"xyy*": {"xyz*": {"xyz", "abc5"}},
 	}
 	for schema, targets := range cases {
 		for table, target := range targets {
@@ -56,6 +56,7 @@ func (t *testRouteSuite) testMatch(c *C, r TableRouter) {
 		{"adc", "abc1", "abc", "abc2"},
 		{"adc", "xyz1", "abc", "abc2"},
 		{"axc", "xyz1", "abc", "abc2"},
+		{"dbc", "xxx", "abc", ""},
 	}
 	cache := make(map[string][]string)
 	for _, tc := range cases {
@@ -69,4 +70,9 @@ func (t *testRouteSuite) testMatch(c *C, r TableRouter) {
 	trie, ok := r.(*trieRouter)
 	c.Assert(ok, IsTrue)
 	c.Assert(trie.cache, DeepEquals, cache)
+	// test schema mathced
+	shema, table := r.Match("dbc", "")
+	c.Assert(shema, Equals, "abc")
+	c.Assert(table, Equals, "")
+	c.Assert(trie.cache["`dbc`"], DeepEquals, []string{"abc", ""})
 }


### PR DESCRIPTION
fix the bug: if call `Match(schema, table)` (schema has matched target schema, but not table), it should` [target schema, ""]` instead of `["", ""]`