### PR TITLE
add partition ID expression for sharding PK ID

### DIFF
--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -96,6 +96,10 @@ type BinlogEvent struct {
 
 // NewBinlogEvent returns a binlog event filter
 func NewBinlogEvent(rules []*BinlogEventRule) (*BinlogEvent, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+
 	b := &BinlogEvent{
 		Selector: selector.NewTrieSelector(),
 	}
@@ -111,6 +115,10 @@ func NewBinlogEvent(rules []*BinlogEventRule) (*BinlogEvent, error) {
 
 // AddRule adds a rule into binlog event filter
 func (b *BinlogEvent) AddRule(rule *BinlogEventRule) error {
+	if b == nil || rule == nil {
+		return nil
+	}
+
 	err := rule.Valid()
 	if err != nil {
 		return errors.Trace(err)
@@ -126,6 +134,10 @@ func (b *BinlogEvent) AddRule(rule *BinlogEventRule) error {
 
 // UpdateRule updates binlog event filter rule
 func (b *BinlogEvent) UpdateRule(rule *BinlogEventRule) error {
+	if b == nil || rule == nil {
+		return nil
+	}
+
 	err := rule.Valid()
 	if err != nil {
 		return errors.Trace(err)
@@ -141,6 +153,10 @@ func (b *BinlogEvent) UpdateRule(rule *BinlogEventRule) error {
 
 // RemoveRule removes a rule from binlog event filter
 func (b *BinlogEvent) RemoveRule(rule *BinlogEventRule) error {
+	if b == nil || rule == nil {
+		return nil
+	}
+
 	err := b.Remove(rule.SchemaPattern, rule.TablePattern)
 	if err != nil {
 		return errors.Annotatef(err, "remove rule %+v", rule)
@@ -152,6 +168,10 @@ func (b *BinlogEvent) RemoveRule(rule *BinlogEventRule) error {
 // Filter filters events or queries by given rules
 // returns action and error
 func (b *BinlogEvent) Filter(schema, table string, dml, ddl EventType, rawQuery string) (ActionType, error) {
+	if b == nil {
+		return Do, nil
+	}
+
 	rules := b.Match(schema, table)
 	if len(rules) == 0 {
 		return Do, nil

--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -96,10 +96,6 @@ type BinlogEvent struct {
 
 // NewBinlogEvent returns a binlog event filter
 func NewBinlogEvent(rules []*BinlogEventRule) (*BinlogEvent, error) {
-	if len(rules) == 0 {
-		return nil, nil
-	}
-
 	b := &BinlogEvent{
 		Selector: selector.NewTrieSelector(),
 	}

--- a/pkg/column-mapping/README.md
+++ b/pkg/column-mapping/README.md
@@ -4,11 +4,11 @@
 
 column mapping is a library to provide a simple and unified way to mapping columns of table:
 
-- add prefix for one column
+- add prefix for one char/varchar/ttext column
 
-- add suffix for one column
-    
-- clone one column
+- add suffix for one char/varchar/text column
+
+- partition ID (used for sharding schema/table, would partition these tables with a custom ID), only for id(int64)
 
 ## column mapping rule
 
@@ -29,11 +29,19 @@ type Rule struct {
 now we support following expressions
 
 ``` go
-addPrefix
-addSuffix
-clone
+add prefix, with arguments[prefix]
+
+add suffix, with arguments[suffix]
+
+partition id, with arguments [prefix of schema, prefix of table].  we would compute a ID like 
+[1:1 bit][2:9 bits][3:10 bits][4:44 bits] int64  (using default bits length)
+- 1: useless, no reason
+- 2: schema ID (schema suffix)
+- 3: table ID (table suffix)
+- 4: origin ID (>= 0, <= 17592186044415)
+And schema = arguments[1] + schema suffix, table = arguments[3] + table suffix
 ```
 
 ## notice
-* only support some poor expressions, we would unify tableInfo later and support more
-* don't support modify DDL automatically, we would implement it later 
+* only support above poor expressions now
+* column mapping don't change column type and table structure now

--- a/pkg/column-mapping/README.md
+++ b/pkg/column-mapping/README.md
@@ -39,7 +39,7 @@ partition id, with arguments [prefix of schema, prefix of table].  we would comp
 - 2: schema ID (schema suffix)
 - 3: table ID (table suffix)
 - 4: origin ID (>= 0, <= 17592186044415)
-And schema = arguments[1] + schema suffix, table = arguments[3] + table suffix
+And schema = arguments[0] + schema suffix, table = arguments[1] + table suffix
 ```
 
 ## notice

--- a/pkg/column-mapping/README.md
+++ b/pkg/column-mapping/README.md
@@ -4,7 +4,7 @@
 
 column mapping is a library to provide a simple and unified way to mapping columns of table:
 
-- add prefix for one char/varchar/ttext column
+- add prefix for one char/varchar/text column
 
 - add suffix for one char/varchar/text column
 

--- a/pkg/column-mapping/README.md
+++ b/pkg/column-mapping/README.md
@@ -33,13 +33,13 @@ add prefix, with arguments[prefix]
 
 add suffix, with arguments[suffix]
 
-partition id, with arguments [prefix of schema, prefix of table].  we would compute a ID like 
+partition id, with arguments [instance_id, prefix of schema, prefix of table]
 [1:1 bit][2:9 bits][3:10 bits][4:44 bits] int64  (using default bits length)
 - 1: useless, no reason
 - 2: schema ID (schema suffix)
 - 3: table ID (table suffix)
 - 4: origin ID (>= 0, <= 17592186044415)
-And schema = arguments[0] + schema suffix, table = arguments[1] + table suffix
+And schema = arguments[1] + schema suffix, table = arguments[2] + table suffix
 ```
 
 ## notice

--- a/pkg/column-mapping/column.go
+++ b/pkg/column-mapping/column.go
@@ -60,7 +60,7 @@ var Exprs = map[Expr]func(*mappingInfo, []interface{}) ([]interface{}, error){
 	// # 3 table ID (table suffix)
 	// # 4 origin ID (>= 0, <= 17592186044415)
 	//
-	// others: schema = arguments[1] + schema suffix, table = arguments[3] + table suffix
+	// others: schema = arguments[0] + schema suffix, table = arguments[1] + table suffix
 	PartitionID: partitionID,
 }
 

--- a/pkg/column-mapping/column.go
+++ b/pkg/column-mapping/column.go
@@ -451,11 +451,12 @@ func partitionID(info *mappingInfo, vals []interface{}) ([]interface{}, error) {
 func computePartitionID(schema, table string, rule *Rule) (instanceID int64, schemaID int64, tableID int64, err error) {
 	shiftCnt := uint(64 - instanceIDBitSize - 1)
 	if instanceIDBitSize > 0 {
-		instanceID, err = strconv.ParseInt(rule.Arguments[0], 10, instanceIDBitSize)
+		var instanceIDUnsign uint64
+		instanceIDUnsign, err = strconv.ParseUint(rule.Arguments[0], 10, instanceIDBitSize)
 		if err != nil {
 			return
 		}
-		instanceID = int64(instanceID << shiftCnt)
+		instanceID = int64(instanceIDUnsign << shiftCnt)
 	}
 
 	if schemaIDBitSize > 0 {

--- a/pkg/column-mapping/column.go
+++ b/pkg/column-mapping/column.go
@@ -431,7 +431,7 @@ func partitionID(info *mappingInfo, vals []interface{}) ([]interface{}, error) {
 		}
 		isChars = true
 	default:
-		return nil, errors.NotValidf("type %T(%v)", vals[info.targetPosition])
+		return nil, errors.NotValidf("type %T(%v)", vals[info.targetPosition], vals[info.targetPosition])
 	}
 
 	if originID >= maxOriginID || originID < 0 {

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -14,6 +14,7 @@
 package column
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -157,7 +158,11 @@ func (t *testColumnMappingSuit) TestPartitionID(c *C) {
 	_, err = partitionID(info, []interface{}{"ha", 1 << 44})
 	c.Assert(err, NotNil)
 
-	vals, err := partitionID(info, []interface{}{"ha", int64(1)})
+	vals, err := partitionID(info, []interface{}{"ha", 1})
 	c.Assert(err, IsNil)
 	c.Assert(vals, DeepEquals, []interface{}{"ha", int64(1<<54 | 1<<44 | 1)})
+
+	vals, err = partitionID(info, []interface{}{"ha", "123"})
+	c.Assert(err, IsNil)
+	c.Assert(vals, DeepEquals, []interface{}{"ha", fmt.Sprintf("%d", int64(1<<54|1<<44|123))})
 }

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -27,17 +27,32 @@ var _ = Suite(&testColumnMappingSuit{})
 
 type testColumnMappingSuit struct{}
 
-func (t *testColumnMappingSuit) TestHandle(c *C) {
-	rules := []*Rule{
-		{"test*", "abc*", "id", "copyid", Clone, nil, "xx"},
-		{"test*", "xxx*", "", "id", AddPrefix, []string{"instance_id"}, "xx"},
-	}
-
+func (t *testColumnMappingSuit) TestRule(c *C) {
+	// test invalid rules
 	inValidRule := &Rule{"test*", "abc*", "id", "id", "Error", nil, "xxx"}
 	c.Assert(inValidRule.Valid(), NotNil)
+
 	inValidRule.TargetColumn = ""
-	inValidRule.Expression = AddPrefix
 	c.Assert(inValidRule.Valid(), NotNil)
+
+	inValidRule.Expression = AddPrefix
+	inValidRule.TargetColumn = "id"
+	c.Assert(inValidRule.Valid(), NotNil)
+
+	inValidRule.Arguments = []string{"1"}
+	c.Assert(inValidRule.Valid(), IsNil)
+
+	inValidRule.Expression = PartitionID
+	c.Assert(inValidRule.Valid(), NotNil)
+
+	inValidRule.Arguments = []string{"test_", "t_"}
+	c.Assert(inValidRule.Valid(), IsNil)
+}
+
+func (t *testColumnMappingSuit) TestHandle(c *C) {
+	rules := []*Rule{
+		{"test*", "xxx*", "", "id", AddPrefix, []string{"instance_id:"}, "xx"},
+	}
 
 	// initial column mapping
 	m, err := NewMapping(rules)
@@ -45,22 +60,104 @@ func (t *testColumnMappingSuit) TestHandle(c *C) {
 	c.Assert(m.cache.infos, HasLen, 0)
 
 	// test clone
-	vals, _, err := m.HandleRowValue("test", "abc", []string{"id", "copyid", "name"}, []interface{}{1, "name"})
+	vals, poss, err := m.HandleRowValue("test", "xxx", []string{"age", "id"}, []interface{}{1, "1"})
 	c.Assert(err, IsNil)
-	c.Assert(vals, DeepEquals, []interface{}{1, 1, "name"})
+	c.Assert(vals, DeepEquals, []interface{}{1, "instance_id:1"})
+	c.Assert(poss, DeepEquals, []int{-1, 1})
 
 	// test cache
-	vals, _, err = m.HandleRowValue("test", "abc", []string{"copyid", "name", "id"}, []interface{}{"name", 1})
+	vals, poss, err = m.HandleRowValue("test", "xxx", []string{"name"}, []interface{}{1, "1"})
 	c.Assert(err, IsNil)
-	c.Assert(vals, DeepEquals, []interface{}{"name", "name", 1})
+	c.Assert(vals, DeepEquals, []interface{}{1, "instance_id:1"})
+	c.Assert(poss, DeepEquals, []int{-1, 1})
 
+	// test resetCache
 	m.resetCache()
-	vals, _, err = m.HandleRowValue("test", "abc", []string{"copyid", "name", "id"}, []interface{}{"name", 1})
-	c.Assert(err, IsNil)
-	c.Assert(vals, DeepEquals, []interface{}{1, "name", 1})
+	_, _, err = m.HandleRowValue("test", "xxx", []string{"name"}, []interface{}{"1"})
+	c.Assert(err, NotNil)
 
-	// test add prefix
-	vals, _, err = m.HandleRowValue("test", "xxx", []string{"id"}, []interface{}{1.1})
+	// test DDL
+	_, poss, err = m.HandleDDL("test", "xxx", []string{"id", "age"}, "create table xxx")
+	c.Assert(err, NotNil)
+
+	statement, poss, err := m.HandleDDL("abc", "xxx", []string{"id", "age"}, "create table xxx")
 	c.Assert(err, IsNil)
-	c.Assert(vals, DeepEquals, []interface{}{"instance_id:1.1"})
+	c.Assert(statement, Equals, "create table xxx")
+	c.Assert(poss, IsNil)
+}
+
+func (t *testColumnMappingSuit) TestQueryColumnInfo(c *C) {
+	rules := []*Rule{
+		{"test*", "xxx*", "", "id", PartitionID, []string{"test_", "xxx_"}, "xx"},
+	}
+
+	// initial column mapping
+	m, err := NewMapping(rules)
+	c.Assert(err, IsNil)
+
+	// test mismatch
+	info, err := m.queryColumnInfo("test_2", "t_1", []string{"id", "name"})
+	c.Assert(err, IsNil)
+	c.Assert(info.ignore, IsTrue)
+
+	info, err = m.queryColumnInfo("test_2", "xxx_1", []string{"id", "name"})
+	c.Assert(info, DeepEquals, &mappingInfo{
+		sourcePosition: -1,
+		targetPosition: 0,
+		rule:           rules[0],
+		schemaID:       int64(2 << 54),
+		tableID:        int64(1 << 44),
+	})
+
+}
+
+func (t *testColumnMappingSuit) TestSetPartitionRule(c *C) {
+	c.Assert(schemaIDBitSize, Equals, 9)
+	c.Assert(tableIDBitSize, Equals, 10)
+	c.Assert(maxOriginID, Equals, int64(1<<44))
+
+	SetPartitionRule(3, 4)
+	c.Assert(schemaIDBitSize, Equals, 3)
+	c.Assert(tableIDBitSize, Equals, 4)
+	c.Assert(maxOriginID, Equals, int64(1<<56))
+}
+
+func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
+	SetPartitionRule(9, 10)
+
+	rule := &Rule{
+		Arguments: []string{"test", "t"},
+	}
+	_, _, err := computePartitionID("test_1", "t_1", rule)
+	c.Assert(err, NotNil)
+	_, _, err = computePartitionID("test", "t", rule)
+	c.Assert(err, NotNil)
+
+	rule = &Rule{
+		Arguments: []string{"test_", "t_"},
+	}
+	schemaID, tableID, err := computePartitionID("test_1", "t_1", rule)
+	c.Assert(err, IsNil)
+	c.Assert(schemaID, Equals, int64(1<<54))
+	c.Assert(tableID, Equals, int64(1<<44))
+}
+
+func (t *testColumnMappingSuit) TestPartitionID(c *C) {
+	info := &mappingInfo{
+		schemaID:       int64(1 << 54),
+		tableID:        int64(1 << 44),
+		targetPosition: 1,
+	}
+
+	// test wrong type
+	_, err := partitionID(info, []interface{}{1, "ha"})
+	c.Assert(err, NotNil)
+
+	// test exceed maxOriginID
+	_, err = partitionID(info, []interface{}{"ha", 1 << 44})
+	c.Assert(err, NotNil)
+
+	vals, err := partitionID(info, []interface{}{"ha", int64(1)})
+	c.Assert(err, IsNil)
+	c.Assert(vals, DeepEquals, []interface{}{"ha", int64(1<<54 | 1<<44 | 1)})
 }

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -104,6 +104,7 @@ func (t *testColumnMappingSuit) TestQueryColumnInfo(c *C) {
 
 	// test matched
 	info, err = m.queryColumnInfo("test_2", "xxx_1", []string{"id", "name"})
+	c.Assert(err, IsNil)
 	c.Assert(info, DeepEquals, &mappingInfo{
 		sourcePosition: -1,
 		targetPosition: 0,

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -60,7 +60,7 @@ func (t *testColumnMappingSuit) TestHandle(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(m.cache.infos, HasLen, 0)
 
-	// test clone
+	// test add prefix, add suffix is similar
 	vals, poss, err := m.HandleRowValue("test", "xxx", []string{"age", "id"}, []interface{}{1, "1"})
 	c.Assert(err, IsNil)
 	c.Assert(vals, DeepEquals, []interface{}{1, "instance_id:1"})

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -45,22 +45,22 @@ func (t *testColumnMappingSuit) TestHandle(c *C) {
 	c.Assert(m.cache.infos, HasLen, 0)
 
 	// test clone
-	vals, err := m.HandleRowValue("test", "abc", []string{"id", "copyid", "name"}, []interface{}{1, "name"})
+	vals, _, err := m.HandleRowValue("test", "abc", []string{"id", "copyid", "name"}, []interface{}{1, "name"})
 	c.Assert(err, IsNil)
 	c.Assert(vals, DeepEquals, []interface{}{1, 1, "name"})
 
 	// test cache
-	vals, err = m.HandleRowValue("test", "abc", []string{"copyid", "name", "id"}, []interface{}{"name", 1})
+	vals, _, err = m.HandleRowValue("test", "abc", []string{"copyid", "name", "id"}, []interface{}{"name", 1})
 	c.Assert(err, IsNil)
 	c.Assert(vals, DeepEquals, []interface{}{"name", "name", 1})
 
 	m.resetCache()
-	vals, err = m.HandleRowValue("test", "abc", []string{"copyid", "name", "id"}, []interface{}{"name", 1})
+	vals, _, err = m.HandleRowValue("test", "abc", []string{"copyid", "name", "id"}, []interface{}{"name", 1})
 	c.Assert(err, IsNil)
 	c.Assert(vals, DeepEquals, []interface{}{1, "name", 1})
 
 	// test add prefix
-	vals, err = m.HandleRowValue("test", "xxx", []string{"id"}, []interface{}{1.1})
+	vals, _, err = m.HandleRowValue("test", "xxx", []string{"id"}, []interface{}{1.1})
 	c.Assert(err, IsNil)
 	c.Assert(vals, DeepEquals, []interface{}{"instance_id:1.1"})
 }


### PR DESCRIPTION
add one expression for sharding PK ID to partition these sharding table.

Some simple instructions
* expression of rule is "partition id"
* arguments of rule contains [instance_id, prefix of schema, prefix of table]
   we would compute a ID like
   [1:1 bit][2:9 bits][3:10 bits][4:44 bits] int64  (using default bits length)
     * 1 useless, no reason
     * 2 schema ID (schema suffix)
     * 3 table ID (table suffix)
     * 4 origin ID (>= 0, <= 17592186044415)

NOTICE: others: schema = arguments[1] + schema suffix, table = arguments[2] + table suffix