### PR TITLE
pump client: compatible with kafka version tidb-binlog && add unit test

### DIFF
--- a/dump_region/main.go
+++ b/dump_region/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/utils"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -14,6 +14,7 @@
 package etcd
 
 import (
+	"context"
 	"crypto/tls"
 	"path"
 	"strings"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pingcap/errors"
-	"golang.org/x/net/context"
 )
 
 // Node organizes the ectd query result as a Trie tree

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -14,6 +14,7 @@
 package etcd
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/coreos/etcd/integration"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/tidb-binlog/binlogctl/meta.go
+++ b/tidb-binlog/binlogctl/meta.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path"
 	"time"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/utils"
 	"github.com/siddontang/go/ioutil2"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const physicalShiftBits = 18

--- a/tidb-binlog/binlogctl/nodes.go
+++ b/tidb-binlog/binlogctl/nodes.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/utils"
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/tidb-binlog/node/registry.go
+++ b/tidb-binlog/node/registry.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"encoding/json"
 	"path"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-tools/pkg/etcd"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // EtcdRegistry wraps the reactions with etcd

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -112,7 +112,7 @@ type PumpsClient struct {
 	// Security is the security config
 	Security *tls.Config
 
-	// binlogSocket file path, for compatible with kafka version pump.
+	// binlog socket file path, for compatible with kafka version pump.
 	binlogSocket string
 }
 
@@ -186,9 +186,7 @@ func NewLocalPumpsClient(binlogSocket string, timeout time.Duration, securityOpt
 		Security:           security,
 		binlogSocket:       binlogSocket,
 	}
-
 	newPumpsClient.getLocalPumpStatus(ctx)
-	newPumpsClient.Selector.SetPumps(copyPumps(newPumpsClient.Pumps.AvaliablePumps))
 
 	return newPumpsClient, nil
 }
@@ -201,7 +199,7 @@ func (c *PumpsClient) getLocalPumpStatus(pctx context.Context) {
 		IsAlive: true,
 		State:   node.Online,
 	}
-	c.addPump(NewPumpStatus(nodeStatus, c.Security), false)
+	c.addPump(NewPumpStatus(nodeStatus, c.Security), true)
 }
 
 // getPumpStatus gets all the pumps status in the etcd.

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -175,6 +175,7 @@ func (c *PumpsClient) getPumpStatus(pctx context.Context, binlogSocket string) e
 			NodeID:  "localPump",
 			Addr:    binlogSocket,
 			IsAlive: true,
+			State:   node.Online,
 		}
 		c.addPump(NewPumpStatus(nodeStatus, c.Security), false)
 

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -172,7 +172,7 @@ func NewPumpsClient(etcdURLs string, timeout time.Duration, securityOpt pd.Secur
 func (c *PumpsClient) getPumpStatus(pctx context.Context, binlogSocket string) error {
 	if len(binlogSocket) != 0 {
 		nodeStatus := &node.Status{
-			NodeID:  "localPump",
+			NodeID:  localPump,
 			Addr:    binlogSocket,
 			IsAlive: true,
 			State:   node.Online,

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -14,6 +14,7 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"path"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
 	pb "github.com/pingcap/tipb/go-binlog"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -246,7 +246,6 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			if (retryTime+1)%RetryTime == 0 {
 				c.setPumpAvaliable(pump, false)
 				pump = c.Selector.Next(binlog, retryTime/5+1)
-				log.Infof("[pumps client] avaliable pumps: %v, write binlog choose pump %v", c.Pumps.AvaliablePumps, pump)
 				Logger.Debugf("[pumps client] avaliable pumps: %v, write binlog choose pump %v", c.Pumps.AvaliablePumps, pump)
 			}
 

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -57,14 +57,8 @@ func (t *testClientSuite) TestSelector(c *C) {
 }
 
 func (*testClientSuite) testSelector(c *C, algorithm string) {
-	pumpInfos := &PumpInfos{
-		Pumps:            make(map[string]*PumpStatus),
-		AvaliablePumps:   make(map[string]*PumpStatus),
-		UnAvaliablePumps: make(map[string]*PumpStatus),
-	}
-
 	pumpsClient := &PumpsClient{
-		Pumps:              pumpInfos,
+		Pumps:              NewPumpInfos(),
 		Selector:           NewSelector(algorithm),
 		RetryTime:          DefaultAllRetryTime,
 		BinlogWriteTimeout: DefaultBinlogWriteTimeout,
@@ -279,11 +273,7 @@ func mockPumpsClient(client pb.PumpClient) *PumpsClient {
 		IsAvaliable: true,
 	}
 
-	pumpInfos := &PumpInfos{
-		Pumps:            make(map[string]*PumpStatus),
-		AvaliablePumps:   make(map[string]*PumpStatus),
-		UnAvaliablePumps: make(map[string]*PumpStatus),
-	}
+	pumpInfos := NewPumpInfos()
 	pumpInfos.Pumps[nodeID1] = pump1
 	pumpInfos.AvaliablePumps[nodeID1] = pump1
 	pumpInfos.Pumps[nodeID2] = pump2

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -14,6 +14,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
 	binlog "github.com/pingcap/tipb/go-binlog"
 	pb "github.com/pingcap/tipb/go-binlog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -225,7 +225,7 @@ func createMockPumpServer(addr string, mode string) (*mockPumpServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	serv := grpc.NewServer(grpc.MaxRecvMsgSize(1024))
+	serv := grpc.NewServer(grpc.MaxRecvMsgSize(testMaxRecvMsgSize))
 	pump := &mockPumpServer{
 		mode:   mode,
 		addr:   addr,

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -200,6 +200,7 @@ type mockPumpServer struct {
 	server *grpc.Server
 }
 
+// WriteBinlog implements PumpServer interface.
 func (p *mockPumpServer) WriteBinlog(ctx context.Context, req *binlog.WriteBinlogReq) (*binlog.WriteBinlogResp, error) {
 	return &binlog.WriteBinlogResp{}, nil
 }

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -14,6 +14,7 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"time"
@@ -21,7 +22,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
 	pb "github.com/pingcap/tipb/go-binlog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -26,6 +26,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+var localPump string = "localPump"
+
 // PumpStatus saves pump's status.
 type PumpStatus struct {
 	/*
@@ -78,9 +80,16 @@ func (p *PumpStatus) createGrpcClient(security *tls.Config) error {
 		p.grpcConn.Close()
 	}
 
-	dialerOpt := grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-		return net.DialTimeout("tcp", addr, timeout)
-	})
+	var dialerOpt 
+	if p.NodeID == localPump {
+		dialerOpt = grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("unix", addr, timeout)
+		})
+	} else {
+		dialerOpt = grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("tcp", addr, timeout)
+		})
+	}
 	Logger.Debugf("[pumps client] create gcpc client at %s", p.Addr)
 	var clientConn *grpc.ClientConn
 	var err error

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -80,7 +80,7 @@ func (p *PumpStatus) createGrpcClient(security *tls.Config) error {
 		p.grpcConn.Close()
 	}
 
-	var dialerOpt 
+	var dialerOpt grpc.DialOption
 	if p.NodeID == localPump {
 		dialerOpt = grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -26,7 +26,10 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-var localPump string = "localPump"
+var (
+	// localPump is used to write local pump through unix socket connection.
+	localPump = "localPump"
+)
 
 // PumpStatus saves pump's status.
 type PumpStatus struct {

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -31,8 +31,8 @@ const (
 	// Score means choose pump by it's score.
 	Score = "score"
 
-	// Local means will only use the local pump.
-	Local = "local"
+	// LocalUnix means will only use the local pump by unix socket.
+	LocalUnix = "local unix"
 )
 
 // PumpSelector selects pump for sending binlog.
@@ -227,19 +227,19 @@ func (r *RangeSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	return nextPump
 }
 
-// LocalSelector will always select the local pump, used for compatible with kafka version tidb-binlog.
-type LocalSelector struct {
+// LocalUnixSelector will always select the local pump, used for compatible with kafka version tidb-binlog.
+type LocalUnixSelector struct {
 	// the pump to be selected.
 	Pump *PumpStatus
 }
 
-// NewLocalSelector returns a LocalSelector.
-func NewLocalSelector() PumpSelector {
-	return &LocalSelector{}
+// NewLocalUnixSelector returns a LocalUnixSelector.
+func NewLocalUnixSelector() PumpSelector {
+	return &LocalUnixSelector{}
 }
 
 // SetPumps implement PumpSelector.SetPumps.
-func (u *LocalSelector) SetPumps(pumps []*PumpStatus) {
+func (u *LocalUnixSelector) SetPumps(pumps []*PumpStatus) {
 	if len(pumps) == 0 {
 		u.Pump = nil
 	} else {
@@ -248,12 +248,12 @@ func (u *LocalSelector) SetPumps(pumps []*PumpStatus) {
 }
 
 // Select implement PumpSelector.Select.
-func (u *LocalSelector) Select(binlog *pb.Binlog) *PumpStatus {
+func (u *LocalUnixSelector) Select(binlog *pb.Binlog) *PumpStatus {
 	return u.Pump
 }
 
 // Next implement PumpSelector.Next. Only for Prewrite binlog.
-func (u *LocalSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
+func (u *LocalUnixSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	return u.Pump
 }
 
@@ -292,8 +292,8 @@ func NewSelector(algorithm string) PumpSelector {
 		selector = NewHashSelector()
 	case Score:
 		selector = NewScoreSelector()
-	case Local:
-		selector = NewLocalSelector()
+	case LocalUnix:
+		selector = NewLocalUnixSelector()
 	default:
 		Logger.Warnf("unknow algorithm %s, use range as default", algorithm)
 		selector = NewRangeSelector()

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -229,6 +229,8 @@ func (r *RangeSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
 
 // LocalUnixSelector will always select the local pump, used for compatible with kafka version tidb-binlog.
 type LocalUnixSelector struct {
+	sync.RWMutex
+
 	// the pump to be selected.
 	Pump *PumpStatus
 }
@@ -240,11 +242,13 @@ func NewLocalUnixSelector() PumpSelector {
 
 // SetPumps implement PumpSelector.SetPumps.
 func (u *LocalUnixSelector) SetPumps(pumps []*PumpStatus) {
+	u.Lock()
 	if len(pumps) == 0 {
 		u.Pump = nil
 	} else {
 		u.Pump = pumps[0]
 	}
+	u.Unlock()
 }
 
 // Select implement PumpSelector.Select.

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -235,7 +235,7 @@ type LocalUnixSelector struct {
 	Pump *PumpStatus
 }
 
-// NewLocalUnixSelector returns a LocalUnixSelector.
+// NewLocalUnixSelector returns a new LocalUnixSelector.
 func NewLocalUnixSelector() PumpSelector {
 	return &LocalUnixSelector{}
 }
@@ -253,11 +253,17 @@ func (u *LocalUnixSelector) SetPumps(pumps []*PumpStatus) {
 
 // Select implement PumpSelector.Select.
 func (u *LocalUnixSelector) Select(binlog *pb.Binlog) *PumpStatus {
+	u.RLock()
+	defer u.RUnlock()
+
 	return u.Pump
 }
 
 // Next implement PumpSelector.Next. Only for Prewrite binlog.
 func (u *LocalUnixSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
+	u.RLock()
+	defer u.RUnlock()
+
 	return u.Pump
 }
 

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -240,7 +240,11 @@ func NewUniqueSelector() PumpSelector {
 
 // SetPumps implement PumpSelector.SetPumps.
 func (u *UniqueSelector) SetPumps(pumps []*PumpStatus) {
-	u.Pump = pumps[0]
+	if len(pumps) == 0 {
+		u.Pump = nil
+	} else {
+		u.Pump = pumps[0]
+	}
 }
 
 // Select implement PumpSelector.Select.

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -31,8 +31,8 @@ const (
 	// Score means choose pump by it's score.
 	Score = "score"
 
-	// Unique means will only use one pump.
-	Unique = "unique"
+	// Local means will only use the local pump.
+	Local = "local"
 )
 
 // PumpSelector selects pump for sending binlog.
@@ -227,19 +227,19 @@ func (r *RangeSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	return nextPump
 }
 
-// UniqueSelector will always select a same pump, used for compatible with kafka version tidb-binlog.
-type UniqueSelector struct {
+// LocalSelector will always select the local pump, used for compatible with kafka version tidb-binlog.
+type LocalSelector struct {
 	// the pump to be selected.
 	Pump *PumpStatus
 }
 
-// NewUniqueSelector returns a UniqueSelector.
-func NewUniqueSelector() PumpSelector {
-	return &UniqueSelector{}
+// NewLocalSelector returns a LocalSelector.
+func NewLocalSelector() PumpSelector {
+	return &LocalSelector{}
 }
 
 // SetPumps implement PumpSelector.SetPumps.
-func (u *UniqueSelector) SetPumps(pumps []*PumpStatus) {
+func (u *LocalSelector) SetPumps(pumps []*PumpStatus) {
 	if len(pumps) == 0 {
 		u.Pump = nil
 	} else {
@@ -248,12 +248,12 @@ func (u *UniqueSelector) SetPumps(pumps []*PumpStatus) {
 }
 
 // Select implement PumpSelector.Select.
-func (u *UniqueSelector) Select(binlog *pb.Binlog) *PumpStatus {
+func (u *LocalSelector) Select(binlog *pb.Binlog) *PumpStatus {
 	return u.Pump
 }
 
 // Next implement PumpSelector.Next. Only for Prewrite binlog.
-func (u *UniqueSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
+func (u *LocalSelector) Next(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	return u.Pump
 }
 
@@ -292,8 +292,8 @@ func NewSelector(algorithm string) PumpSelector {
 		selector = NewHashSelector()
 	case Score:
 		selector = NewScoreSelector()
-	case Unique:
-		selector = NewUniqueSelector()
+	case Local:
+		selector = NewLocalSelector()
 	default:
 		Logger.Warnf("unknow algorithm %s, use range as default", algorithm)
 		selector = NewRangeSelector()


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
make pump client compatible with kafka version tidb-binlog

### What is changed and how it works?
add binlog socket as args when create pumps client, and if binlog socket is not empty, will always use local pump to write binlog.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Related changes

 - Need to update the documentation
 - Need to be included in the release note