### PR TITLE
bump pd version to v2.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/pingcap/check v0.0.0-20161122095354-9b266636177e
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20180123023251-7b013aefd721
-	github.com/pingcap/pd v0.0.0-20180619050643-0ec6ffcf94e8
+	github.com/pingcap/pd v2.0.5+incompatible
 	github.com/pingcap/tidb v2.0.8+incompatible
 	github.com/pingcap/tipb v0.0.0-20171213095807-07ff5b094233
 	github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/pingcap/kvproto v0.0.0-20180123023251-7b013aefd721 h1:GxpB3vKLDZvRs6Z
 github.com/pingcap/kvproto v0.0.0-20180123023251-7b013aefd721/go.mod h1:0gwbe1F2iBIjuQ9AH0DbQhL+Dpr5GofU8fgYyXk+ykk=
 github.com/pingcap/pd v0.0.0-20180619050643-0ec6ffcf94e8 h1:gaQBEv0OV6VWYakNRi8ZlT9fnkInHdwMSQkxQmUGeQ4=
 github.com/pingcap/pd v0.0.0-20180619050643-0ec6ffcf94e8/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
+github.com/pingcap/pd v2.0.5+incompatible h1:nUTetzzM/tLbd03DoMB76AAvI57oYftNib9sUE3KPFk=
+github.com/pingcap/pd v2.0.5+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb v2.0.8+incompatible h1:4G85C71eFTQRJ0Icwul/z3gJfR0u0aWXq1t/f4O8R40=
 github.com/pingcap/tidb v2.0.8+incompatible/go.mod h1:I8C6jrPINP2rrVunTRd7C9fRRhQrtR43S1/CL5ix/yQ=
 github.com/pingcap/tidb-tools v0.0.0-20181011071128-224e3c29d23a h1:Z0zyuxGu+QEddUbD0aEsavqPx8aLZ1ykabG4M23u660=


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I'm dealing with https://github.com/pingcap/tidb/issues/7922, and find that [after tidb-tools introduce Go module](https://github.com/pingcap/tidb-tools/pull/92), TiDB will meet this error:

```
CGO_ENABLED=0 GO111MODULE=on go build   -ldflags '-X "github.com/pingcap/parser/mysql.TiDBReleaseVersion=v2.1.0-rc.3-134-gcf432188b-dirty" -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=2018-10-31 03:31:00" -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=cf432188beaa2213e62ac7ad8613a1314f8e6da7" -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=go-module" -X "github.com/pingcap/tidb/util/printer.GoVersion=go version go1.11.1 linux/amd64" ' -o bin/tidb-server tidb-server/main.go
go: finding github.com/pingcap/pd/client latest
tidb-server/main.go:29:2: unknown import path "github.com/pingcap/pd/client": cannot find module providing package github.com/pingcap/pd/client
``` 

The pd version is too old, I guess TiDB can't find a compatible version. 

### What is changed and how it works?

Try to update its pd version

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
