### PR TITLE
diff: use different checksum sql for tidb and mysql

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -206,6 +206,8 @@ func GetCRC32Checksum(ctx context.Context, db *sql.DB, schemaName string, tbInfo
 		+------------+
 		| 1171947116 |
 		+------------+
+
+		Notice: in the older tidb version, tidb will get different checksum with mysql, can see this issue pingcap/tidb#7446
 	*/
 	isTiDB, err := IsTiDB(ctx, db)
 	if err != nil {

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -274,7 +274,7 @@ func (df *Diff) checkChunkDataEqual(checkJobs []*CheckJob, table *TableCheckCfg)
 		}
 
 		// if checksum is not equal, compare the data
-		log.Errorf("table: %s, range: %s, args: %v, checksum is not equal", job.Table, job.Args, job.Where)
+		log.Errorf("table: %s, range: %s, args: %v, checksum is not equal, one is %s, another is %s", job.Table, job.Args, job.Where, checksum1, checksum2)
 		rows1, orderKeyCols, err := getChunkRows(df.ctx, df.db1, df.schema, table, job.Where, job.Args, df.useRowID)
 		if err != nil {
 			return false, errors.Trace(err)

--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -27,9 +27,6 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/utils"
 )
 
-var maxOpenConns = 100
-var maxIdleConns = 100
-
 func main() {
 	cfg := NewConfig()
 	err := cfg.Parse(os.Args[1:])
@@ -61,8 +58,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("create source db %+v error %v", cfg.SourceDBCfg, err)
 	}
-	sourceDB.SetMaxOpenConns(maxOpenConns)
-	sourceDB.SetMaxIdleConns(maxIdleConns)
+	sourceDB.SetMaxOpenConns(cfg.CheckThreadCount)
+	sourceDB.SetMaxIdleConns(cfg.CheckThreadCount)
 	defer dbutil.CloseDB(sourceDB)
 	if cfg.SourceSnapshot != "" {
 		err = dbutil.SetSnapshot(ctx, sourceDB, cfg.SourceSnapshot)
@@ -75,8 +72,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("create target db %+v error %v", cfg.TargetDBCfg, err)
 	}
-	targetDB.SetMaxOpenConns(maxOpenConns)
-	targetDB.SetMaxIdleConns(maxIdleConns)
+	targetDB.SetMaxOpenConns(cfg.CheckThreadCount)
+	targetDB.SetMaxIdleConns(cfg.CheckThreadCount)
 	defer dbutil.CloseDB(targetDB)
 	if cfg.TargetSnapshot != "" {
 		err = dbutil.SetSnapshot(ctx, targetDB, cfg.TargetSnapshot)

--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -27,6 +27,9 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/utils"
 )
 
+var maxOpenConns = 100
+var maxIdleConns = 100
+
 func main() {
 	cfg := NewConfig()
 	err := cfg.Parse(os.Args[1:])
@@ -58,6 +61,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("create source db %+v error %v", cfg.SourceDBCfg, err)
 	}
+	sourceDB.SetMaxOpenConns(maxOpenConns)
+	sourceDB.SetMaxIdleConns(maxIdleConns)
 	defer dbutil.CloseDB(sourceDB)
 	if cfg.SourceSnapshot != "" {
 		err = dbutil.SetSnapshot(ctx, sourceDB, cfg.SourceSnapshot)
@@ -70,6 +75,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("create target db %+v error %v", cfg.TargetDBCfg, err)
 	}
+	targetDB.SetMaxOpenConns(maxOpenConns)
+	targetDB.SetMaxIdleConns(maxIdleConns)
 	defer dbutil.CloseDB(targetDB)
 	if cfg.TargetSnapshot != "" {
 		err = dbutil.SetSnapshot(ctx, targetDB, cfg.TargetSnapshot)


### PR DESCRIPTION
1. will judge the database's type by `select tidb_version`
2. use different checksum sql for tidb and mysql, and will get same checksum if data in tidb is equal to mysql's. (in the older tidb version, tidb will get different result with mysql, can see this issue https://github.com/pingcap/tidb/issues/7446)