### PR TITLE
binlogctl link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When tidb-tools are built successfully, you can find the binary in the `bin` dir
 
     A tool for comparing two databases' data and outputting a brief report about the differences.
 
-- [binlogctl](./tidb_binlog/binlogctl)
+- [binlogctl](./tidb-binlog/binlogctl)
 
     A tool for performing some tidb-binlog related operations, like querying the status of Pump/Drainer and pause/offline some Pump/Drainer.
 


### PR DESCRIPTION

### What problem does this PR solve?
Just doc link fix

### What is changed and how it works?
link to tidb-binlog/binlogctl. Now it opens properly in browser