### PR TITLE
offset_test.go: add timeout config

### DIFF
--- a/tidb_binlog/driver/reader/offset_test.go
+++ b/tidb_binlog/driver/reader/offset_test.go
@@ -46,6 +46,9 @@ func (to *testOffsetSuite) SetUpSuite(c *C) {
 	to.config = sarama.NewConfig()
 	to.config.Producer.Partitioner = sarama.NewManualPartitioner
 	to.config.Producer.Return.Successes = true
+	to.config.Net.DialTimeout = time.Second * 3
+	to.config.Net.ReadTimeout = time.Second * 3
+	to.config.Net.WriteTimeout = time.Second * 3
 	// need at least version to delete topic
 	to.config.Version = sarama.V0_10_1_0
 	var err error


### PR DESCRIPTION
this reduce the time to run test if the kafka is not available