### PR TITLE
*: support ingnore instance/schema/table ID in computing partition ID

### DIFF
--- a/pkg/column-mapping/column.go
+++ b/pkg/column-mapping/column.go
@@ -66,6 +66,7 @@ var Exprs = map[Expr]func(*mappingInfo, []interface{}) ([]interface{}, error){
 	// others: schema = arguments[1] + schema suffix
 	//         table = arguments[2] + table suffix
 	//  example: schema = schema_1 table = t_1  => arguments[1] = "schema_", arguments[2] = "t_"
+	//  if arguments[1]/arguments[2] == "", it means we don't use schemaID/tableID to compute partition ID
 	PartitionID: partitionID,
 }
 
@@ -479,7 +480,7 @@ func partitionID(info *mappingInfo, vals []interface{}) ([]interface{}, error) {
 
 func computePartitionID(schema, table string, rule *Rule) (instanceID int64, schemaID int64, tableID int64, err error) {
 	shiftCnt := uint(64 - instanceIDBitSize - 1)
-	if instanceIDBitSize > 0 {
+	if instanceIDBitSize > 0 && len(rule.Arguments[0]) > 0 {
 		var instanceIDUnsign uint64
 		instanceIDUnsign, err = strconv.ParseUint(rule.Arguments[0], 10, instanceIDBitSize)
 		if err != nil {
@@ -488,7 +489,7 @@ func computePartitionID(schema, table string, rule *Rule) (instanceID int64, sch
 		instanceID = int64(instanceIDUnsign << shiftCnt)
 	}
 
-	if schemaIDBitSize > 0 {
+	if schemaIDBitSize > 0 && len(rule.Arguments[1]) > 0 {
 		shiftCnt = shiftCnt - uint(schemaIDBitSize)
 		schemaID, err = computeID(schema, rule.Arguments[1], schemaIDBitSize, shiftCnt)
 		if err != nil {
@@ -496,7 +497,7 @@ func computePartitionID(schema, table string, rule *Rule) (instanceID int64, sch
 		}
 	}
 
-	if tableIDBitSize > 0 {
+	if tableIDBitSize > 0 && len(rule.Arguments[2]) > 0 {
 		shiftCnt = shiftCnt - uint(tableIDBitSize)
 		tableID, err = computeID(table, rule.Arguments[2], tableIDBitSize, shiftCnt)
 	}

--- a/pkg/column-mapping/column.go
+++ b/pkg/column-mapping/column.go
@@ -479,9 +479,10 @@ func partitionID(info *mappingInfo, vals []interface{}) ([]interface{}, error) {
 }
 
 func computePartitionID(schema, table string, rule *Rule) (instanceID int64, schemaID int64, tableID int64, err error) {
-	shiftCnt := uint(64 - instanceIDBitSize - 1)
+	shiftCnt := uint(63)
 	if instanceIDBitSize > 0 && len(rule.Arguments[0]) > 0 {
 		var instanceIDUnsign uint64
+		shiftCnt = shiftCnt - uint(instanceIDBitSize)
 		instanceIDUnsign, err = strconv.ParseUint(rule.Arguments[0], 10, instanceIDBitSize)
 		if err != nil {
 			return

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -170,6 +170,37 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 	c.Assert(instanceID, Equals, int64(2<<59))
 	c.Assert(schemaID, Equals, int64(0))
 	c.Assert(tableID, Equals, int64(1<<51))
+
+	// test ignore instance ID
+	SetPartitionRule(4, 7, 8)
+	rule = &Rule{
+		Arguments: []string{"", "test_", "t_"},
+	}
+	instanceID, schemaID, tableID, err = computePartitionID("test_1", "t_1", rule)
+	c.Assert(err, IsNil)
+	c.Assert(instanceID, Equals, int64(0))
+	c.Assert(schemaID, Equals, int64(1<<56))
+	c.Assert(tableID, Equals, int64(1<<48))
+
+	// test ignore schema ID
+	rule = &Rule{
+		Arguments: []string{"2", "", "t_"},
+	}
+	instanceID, schemaID, tableID, err = computePartitionID("test_1", "t_1", rule)
+	c.Assert(err, IsNil)
+	c.Assert(instanceID, Equals, int64(2<<59))
+	c.Assert(schemaID, Equals, int64(0))
+	c.Assert(tableID, Equals, int64(1<<51))
+
+	// test ignore schema ID
+	rule = &Rule{
+		Arguments: []string{"2", "test_", ""},
+	}
+	instanceID, schemaID, tableID, err = computePartitionID("test_1", "t_1", rule)
+	c.Assert(err, IsNil)
+	c.Assert(instanceID, Equals, int64(2<<59))
+	c.Assert(schemaID, Equals, int64(1<<52))
+	c.Assert(tableID, Equals, int64(0))
 }
 
 func (t *testColumnMappingSuit) TestPartitionID(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
improve partition ID expression in column mapping 
we can ignore instance/schema/table ID
some case only have shard schemas [schema_1, schema_2]， not no shard tables

### What is changed and how it works?

only change configuration items

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test