### PR TITLE
pkg: add binlog event filter

### DIFF
--- a/pkg/binlog-filter/README.md
+++ b/pkg/binlog-filter/README.md
@@ -1,0 +1,83 @@
+# Binlog Filter
+
+## introduction
+
+Binlog Filter is a libary to provide a simple and unified way to filter binlog events with the following features:
+
+- Do/Ignore databases
+
+    /Ignore replicated data from these databases.
+
+- Do/Ignore tables
+    
+    Synchronize/Ignore replicated data from these tables.
+
+- Do/Ignore binlog events
+    
+    Synchronize/Ignore some specified replicated binlog events from these specfied databases/tables by given rules.
+
+- Do/Ignore binlog queries
+
+    Synchronize/Ignore some specified replicated binlog queries that is in Binog Query Event from these specfied databases/tables by given rules.
+
+## binlog event rule
+
+we define a rule BinlogEventRule to filter specified binlog events and queries that is in Binog Query Event
+
+```go
+type BinlogEventRule struct {
+	SchemaPattern string      `jsSynchronizeon:"schema-pattern" toml:"schema-pattern"`
+	TablePattern  string      `json:"table-pattern" toml:"table-pattern"`
+	DMLEvent      []EventType `json:"dml" toml:"dml"`                 
+	DDLEvent      []EventType `json:"ddl" toml:"ddl"`
+	SQLPattern    []string    `json:"sql-pattern" toml:"sql-pattern"` // regular expression
+	sqlRegularExp *regexp.Regexp
+
+	Action ActionType `json:"action" toml:"action"`
+}
+```
+
+now we support following events 
+
+``` go
+    // it indicates all dml/ddl events in rule
+    AllEvent
+    
+	// it indicates no any dml/ddl events in rule,
+	// and equals empty rule.DDLEvent/DMLEvent array
+	NoneEvent
+
+    // DML events
+	InsertEvent
+	UpdateEvent
+	DeleteEvent
+
+    // DDL events
+	CreateDatabase
+	DropDatabase
+	CreateTable
+	DropTable
+	TruncateTable
+	RenameTable
+	CreateIndex
+	DropIndex
+	AlertTable
+
+    // unknow event
+	NullEvent EventType = ""
+```
+
+## notice
+if you want to use BinlogEventRule to synchronize/ignore some table, you must pay attention to setting `AllEvent` and `NoneEvent`.
+
+like synchronizing all events from specified table, ignore is opposite.
+``` go
+BinlogEventRule {
+	SchemaPattern: test*,
+	TablePattern:  test*,
+	DMLEvent:     []EventType{AllEvent},               
+	DDLEvent:     []EventType{AllEvent},
+
+    Action: Do,
+}
+```

--- a/pkg/binlog-filter/README.md
+++ b/pkg/binlog-filter/README.md
@@ -14,15 +14,15 @@ Binlog Filter is a libary to provide a simple and unified way to filter binlog e
 
 - Do/Ignore binlog events
     
-    Synchronize/Ignore some specified replicated binlog events from these specfied databases/tables by given rules.
+    Synchronize/Ignore some specified replicated `Binlog Events` from these specfied databases/tables by given rules.
 
 - Do/Ignore binlog queries
 
-    Synchronize/Ignore some specified replicated binlog queries that is in Binog Query Event from these specfied databases/tables by given rules.
+    Synchronize/Ignore some specified replicated queries that is in `Binog Query Event` from these specfied databases/tables by given rules.
 
 ## binlog event rule
 
-we define a rule BinlogEventRule to filter specified binlog events and queries that is in Binog Query Event
+we define a rule `BinlogEventRule` to filter specified `Binlog Events` and queries that is in `Binog Query Event`
 
 ```go
 type BinlogEventRule struct {
@@ -40,35 +40,35 @@ type BinlogEventRule struct {
 now we support following events 
 
 ``` go
-    // it indicates all dml/ddl events in rule
-    AllEvent
+// it indicates all dml/ddl events in rule
+AllEvent
     
-	// it indicates no any dml/ddl events in rule,
-	// and equals empty rule.DDLEvent/DMLEvent array
-	NoneEvent
+// it indicates no any dml/ddl events in rule,
+// and equals empty rule.DDLEvent/DMLEvent array
+NoneEvent
 
-    // DML events
-	InsertEvent
-	UpdateEvent
-	DeleteEvent
+// DML events
+InsertEvent
+UpdateEvent
+DeleteEvent
 
-    // DDL events
-	CreateDatabase
-	DropDatabase
-	CreateTable
-	DropTable
-	TruncateTable
-	RenameTable
-	CreateIndex
-	DropIndex
-	AlertTable
+// DDL events
+CreateDatabase
+DropDatabase
+CreateTable
+DropTable
+TruncateTable
+RenameTable
+CreateIndex
+DropIndex
+AlertTable
 
-    // unknow event
-	NullEvent EventType = ""
+// unknow event
+NullEvent EventType = ""
 ```
 
 ## notice
-if you want to use BinlogEventRule to synchronize/ignore some table, you must pay attention to setting `AllEvent` and `NoneEvent`.
+if you want to use `BinlogEventRule` to synchronize/ignore some table, you may need to pay attention to setting `AllEvent` and `NoneEvent`.
 
 like synchronizing all events from specified table, ignore is opposite.
 ``` go

--- a/pkg/binlog-filter/README.md
+++ b/pkg/binlog-filter/README.md
@@ -70,7 +70,7 @@ NullEvent EventType = ""
 ## notice
 if you want to use `BinlogEventRule` to synchronize/ignore some table, you may need to pay attention to setting `AllEvent` and `NoneEvent`.
 
-like synchronizing all events from specified table, ignore is opposite.
+like synchronizing all events from specified table or setting a do table, ignore is opposite.
 ``` go
 BinlogEventRule {
 	SchemaPattern: test*,

--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -168,7 +168,7 @@ func (b *BinlogEvent) Filter(schema, table string, dml, ddl EventType, rawQuery 
 			matched = b.matchEvent(dml, binlogEventRule.DMLEvent)
 		} else if len(ddl) > 0 {
 			matched = b.matchEvent(ddl, binlogEventRule.DDLEvent)
-		} else if len(rawQuery) > 0 {
+		} else if len(rawQuery) > 0 && len(binlogEventRule.SQLPattern) > 0 {
 			matched = binlogEventRule.sqlRegularExp.FindStringIndex(rawQuery) != nil
 		} else {
 			if binlogEventRule.Action == Ignore { // Ignore has highest priority

--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -35,6 +35,12 @@ type EventType string
 
 // show DML/DDL Events
 const (
+	// it indicates all dml/ddl events in rule
+	AllEvent EventType = "all"
+	// it indicates no any dml/ddl events in  rule,
+	// and equals empty rule.DDLEvent/DMLEvent
+	NoneEvent EventType = "none"
+
 	InsertEvent EventType = "insert"
 	UpdateEvent EventType = "update"
 	DeleteEvent EventType = "delete"
@@ -187,6 +193,14 @@ func (b *BinlogEvent) Filter(schema, table string, dml, ddl EventType, rawQuery 
 
 func (b *BinlogEvent) matchEvent(event EventType, rules []EventType) bool {
 	for _, rule := range rules {
+		if rule == AllEvent {
+			return true
+		}
+
+		if rule == NoneEvent {
+			return false
+		}
+
 		if rule == event {
 			return true
 		}

--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -168,7 +168,12 @@ func (b *BinlogEvent) Filter(schema, table string, dml, ddl EventType, rawQuery 
 			matched = b.matchEvent(dml, binlogEventRule.DMLEvent)
 		} else if len(ddl) > 0 {
 			matched = b.matchEvent(ddl, binlogEventRule.DDLEvent)
-		} else if len(rawQuery) > 0 && len(binlogEventRule.SQLPattern) > 0 {
+		} else if len(rawQuery) > 0 {
+			if len(binlogEventRule.SQLPattern) == 0 {
+				// sql pattern is disabled , just continue
+				continue
+			}
+
 			matched = binlogEventRule.sqlRegularExp.FindStringIndex(rawQuery) != nil
 		} else {
 			if binlogEventRule.Action == Ignore { // Ignore has highest priority

--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -26,8 +26,8 @@ type ActionType string
 
 //  show that how to handle rules
 const (
-	Skip ActionType = "Skip"
-	Do   ActionType = "Do"
+	Ignore ActionType = "Ignore"
+	Do     ActionType = "Do"
 )
 
 // EventType is DML/DDL Event type
@@ -82,7 +82,7 @@ func (b *BinlogEventRule) Valid() error {
 		b.sqlRegularExp = reg
 	}
 
-	if b.Action != Do && b.Action != Skip {
+	if b.Action != Do && b.Action != Ignore {
 		return errors.Errorf("action of binlog event rule %+v should not be empty", b)
 	}
 
@@ -171,19 +171,19 @@ func (b *BinlogEvent) Filter(schema, table string, dml, ddl EventType, rawQuery 
 		} else if len(rawQuery) > 0 {
 			matched = binlogEventRule.sqlRegularExp.FindStringIndex(rawQuery) != nil
 		} else {
-			if binlogEventRule.Action == Skip { // skip has highest priority
-				return Skip, nil
+			if binlogEventRule.Action == Ignore { // Ignore has highest priority
+				return Ignore, nil
 			}
 		}
 
-		// skip has highest priority
+		// ignore has highest priority
 		if matched {
-			if binlogEventRule.Action == Skip {
-				return Skip, nil
+			if binlogEventRule.Action == Ignore {
+				return Ignore, nil
 			}
 		} else {
 			if binlogEventRule.Action == Do {
-				return Skip, nil
+				return Ignore, nil
 			}
 		}
 	}

--- a/pkg/binlog-filter/filter_test.go
+++ b/pkg/binlog-filter/filter_test.go
@@ -1,0 +1,115 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+func TestClient(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testRouterSuite{})
+
+type testRouterSuite struct{}
+
+func (t *testRouterSuite) TestRoute(c *C) {
+	rules := []*BinlogEventRule{
+		{"test_1_*", "abc*", []EventType{DeleteEvent, InsertEevent}, []EventType{CreateIndex, DropIndex}, []string{"^DROP\\s+PROCEDURE", "^CREATE\\s+PROCEDURE"}, nil, Skip},
+	}
+
+	cases := []struct {
+		schema, table string
+		dml, ddl      EventType
+		sql           string
+		action        ActionType
+	}{
+		{"test_1_a", "abc1", DeleteEvent, NullEvent, "", Skip},
+		{"test_1_a", "abc1", InsertEevent, NullEvent, "", Skip},
+		{"test_1_a", "abc1", UpdateEvent, NullEvent, "", Do},
+		{"test_1_a", "abc1", NullEvent, CreateIndex, "", Skip},
+		{"test_1_a", "abc1", NullEvent, RenameTable, "", Do},
+		{"test_1_a", "abc1", NullEvent, NullEvent, "drop procedure abc", Skip},
+		{"test_1_a", "abc1", NullEvent, NullEvent, "create procedure abc", Skip},
+		{"test_1_a", "abc1", NullEvent, NullEvent, "create function abc", Do},
+	}
+
+	// initial binlog event filter
+	filter, err := NewBinlogEvent(rules)
+	c.Assert(err, IsNil)
+
+	// insert duplicate rules
+	for _, rule := range rules {
+		err = filter.AddRule(rule)
+		c.Assert(err, NotNil)
+	}
+	for _, cs := range cases {
+		action, err := filter.Filter(cs.schema, cs.table, cs.dml, cs.ddl, cs.sql)
+		c.Assert(err, IsNil)
+		c.Assert(action, Equals, cs.action)
+	}
+
+	// test update rules
+	rules[0].DMLEevent = []EventType{}
+	cases[0].action = Do // delete
+	cases[1].action = Do // insert
+	err = filter.UpdateRule(rules[0])
+	c.Assert(err, IsNil)
+	for _, cs := range cases {
+		action, err := filter.Filter(cs.schema, cs.table, cs.dml, cs.ddl, cs.sql)
+		c.Assert(err, IsNil)
+		c.Assert(action, Equals, cs.action)
+	}
+
+	// test multiple rules
+	rule := &BinlogEventRule{"test_*", "ab*", []EventType{InsertEevent}, []EventType{CreateIndex, TruncateTable}, []string{"^DROP\\s+PROCEDURE"}, nil, Do}
+	err = filter.AddRule(rule)
+	c.Assert(err, IsNil)
+	cases[0].action = Skip //delete
+	cases[2].action = Skip // update
+	cases[4].action = Skip // rename table
+	cases[7].action = Skip // create function
+	for _, cs := range cases {
+		action, err := filter.Filter(cs.schema, cs.table, cs.dml, cs.ddl, cs.sql)
+		c.Assert(err, IsNil)
+		c.Assert(action, Equals, cs.action)
+	}
+
+	// test remove rule
+	err = filter.RemoveRule(rules[0])
+	c.Assert(err, IsNil)
+	// test remove not existing rule
+	err = filter.RemoveRule(rules[0])
+	c.Assert(err, NotNil)
+	cases[3].action = Do // create index
+	cases[5].action = Do // drop procedure
+	for _, cs := range cases {
+		action, err := filter.Filter(cs.schema, cs.table, cs.dml, cs.ddl, cs.sql)
+		c.Assert(err, IsNil)
+		c.Assert(action, Equals, cs.action)
+	}
+
+	// test mismacthed
+	action, err := filter.Filter("xxx_a", "", InsertEevent, NullEvent, "")
+	c.Assert(action, Equals, Do)
+
+	// invalid rule
+	err = filter.Selector.Insert("test_1_*", "abc*", "error", false)
+	c.Assert(err, IsNil)
+	_, err = filter.Filter("test_1_a", "abc", InsertEevent, NullEvent, "")
+	c.Assert(err, NotNil)
+}

--- a/pkg/binlog-filter/filter_test.go
+++ b/pkg/binlog-filter/filter_test.go
@@ -29,7 +29,7 @@ type testRouterSuite struct{}
 
 func (t *testRouterSuite) TestRoute(c *C) {
 	rules := []*BinlogEventRule{
-		{"test_1_*", "abc*", []EventType{DeleteEvent, InsertEvent}, []EventType{CreateIndex, DropIndex}, []string{"^DROP\\s+PROCEDURE", "^CREATE\\s+PROCEDURE"}, nil, Skip},
+		{"test_1_*", "abc*", []EventType{DeleteEvent, InsertEvent}, []EventType{CreateIndex, DropIndex}, []string{"^DROP\\s+PROCEDURE", "^CREATE\\s+PROCEDURE"}, nil, Ignore},
 	}
 
 	cases := []struct {
@@ -38,13 +38,13 @@ func (t *testRouterSuite) TestRoute(c *C) {
 		sql           string
 		action        ActionType
 	}{
-		{"test_1_a", "abc1", DeleteEvent, NullEvent, "", Skip},
-		{"test_1_a", "abc1", InsertEvent, NullEvent, "", Skip},
+		{"test_1_a", "abc1", DeleteEvent, NullEvent, "", Ignore},
+		{"test_1_a", "abc1", InsertEvent, NullEvent, "", Ignore},
 		{"test_1_a", "abc1", UpdateEvent, NullEvent, "", Do},
-		{"test_1_a", "abc1", NullEvent, CreateIndex, "", Skip},
+		{"test_1_a", "abc1", NullEvent, CreateIndex, "", Ignore},
 		{"test_1_a", "abc1", NullEvent, RenameTable, "", Do},
-		{"test_1_a", "abc1", NullEvent, NullEvent, "drop procedure abc", Skip},
-		{"test_1_a", "abc1", NullEvent, NullEvent, "create procedure abc", Skip},
+		{"test_1_a", "abc1", NullEvent, NullEvent, "drop procedure abc", Ignore},
+		{"test_1_a", "abc1", NullEvent, NullEvent, "create procedure abc", Ignore},
 		{"test_1_a", "abc1", NullEvent, NullEvent, "create function abc", Do},
 	}
 
@@ -79,10 +79,10 @@ func (t *testRouterSuite) TestRoute(c *C) {
 	rule := &BinlogEventRule{"test_*", "ab*", []EventType{InsertEvent}, []EventType{CreateIndex, TruncateTable}, []string{"^DROP\\s+PROCEDURE"}, nil, Do}
 	err = filter.AddRule(rule)
 	c.Assert(err, IsNil)
-	cases[0].action = Skip //delete
-	cases[2].action = Skip // update
-	cases[4].action = Skip // rename table
-	cases[7].action = Skip // create function
+	cases[0].action = Ignore //delete
+	cases[2].action = Ignore // update
+	cases[4].action = Ignore // rename table
+	cases[7].action = Ignore // create function
 	for _, cs := range cases {
 		action, err := filter.Filter(cs.schema, cs.table, cs.dml, cs.ddl, cs.sql)
 		c.Assert(err, IsNil)

--- a/pkg/binlog-filter/util.go
+++ b/pkg/binlog-filter/util.go
@@ -15,7 +15,7 @@ package filter
 
 import "github.com/pingcap/tidb/ast"
 
-// AstToDDLEvent return filter.DDLEvent
+// AstToDDLEvent returns filter.DDLEvent
 func AstToDDLEvent(node ast.StmtNode) EventType {
 	switch node.(type) {
 	case *ast.CreateDatabaseStmt:

--- a/pkg/binlog-filter/util.go
+++ b/pkg/binlog-filter/util.go
@@ -1,0 +1,42 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import "github.com/pingcap/tidb/ast"
+
+// AstToDDLEvent return filter.DDLEvent
+func AstToDDLEvent(node ast.StmtNode) EventType {
+	switch node.(type) {
+	case *ast.CreateDatabaseStmt:
+		return CreateDatabase
+	case *ast.DropDatabaseStmt:
+		return DropDatabase
+	case *ast.CreateTableStmt:
+		return CreateTable
+	case *ast.DropTableStmt:
+		return DropTable
+	case *ast.TruncateTableStmt:
+		return TruncateTable
+	case *ast.RenameTableStmt:
+		return RenameTable
+	case *ast.CreateIndexStmt:
+		return CreateIndex
+	case *ast.DropIndexStmt:
+		return DropIndex
+	case *ast.AlterTableStmt:
+		return AlertTable
+	}
+
+	return NullEvent
+}


### PR DESCRIPTION
We have three types of filters:

1. builtin parser filter unsupport SQLs (skip or issue error) (we should wrap and make parser to a package wich has more sophisticated and powerful features ) 
2. schema/table name back/white list filter
3.  binlog event filter

this pr implements 3 now. But It can also implement 2, expect for it's not the simplest use. let's decide 
how to do it later (inside it or outside). And I would implement 1 in next pr
@csuzhangxc @holys PTAL
