### PR TITLE
diff: fix sourcetable in table struct diff

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -128,7 +128,7 @@ func (t *TableDiff) CheckTableStruct(ctx context.Context) (bool, error) {
 	t.TargetTable.info = removeColumns(tableInfo, t.RemoveColumns)
 
 	for _, sourceTable := range t.SourceTables {
-		tableInfo, err := dbutil.GetTableInfoWithRowID(ctx, t.TargetTable.Conn, t.TargetTable.Schema, t.TargetTable.Table, t.UseRowID)
+		tableInfo, err := dbutil.GetTableInfoWithRowID(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, t.UseRowID)
 		if err != nil {
 			return false, errors.Trace(err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix https://github.com/pingcap/tidb-tools/issues/121

### What is changed and how it works?
Use right sourceTable to get tableInfo

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   * create table t1 in both source db and target db, with different ddl.
   * use sync_diff_inspector to check and get `table's struct not equal`
