### PR TITLE
Update generate_savepoint.go

### DIFF
--- a/generate_binlog_position/generate_savepoint.go
+++ b/generate_binlog_position/generate_savepoint.go
@@ -44,7 +44,7 @@ func GenSavepointInfo(cfg *Config) error {
 	}
 
 	// generate meta infomation
-	meta := NewLocalMeta(path.Join(cfg.DataDir, "savePoint"))
+	meta := NewLocalMeta(path.Join(cfg.DataDir, "savepoint"))
 	err = meta.Save(commitTS, cfg.TimeZone)
 	return errors.Trace(err)
 }


### PR DESCRIPTION
Drainer will encounter some errors while it starting if the savepoint filename is "savePoint"(note in there, the "P" is uppercase).