### PR TITLE
refine binlogctl's output

### DIFF
--- a/tidb-binlog/binlogctl/config.go
+++ b/tidb-binlog/binlogctl/config.go
@@ -62,7 +62,7 @@ func NewConfig() *Config {
 	cfg.FlagSet = flag.NewFlagSet("binlogctl", flag.ContinueOnError)
 
 	cfg.FlagSet.StringVar(&cfg.Command, "cmd", "pumps", "operator: \"generate_meta\", \"pumps\", \"drainers\", \"update-pump\", \"update-drainer\", \"pause-pump\", \"pause-drainer\", \"offline-pump\", \"offline-drainer\"")
-	cfg.FlagSet.StringVar(&cfg.NodeID, "node-id", "", "id of node, use to delete some node with operation delete-pump and delete-drainer")
+	cfg.FlagSet.StringVar(&cfg.NodeID, "node-id", "", "id of node, use to update some node with operation update-pump, update-drainer, pause-pump, pause-drainer, offline-pump and offline-drainer")
 	cfg.FlagSet.StringVar(&cfg.DataDir, "data-dir", defaultDataDir, "meta directory path")
 	cfg.FlagSet.StringVar(&cfg.EtcdURLs, "pd-urls", defaultEtcdURLs, "a comma separated list of PD endpoints")
 	cfg.FlagSet.StringVar(&cfg.SSLCA, "ssl-ca", "", "Path of file that contains list of trusted SSL CAs for connection with cluster components.")

--- a/tidb-binlog/binlogctl/nodes.go
+++ b/tidb-binlog/binlogctl/nodes.go
@@ -43,7 +43,7 @@ func queryNodesByKind(urls string, kind string) error {
 	}
 
 	for _, n := range nodes {
-		log.Infof("%s: %+v", kind, n)
+		log.Infof("%s: %s", kind, formatNodeInfo(n))
 	}
 
 	return nil
@@ -128,4 +128,9 @@ func applyAction(urls, kind, nodeID string, action string) error {
 	}
 
 	return errors.NotFoundf("nodeID %s", nodeID)
+}
+
+func formatNodeInfo(status *node.Status) string {
+	updateTime := utils.TSOToRoughTime(status.UpdateTS)
+	return fmt.Sprintf("{NodeID: %s, Addr: %s, State: %s, MaxCommitTS: %d, UpdateTime: %v}", status.NodeID, status.Addr, status.State, status.MaxCommitTS, updateTime)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
refine binlogctl's output, some field is not used now, may make user confused, removed them in output.
issue: https://internal.pingcap.net/jira/browse/TOOL-580

### What is changed and how it works?
format node's information.
and the output looks like:
```
./binlogctl  -pd-urls http://172.16.30.192:2379 -cmd pumps

INFO[0000] pump: {NodeID: ip-172-16-30-67:8250, Addr: 172.16.30.192:8250, State: online, MaxCommitTS: 405197570529820673, UpdateTime: 2018-12-25 14:23:37 +0800 CST}
```

### Check List <!--REMOVE the items that are not applicable-->


Related changes

 - Need to update the documentation