### PR TITLE
sync_diff_inspector: fix a misleading regex example in config.toml

### DIFF
--- a/sync_diff_inspector/config.toml
+++ b/sync_diff_inspector/config.toml
@@ -39,7 +39,7 @@ tables = ["test1", "test2", "test3"]
 
 # support regular expression, must start with '~'.
 # for example, this config will check tables with prefix 'test'.
-# tables = ["~test*"]
+# tables = ["~^test.*"]
 
 
 # schema and table in table-config must be contained in check-tables.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In `[[check-tables]] tables`, the example mentions `~test*` will check tables with prefix 'test'. However, as a regular expression this will actually check tables containing `tes`, `test`, `testt`, `testttttt`...

### What is changed and how it works?

Changed to a proper regex `~^test.*`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

 - Need to update the documentation
