### PR TITLE
binlog: add interface to pause or close node && some minor update

### DIFF
--- a/tidb-binlog/binlogctl/README.md
+++ b/tidb-binlog/binlogctl/README.md
@@ -54,10 +54,14 @@ Then the result will be like this:
 we would format output later :)
 
 
-### unregister pump/drainer
+### update pump/drainer's state
+pump/drainer's state can be online, pausing, paused, closing and offline. In most cases, we only need update pump/drainer's state to paused or offline.
 ```
-bin/binlogctl -pd-urls=http://127.0.0.1:2379 -cmd delete-pump/delete-drainer -node-id ip-127-0-0-1:8250/{nodeID}
+bin/binlogctl -pd-urls=http://127.0.0.1:2379 -cmd update-pump/update-drainer -node-id ip-127-0-0-1:8250/{nodeID} -state {state}
 ```
+This cmd will update pump/drainer's state.
+
+And if you want to pause or close pump/drainer, you can set the state to `pause` or `close`, then binlogctl will send request to pump/drainer, and finally pump/drainer will exit by itself with paused or offline state.
 
 ### generate meta
 meta contains commit TS that can be used to specifies the location of the synchronized data

--- a/tidb-binlog/binlogctl/README.md
+++ b/tidb-binlog/binlogctl/README.md
@@ -61,7 +61,11 @@ bin/binlogctl -pd-urls=http://127.0.0.1:2379 -cmd update-pump/update-drainer -no
 ```
 This cmd will update pump/drainer's state.
 
-And if you want to pause or close pump/drainer, you can set the state to `pause` or `close`, then binlogctl will send request to pump/drainer, and finally pump/drainer will exit by itself with paused or offline state.
+### pause/offline pump/drainer
+```
+bin/binlogctl -pd-urls=http://127.0.0.1:2379 -cmd pause-pump/pause-drainer/offline-pump/offline-drainer -node-id ip-127-0-0-1:8250/{nodeID}
+```
+binlogctl will send http request to pump/drainer, and finally pump/drainer will exit by itself with paused or offline state.
 
 ### generate meta
 meta contains commit TS that can be used to specifies the location of the synchronized data

--- a/tidb-binlog/binlogctl/config.go
+++ b/tidb-binlog/binlogctl/config.go
@@ -28,11 +28,15 @@ const (
 )
 
 const (
-	generateMeta  = "generate_meta"
-	queryPumps    = "pumps"
-	queryDrainer  = "drainers"
-	updatePumps   = "update-pump"
-	updateDrainer = "update-drainer"
+	generateMeta   = "generate_meta"
+	queryPumps     = "pumps"
+	queryDrainers  = "drainers"
+	updatePump     = "update-pump"
+	updateDrainer  = "update-drainer"
+	pausePump      = "pause-pump"
+	offlinePump    = "offline-pump"
+	pauseDrainer   = "pause-drainer"
+	offlineDrainer = "offline-drainer"
 )
 
 // Config holds the configuration of drainer

--- a/tidb-binlog/binlogctl/main.go
+++ b/tidb-binlog/binlogctl/main.go
@@ -22,6 +22,11 @@ import (
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
 )
 
+const (
+	pause = "pause"
+	close = "close"
+)
+
 func main() {
 	cfg := NewConfig()
 	err := cfg.Parse(os.Args[1:])
@@ -39,12 +44,20 @@ func main() {
 		err = generateMetaInfo(cfg)
 	case queryPumps:
 		err = queryNodesByKind(cfg.EtcdURLs, node.PumpNode)
-	case queryDrainer:
+	case queryDrainers:
 		err = queryNodesByKind(cfg.EtcdURLs, node.DrainerNode)
-	case updatePumps:
+	case updatePump:
 		err = updateNodeState(cfg.EtcdURLs, node.PumpNode, cfg.NodeID, cfg.State)
 	case updateDrainer:
 		err = updateNodeState(cfg.EtcdURLs, node.DrainerNode, cfg.NodeID, cfg.State)
+	case pausePump:
+		err = applyAction(cfg.EtcdURLs, node.PumpNode, cfg.NodeID, pause)
+	case pauseDrainer:
+		err = applyAction(cfg.EtcdURLs, node.DrainerNode, cfg.NodeID, pause)
+	case offlinePump:
+		err = applyAction(cfg.EtcdURLs, node.PumpNode, cfg.NodeID, close)
+	case offlineDrainer:
+		err = applyAction(cfg.EtcdURLs, node.DrainerNode, cfg.NodeID, close)
 	}
 
 	if err != nil {

--- a/tidb-binlog/binlogctl/nodes.go
+++ b/tidb-binlog/binlogctl/nodes.go
@@ -75,9 +75,11 @@ func updateNodeState(urls, kind, nodeID, state string) error {
 			// pause node, then node's state will be pausing
 			// close node, then node's state will be closing
 			return applyAction(n, state)
-		default:
+		case node.Online, node.Pausing, node.Paused, node.Closing, node.Offline:
 			n.State = state
 			return registry.UpdateNode(context.Background(), node.NodePrefix[kind], n)
+		default:
+			return errors.Errorf("state %s is illegal", state)
 		}
 	}
 

--- a/tidb-binlog/binlogctl/nodes.go
+++ b/tidb-binlog/binlogctl/nodes.go
@@ -51,6 +51,11 @@ func queryNodesByKind(urls string, kind string) error {
 
 // updateNodeState update pump or drainer's state.
 func updateNodeState(urls, kind, nodeID, state string) error {
+	/*
+		node's state can be online, pausing, paused, closing and offline.
+		if the state is one of them, will update the node's state saved in etcd directly.
+		otherwise if the state is pause or close, will send request to node.
+	*/
 	registry, err := createRegistry(urls)
 	if err != nil {
 		return errors.Trace(err)

--- a/tidb-binlog/node/node.go
+++ b/tidb-binlog/node/node.go
@@ -1,9 +1,5 @@
 package node
 
-import (
-	"github.com/juju/errors"
-)
-
 var (
 	// DefaultRootPath is the root path of the keys stored in etcd, the `v1` is the tidb-binlog's version.
 	DefaultRootPath = "/tidb-binlog/v1"
@@ -21,43 +17,22 @@ var (
 	}
 )
 
-// State is the state of node.
-type State string
-
 const (
 	// Online means the node can receive request.
-	Online State = "online"
+	Online = "online"
 
 	// Pausing means the node is pausing.
-	Pausing State = "pausing"
+	Pausing = "pausing"
 
 	// Paused means the node is already paused.
-	Paused State = "paused"
+	Paused = "paused"
 
 	// Closing means the node is closing, and the state will be Offline when closed.
-	Closing State = "closing"
+	Closing = "closing"
 
 	// Offline means the node is offline, and will not provide service.
-	Offline State = "offline"
+	Offline = "offline"
 )
-
-// GetState returns a state by state name.
-func GetState(state string) (State, error) {
-	switch state {
-	case "online":
-		return Online, nil
-	case "pausing":
-		return Pausing, nil
-	case "paused":
-		return Paused, nil
-	case "closing":
-		return Closing, nil
-	case "offline":
-		return Offline, nil
-	default:
-		return Offline, errors.NotFoundf("state %s", state)
-	}
-}
 
 // Label is key/value pairs that are attached to objects
 type Label struct {
@@ -69,11 +44,11 @@ type Status struct {
 	// the id of node.
 	NodeID string `json:"nodeId"`
 
-	// the address of pump or node.
-	Addr string `json:"addr"`
+	// the host of pump or node.
+	Addr string `json:"host"`
 
 	// the state of pump.
-	State State `json:"state"`
+	State string `json:"state"`
 
 	// the node is alive or not.
 	IsAlive bool `json:"isAlive"`
@@ -85,6 +60,10 @@ type Status struct {
 	// the label of this node. Now only used for pump.
 	// pump client will only send to a pump which label is matched.
 	Label *Label `json:"label"`
+
+	// for pump: max commit ts in pump
+	// for drainer: drainer has consume all binlog less than or equal MaxCommitTS
+	MaxCommitTS int64 `json:"maxCommitTS"`
 
 	// UpdateTS is the last update ts of node's status.
 	UpdateTS int64 `json:"updateTS"`

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -14,6 +14,7 @@
 package client
 
 import (
+	"crypto/tls"
 	"net"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	pb "github.com/pingcap/tipb/go-binlog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // PumpStatus saves pump's status.
@@ -51,7 +53,7 @@ type PumpStatus struct {
 }
 
 // NewPumpStatus returns a new PumpStatus according to node's status.
-func NewPumpStatus(status *node.Status) *PumpStatus {
+func NewPumpStatus(status *node.Status, security *tls.Config) *PumpStatus {
 	pumpStatus := &PumpStatus{}
 	pumpStatus.Status = *status
 	pumpStatus.IsAvaliable = (status.State == node.Online)
@@ -60,7 +62,7 @@ func NewPumpStatus(status *node.Status) *PumpStatus {
 		return pumpStatus
 	}
 
-	err := pumpStatus.createGrpcClient()
+	err := pumpStatus.createGrpcClient(security)
 	if err != nil {
 		log.Errorf("[pumps client] create grpc client for %s failed, error %v", status.NodeID, err)
 		pumpStatus.IsAvaliable = false
@@ -70,7 +72,7 @@ func NewPumpStatus(status *node.Status) *PumpStatus {
 }
 
 // createGrpcClient create grpc client for online pump.
-func (p *PumpStatus) createGrpcClient() error {
+func (p *PumpStatus) createGrpcClient(security *tls.Config) error {
 	if p.Client != nil {
 		return nil
 	}
@@ -79,7 +81,13 @@ func (p *PumpStatus) createGrpcClient() error {
 		return net.DialTimeout("tcp", addr, timeout)
 	})
 	log.Debugf("[pumps client] create gcpc client at %s", p.Addr)
-	clientConn, err := grpc.Dial(p.Addr, dialerOpt, grpc.WithInsecure())
+	var clientConn *grpc.ClientConn
+	var err error
+	if security != nil {
+		clientConn, err = grpc.Dial(p.Addr, dialerOpt, grpc.WithTransportCredentials(credentials.NewTLS(security)))
+	} else {
+		clientConn, err = grpc.Dial(p.Addr, dialerOpt, grpc.WithInsecure())
+	}
 	if err != nil {
 		return err
 	}

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -73,8 +73,9 @@ func NewPumpStatus(status *node.Status, security *tls.Config) *PumpStatus {
 
 // createGrpcClient create grpc client for online pump.
 func (p *PumpStatus) createGrpcClient(security *tls.Config) error {
-	if p.Client != nil {
-		return nil
+	// release the old connection, and create a new one
+	if p.grpcConn != nil {
+		p.grpcConn.Close()
 	}
 
 	dialerOpt := grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {


### PR DESCRIPTION
1. add interface to pause or close node, the cmd looks like:
```
./bin/binlogctl -pd-urls http://192.168.31.246:2379  -node-id xiangdeMacBook-Pro.local:8249 -cmd update-drainer -state close
```
2. some update about node and register, make it same with tidb-binlog's code
3. some minor update in pump client