### PR TITLE
diff: minor fix about collation

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -239,14 +239,14 @@ func (t *TableDiff) checkChunkDataEqual(ctx context.Context, checkJobs []*CheckJ
 		// if checksum is not equal or don't need compare checksum, compare the data
 		sourceRows := make(map[string]*sql.Rows)
 		for i, sourceTable := range t.SourceTables {
-			rows, _, err := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, job.Where, job.Args, SliceToMap(t.IgnoreColumns))
+			rows, _, err := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, job.Where, job.Args, SliceToMap(t.IgnoreColumns), t.Collation)
 			if err != nil {
 				return false, errors.Trace(err)
 			}
 			sourceRows[fmt.Sprintf("source-%d", i)] = rows
 		}
 
-		targetRows, orderKeyCols, err := getChunkRows(ctx, t.TargetTable.Conn, t.TargetTable.Schema, t.TargetTable.Table, t.TargetTable.info, job.Where, job.Args, SliceToMap(t.IgnoreColumns))
+		targetRows, orderKeyCols, err := getChunkRows(ctx, t.TargetTable.Conn, t.TargetTable.Schema, t.TargetTable.Table, t.TargetTable.info, job.Where, job.Args, SliceToMap(t.IgnoreColumns), t.Collation)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
@@ -515,7 +515,7 @@ func compareData(map1, map2 map[string][]byte, null1, null2 map[string]bool, ord
 }
 
 func getChunkRows(ctx context.Context, db *sql.DB, schema, table string, tableInfo *model.TableInfo, where string,
-	args []interface{}, ignoreColumns map[string]interface{}) (*sql.Rows, []*model.ColumnInfo, error) {
+	args []interface{}, ignoreColumns map[string]interface{}, collation string) (*sql.Rows, []*model.ColumnInfo, error) {
 	orderKeys, orderKeyCols := dbutil.SelectUniqueOrderKey(tableInfo)
 	columns := "*"
 
@@ -533,8 +533,13 @@ func getChunkRows(ctx context.Context, db *sql.DB, schema, table string, tableIn
 	if orderKeys[0] == dbutil.ImplicitColName {
 		columns = fmt.Sprintf("%s, %s", columns, dbutil.ImplicitColName)
 	}
-	query := fmt.Sprintf("SELECT /*!40001 SQL_NO_CACHE */ %s FROM `%s`.`%s` WHERE %s ORDER BY %s",
-		columns, schema, table, where, strings.Join(orderKeys, ","))
+
+	if collation != "" {
+		collation = fmt.Sprintf(" COLLATE \"%s\"", collation)
+	}
+
+	query := fmt.Sprintf("SELECT /*!40001 SQL_NO_CACHE */ %s FROM `%s`.`%s` WHERE %s ORDER BY %s%s",
+		columns, schema, table, where, strings.Join(orderKeys, ","), collation)
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {


### PR DESCRIPTION
### What problem does this PR solve? 
forget add collation config when select data, mysql and tidb may return data with different order.

### What is changed and how it works?
add collation config in sql

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test
generate data, execute these sqls in mysql and tidb:
```
create table test3(name varchar(24) primary key);
insert into test3 values("A");
insert into test3 values("D");
insert into test3 values("C");
insert into test3 values("b");
```
set collation = "latin1_bin", use sync-diff-inspector to check data, is equal.
and then delete one row from mysql:
```
delete from test where name="C"
```
use sync-diff-inspector to check data, data is not equal, and then use sql in fix.sql to repair data, finally use sync-diff-inspector to check again, data is equal.