### PR TITLE
pump client: write commit binlog will never return error

### DIFF
--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -266,8 +266,8 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			Logger.Errorf("[pumps client] write binlog error %v", err)
 		}
 
-		if binlog.Tp == pb.BinlogType_Commit {
-			// only use one pump to write commit binlog, util write success or blocked for ten minutes. And will not return error to tidb.
+		if binlog.Tp != pb.BinlogType_Prewrite {
+			// only use one pump to write commit/rollback binlog, util write success or blocked for ten minutes. And will not return error to tidb.
 			if time.Since(startTime) > CommitBinlogMaxRetryTime {
 				Logger.Warnf("[pumps client] write commit binlog %d failed, error %v", binlog.CommitTs, err)
 				return nil

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -506,13 +506,7 @@ func isRetryableError(err error) bool {
 	// ResourceExhausted indicates some resource has been exhausted, perhaps
 	// a per-user quota, or perhaps the entire file system is out of space.
 	// https://github.com/grpc/grpc-go/blob/9cc4fdbde2304827ffdbc7896f49db40c5536600/codes/codes.go#L76
-	/*
-		if strings.Contains(err.Error(), "ResourceExhausted") {
-			return false
-		}
-	*/
-
-	if strings.Contains(err.Error(), "received message larger than max") {
+	if strings.Contains(err.Error(), "ResourceExhausted") {
 		return false
 	}
 

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -510,6 +511,10 @@ func isRetryableError(err error) bool {
 			return false
 		}
 	*/
+
+	if strings.Contains(err.Error(), "received message larger than max") {
+		return false
+	}
 
 	return true
 }

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -335,6 +335,10 @@ func (c *PumpsClient) setPumpAvaliable(pump *PumpStatus, avaliable bool) {
 
 // addPump add a new pump.
 func (c *PumpsClient) addPump(pump *PumpStatus, updateSelector bool) {
+	if pump == nil {
+		return
+	}
+
 	c.Pumps.Lock()
 
 	if pump.State == node.Online {
@@ -353,6 +357,10 @@ func (c *PumpsClient) addPump(pump *PumpStatus, updateSelector bool) {
 
 // updatePump update pump's status, and return whether pump's IsAvaliable should be changed.
 func (c *PumpsClient) updatePump(status *node.Status) (pump *PumpStatus, avaliableChanged, avaliable bool) {
+	if status == nil {
+		return
+	}
+
 	var ok bool
 	c.Pumps.Lock()
 	if pump, ok = c.Pumps.Pumps[status.NodeID]; ok {


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
write commit binlog should not return error to tidb.

### What is changed and how it works?
just return nil if retry more than 10 minutes.
and add unit for it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test