### PR TITLE
pump client: increase retry time, and refine some code

### DIFF
--- a/checker/main.go
+++ b/checker/main.go
@@ -20,10 +20,10 @@ import (
 	"os"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/ngaut/log"
 	"github.com/pingcap/tidb-tools/pkg/check"
 	"github.com/pingcap/tidb-tools/pkg/dbutil"
 	"github.com/pingcap/tidb-tools/pkg/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ngaut/log"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb-tools/pkg/dbutil"
+	log "github.com/sirupsen/logrus"
 )
 
 // TableInstance record a table instance

--- a/pkg/diff/merge.go
+++ b/pkg/diff/merge.go
@@ -14,9 +14,9 @@
 package diff
 
 import (
+	"log"
 	"strconv"
 
-	"github.com/ngaut/log"
 	"github.com/pingcap/parser/model"
 )
 

--- a/pkg/diff/util.go
+++ b/pkg/diff/util.go
@@ -16,10 +16,10 @@ package diff
 import (
 	"math/rand"
 
-	"github.com/ngaut/log"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb-tools/pkg/dbutil"
 	"github.com/pingcap/tidb/types"
+	log "github.com/sirupsen/logrus"
 )
 
 func equalStrings(str1, str2 []string) bool {

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -89,18 +89,18 @@ func (e *Client) Create(ctx context.Context, key string, val string, opts []clie
 }
 
 // Get returns a key/value matchs the given key
-func (e *Client) Get(ctx context.Context, key string) ([]byte, error) {
+func (e *Client) Get(ctx context.Context, key string) (value []byte, revision int64, err error) {
 	key = keyWithPrefix(e.rootPath, key)
 	resp, err := e.client.KV.Get(ctx, key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, -1, errors.Trace(err)
 	}
 
 	if len(resp.Kvs) == 0 {
-		return nil, errors.NotFoundf("key %s in etcd", key)
+		return nil, -1, errors.NotFoundf("key %s in etcd", key)
 	}
 
-	return resp.Kvs[0].Value, nil
+	return resp.Kvs[0].Value, resp.Header.Revision, nil
 }
 
 // Update updates a key/value.
@@ -156,7 +156,7 @@ func (e *Client) UpdateOrCreate(ctx context.Context, key string, val string, ttl
 }
 
 // List returns the trie struct that constructed by the key/value with same prefix
-func (e *Client) List(ctx context.Context, key string) (*Node, error) {
+func (e *Client) List(ctx context.Context, key string) (node *Node, revision int64, err error) {
 	key = keyWithPrefix(e.rootPath, key)
 	if !strings.HasSuffix(key, "/") {
 		key += "/"
@@ -164,7 +164,7 @@ func (e *Client) List(ctx context.Context, key string) (*Node, error) {
 
 	resp, err := e.client.KV.Get(ctx, key, clientv3.WithPrefix())
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, -1, errors.Trace(err)
 	}
 
 	root := new(Node)
@@ -180,7 +180,7 @@ func (e *Client) List(ctx context.Context, key string) (*Node, error) {
 		tailNode.Value = kv.Value
 	}
 
-	return root, nil
+	return root, resp.Header.Revision, nil
 }
 
 // Delete deletes the key/values with matching prefix or key
@@ -200,7 +200,10 @@ func (e *Client) Delete(ctx context.Context, key string, withPrefix bool) error 
 }
 
 // Watch watchs the events of key with prefix.
-func (e *Client) Watch(ctx context.Context, prefix string) clientv3.WatchChan {
+func (e *Client) Watch(ctx context.Context, prefix string, revision int64) clientv3.WatchChan {
+	if revision > 0 {
+		return e.client.Watch(ctx, prefix, clientv3.WithPrefix(), clientv3.WithRev(revision))
+	}
 	return e.client.Watch(ctx, prefix, clientv3.WithPrefix())
 }
 

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -71,7 +71,7 @@ func (t *testEtcdSuite) TestCreateWithTTL(c *C) {
 	c.Assert(err, IsNil)
 
 	time.Sleep(2 * time.Second)
-	_, err = etcdCli.Get(ctx, key)
+	_, _, err = etcdCli.Get(ctx, key)
 	c.Assert(errors.IsNotFound(err), IsTrue)
 }
 
@@ -106,12 +106,12 @@ func (t *testEtcdSuite) TestUpdate(c *C) {
 
 	time.Sleep(2 * time.Second)
 
-	res, err := etcdCli.Get(ctx, key)
+	res, _, err := etcdCli.Get(ctx, key)
 	c.Assert(err, IsNil)
 	c.Assert(string(res), Equals, obj2)
 
 	time.Sleep(2 * time.Second)
-	res, err = etcdCli.Get(ctx, key)
+	res, _, err = etcdCli.Get(ctx, key)
 	c.Assert(errors.IsNotFound(err), IsTrue)
 }
 
@@ -142,7 +142,7 @@ func (t *testEtcdSuite) TestList(c *C) {
 	err = etcdCli.Create(ctx, k11, k11, nil)
 	c.Assert(err, IsNil)
 
-	root, err := etcdCli.List(ctx, key)
+	root, _, err := etcdCli.List(ctx, key)
 	c.Assert(err, IsNil)
 	c.Assert(string(root.Childs["level1"].Value), Equals, k1)
 	c.Assert(string(root.Childs["level1"].Childs["level1"].Value), Equals, k11)
@@ -158,21 +158,21 @@ func (t *testEtcdSuite) TestDelete(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	root, err := etcdCli.List(ctx, key)
+	root, _, err := etcdCli.List(ctx, key)
 	c.Assert(err, IsNil)
 	c.Assert(root.Childs, HasLen, 2)
 
 	err = etcdCli.Delete(ctx, keys[1], false)
 	c.Assert(err, IsNil)
 
-	root, err = etcdCli.List(ctx, key)
+	root, _, err = etcdCli.List(ctx, key)
 	c.Assert(err, IsNil)
 	c.Assert(root.Childs, HasLen, 1)
 
 	err = etcdCli.Delete(ctx, key, true)
 	c.Assert(err, IsNil)
 
-	root, err = etcdCli.List(ctx, key)
+	root, _, err = etcdCli.List(ctx, key)
 	c.Assert(err, IsNil)
 	c.Assert(root.Childs, HasLen, 0)
 }

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/integration"
+	"github.com/pingcap/check"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 )
@@ -114,7 +115,7 @@ func (t *testEtcdSuite) TestUpdate(c *C) {
 	res, revision2, err := etcdCli.Get(ctx, key)
 	c.Assert(err, IsNil)
 	c.Assert(string(res), Equals, obj2)
-	c.Assert(revision2-revision1 > 0, Equals, true)
+	c.Assert(revision2, check.Greater, revision1)
 
 	time.Sleep(2 * time.Second)
 	res, _, err = etcdCli.Get(ctx, key)
@@ -155,7 +156,7 @@ func (t *testEtcdSuite) TestList(c *C) {
 	c.Assert(string(root.Childs["level2"].Value), Equals, k2)
 	c.Assert(string(root.Childs["level3"].Value), Equals, k3)
 
-	// the revision of list should equal to the key's revision under the list path
+	// the revision of list should equal to the latest update's revision
 	_, revision2, err := etcdCli.Get(ctx, k11)
 	c.Assert(err, IsNil)
 	c.Assert(revision1, Equals, revision2)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/errors"
+	"github.com/pingcap/errors"
 	"github.com/siddontang/go/sync2"
 )
 

--- a/tidb-binlog/binlogctl/nodes.go
+++ b/tidb-binlog/binlogctl/nodes.go
@@ -37,7 +37,7 @@ func queryNodesByKind(urls string, kind string) error {
 		return errors.Trace(err)
 	}
 
-	nodes, err := registry.Nodes(context.Background(), node.NodePrefix[kind])
+	nodes, _, err := registry.Nodes(context.Background(), node.NodePrefix[kind])
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -60,7 +60,7 @@ func updateNodeState(urls, kind, nodeID, state string) error {
 		return errors.Trace(err)
 	}
 
-	nodes, err := registry.Nodes(context.Background(), node.NodePrefix[kind])
+	nodes, _, err := registry.Nodes(context.Background(), node.NodePrefix[kind])
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -101,7 +101,7 @@ func applyAction(urls, kind, nodeID string, action string) error {
 		return errors.Trace(err)
 	}
 
-	nodes, err := registry.Nodes(context.Background(), node.NodePrefix[kind])
+	nodes, _, err := registry.Nodes(context.Background(), node.NodePrefix[kind])
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/tidb-binlog/node/registry.go
+++ b/tidb-binlog/node/registry.go
@@ -38,36 +38,37 @@ func (r *EtcdRegistry) prefixed(p ...string) string {
 }
 
 // Node returns the nodeStatus that matchs nodeID in the etcd
-func (r *EtcdRegistry) Node(pctx context.Context, prefix, nodeID string) (*Status, error) {
+func (r *EtcdRegistry) Node(pctx context.Context, prefix, nodeID string) (status *Status, revision int64, err error) {
 	ctx, cancel := context.WithTimeout(pctx, r.reqTimeout)
 	defer cancel()
 
-	data, err := r.client.Get(ctx, r.prefixed(prefix, nodeID))
+	data, revision, err := r.client.Get(ctx, r.prefixed(prefix, nodeID))
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, -1, errors.Trace(err)
 	}
 
-	status := &Status{}
 	if err = json.Unmarshal(data, &status); err != nil {
-		return nil, errors.Annotatef(err, "Invalid nodeID(%s)", nodeID)
+		return nil, -1, errors.Annotatef(err, "Invalid nodeID(%s)", nodeID)
 	}
-	return status, nil
+	return status, revision, nil
 }
 
 // Nodes retruns all the nodeStatuses in the etcd
-func (r *EtcdRegistry) Nodes(pctx context.Context, prefix string) ([]*Status, error) {
+func (r *EtcdRegistry) Nodes(pctx context.Context, prefix string) (status []*Status, revision int64, err error) {
 	ctx, cancel := context.WithTimeout(pctx, r.reqTimeout)
 	defer cancel()
 
-	resp, err := r.client.List(ctx, r.prefixed(prefix))
+	resp, revision, err := r.client.List(ctx, r.prefixed(prefix))
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, -1, errors.Trace(err)
 	}
-	status, err := NodesStatusFromEtcdNode(resp)
+
+	status, err = NodesStatusFromEtcdNode(resp)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, -1, errors.Trace(err)
 	}
-	return status, nil
+
+	return status, revision, nil
 }
 
 // UpdateNode update the node information.
@@ -88,7 +89,7 @@ func (r *EtcdRegistry) UpdateNode(pctx context.Context, prefix string, status *S
 }
 
 func (r *EtcdRegistry) checkNodeExists(ctx context.Context, prefix, nodeID string) (bool, error) {
-	_, err := r.client.Get(ctx, r.prefixed(prefix, nodeID))
+	_, _, err := r.client.Get(ctx, r.prefixed(prefix, nodeID))
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -119,8 +120,8 @@ func (r *EtcdRegistry) createNode(ctx context.Context, prefix string, status *St
 }
 
 // WatchNode watchs node's event
-func (r *EtcdRegistry) WatchNode(pctx context.Context, prefix string) clientv3.WatchChan {
-	return r.client.Watch(pctx, prefix)
+func (r *EtcdRegistry) WatchNode(pctx context.Context, prefix string, revision int64) clientv3.WatchChan {
+	return r.client.Watch(pctx, prefix, revision)
 }
 
 func nodeStatusFromEtcdNode(id string, node *etcd.Node) (*Status, error) {

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -437,37 +437,23 @@ func (c *PumpsClient) exist(nodeID string) bool {
 // watchStatus watchs pump's status in etcd.
 func (c *PumpsClient) watchStatus(revision int64) {
 	defer c.wg.Done()
-	needUpdatePumps := false
 	rootPath := path.Join(node.DefaultRootPath, node.NodePrefix[node.PumpNode])
 	rch := c.EtcdRegistry.WatchNode(c.ctx, rootPath, revision)
 
 	for {
-		if needUpdatePumps {
-			revision, err := c.getPumpStatus(c.ctx)
-			if err == nil {
-				c.Pumps.Lock()
-				c.Selector.SetPumps(copyPumps(c.Pumps.AvaliablePumps))
-				c.Pumps.Unlock()
-				rch = c.EtcdRegistry.WatchNode(c.ctx, rootPath, revision)
-				needUpdatePumps = false
-			} else {
-				Logger.Warnf("[pumps client] get pumps from pd failed, error: %v", errors.Trace(err))
-				time.Sleep(time.Second)
-			}
-		}
-
 		select {
 		case <-c.ctx.Done():
 			Logger.Info("[pumps client] watch status finished")
 			return
 		case wresp := <-rch:
-			err := wresp.Err()
-			if err != nil {
-				// meet error, some event may missed, get all the pump's information from etcd again.
-				Logger.Warnf("[pumps client] watch status meet error %v", err)
-				needUpdatePumps = true
+			if wresp.Err() != nil {
+				// meet error, watch from the latest revision.
+				Logger.Warnf("[pumps client] watch status meet error %v", wresp.Err())
+				rch = c.EtcdRegistry.WatchNode(c.ctx, rootPath, revision)
 				continue
 			}
+
+			revision = wresp.Header.Revision
 
 			for _, ev := range wresp.Events {
 				status := &node.Status{}

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -72,9 +72,6 @@ type PumpInfos struct {
 	// UnAvaliablePumps saves the unAvaliable pumps.
 	// And only pump with Online state in this map need check is it avaliable.
 	UnAvaliablePumps map[string]*PumpStatus
-
-	// ErrNums saves the error's num for every pump.
-	ErrNums map[string]int64
 }
 
 // NewPumpInfos returns a PumpInfos.
@@ -83,7 +80,6 @@ func NewPumpInfos() *PumpInfos {
 		Pumps:            make(map[string]*PumpStatus),
 		AvaliablePumps:   make(map[string]*PumpStatus),
 		UnAvaliablePumps: make(map[string]*PumpStatus),
-		ErrNums:          make(map[string]int64),
 	}
 }
 
@@ -239,20 +235,11 @@ func (c *PumpsClient) getPumpStatus(pctx context.Context) (revision int64, err e
 
 // WriteBinlog writes binlog to a situable pump.
 func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
-	errNums := make(map[*PumpStatus]int64)
-	var successPump *PumpStatus
+	meetError := false
 	defer func() {
-		if len(errNums) == 0 {
-			return
+		if meetError {
+			c.checkPumpAvaliable()
 		}
-
-		for pump, errNum := range errNums {
-			c.addErrNum(pump.NodeID, errNum)
-		}
-		if successPump != nil {
-			c.clearErrNum(successPump.NodeID)
-		}
-		c.checkErr()
 	}()
 
 	commitData, err := binlog.Marshal()
@@ -279,10 +266,10 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			err = errors.New(resp.Errmsg)
 		}
 		if err == nil {
-			successPump = pump
 			return nil
 		}
-		errNums[pump]++
+
+		meetError = true
 		Logger.Warnf("[pumps client] write binlog to pump %s (type: %s, start ts: %d, commit ts: %d, length: %d) error %v", pump.NodeID, binlog.Tp, binlog.StartTs, binlog.CommitTs, len(commitData), err)
 
 		if binlog.Tp != pb.BinlogType_Prewrite {
@@ -312,7 +299,6 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 
 	pump, err1 := c.backoffWriteBinlog(req, binlog.Tp)
 	if err1 == nil {
-		successPump = pump
 		return nil
 	}
 
@@ -335,6 +321,8 @@ func (c *PumpsClient) backoffWriteBinlog(req *pb.WriteBinlogReq, binlogType pb.B
 	var resp *pb.WriteBinlogResp
 	// send binlog to unavaliable pumps to retry again.
 	for _, pump := range unAvaliablePumps {
+		pump.ResetGrpcClient()
+
 		resp, err = pump.WriteBinlog(req, c.BinlogWriteTimeout)
 		if err == nil {
 			if resp.Errmsg != "" {
@@ -351,43 +339,16 @@ func (c *PumpsClient) backoffWriteBinlog(req *pb.WriteBinlogReq, binlogType pb.B
 	return nil, err
 }
 
-func (c *PumpsClient) addErrNum(nodeID string, num int64) {
-	c.Pumps.Lock()
-	c.Pumps.ErrNums[nodeID] += num
-	c.Pumps.Unlock()
-}
-
-func (c *PumpsClient) clearErrNum(nodeID string) {
+func (c *PumpsClient) checkPumpAvaliable() {
 	c.Pumps.RLock()
-	if _, ok := c.Pumps.ErrNums[nodeID]; !ok {
-		c.Pumps.RUnlock()
-		return
-	}
+	allPumps := copyPumps(c.Pumps.Pumps)
 	c.Pumps.RUnlock()
 
-	c.Pumps.Lock()
-	delete(c.Pumps.ErrNums, nodeID)
-	c.Pumps.Unlock()
-}
-
-// checkErr checks the error num for each pump, if this num is greater than DefaultRetryTime, set this pump to unavaliable.
-func (c *PumpsClient) checkErr() {
-	unAvaliablePumps := make([]*PumpStatus, 0, 3)
-
-	c.Pumps.RLock()
-	for nodeID, num := range c.Pumps.ErrNums {
-		if num >= DefaultRetryTime {
-			if pump, ok := c.Pumps.Pumps[nodeID]; ok {
-				unAvaliablePumps = append(unAvaliablePumps, pump)
-			}
+	for _, pump := range allPumps {
+		if !pump.IsAvaliable() {
+			c.setPumpAvaliable(pump, false)
 		}
 	}
-	c.Pumps.RUnlock()
-
-	for _, pump := range unAvaliablePumps {
-		c.setPumpAvaliable(pump, false)
-	}
-
 }
 
 // setPumpAvaliable set pump's isAvaliable, and modify UnAvaliablePumps or AvaliablePumps.
@@ -395,11 +356,9 @@ func (c *PumpsClient) setPumpAvaliable(pump *PumpStatus, avaliable bool) {
 	c.Pumps.Lock()
 	defer c.Pumps.Unlock()
 
-	pump.IsAvaliable = avaliable
-	delete(c.Pumps.ErrNums, pump.NodeID)
 	pump.ResetGrpcClient()
 
-	if pump.IsAvaliable {
+	if avaliable {
 		delete(c.Pumps.UnAvaliablePumps, pump.NodeID)
 		if _, ok := c.Pumps.Pumps[pump.NodeID]; ok {
 			c.Pumps.AvaliablePumps[pump.NodeID] = pump

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -161,6 +161,11 @@ func NewPumpsClient(etcdURLs string, timeout time.Duration, securityOpt pd.Secur
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	if len(newPumpsClient.Pumps.Pumps) == 0 {
+		return nil, errors.New("no pump found in pd")
+	}
+
 	newPumpsClient.Selector.SetPumps(copyPumps(newPumpsClient.Pumps.AvaliablePumps))
 
 	newPumpsClient.RetryTime = DefaultAllRetryTime / len(newPumpsClient.Pumps.Pumps)

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -298,7 +298,7 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			}
 
 			// make sure already retry every avaliable pump.
-			if time.Since(startTime) > c.BinlogWriteTimeout && retryTime > pumpNum { 
+			if time.Since(startTime) > c.BinlogWriteTimeout && retryTime > pumpNum {
 				break
 			}
 

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -281,6 +281,7 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 
 		}
 		if pump == nil {
+			err = ErrNoAvaliablePump
 			break
 		}
 		Logger.Debugf("[pumps client] write binlog choose pump %s", pump.NodeID)

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -105,7 +105,7 @@ type PumpsClient struct {
 	// Selector will select a suitable pump.
 	Selector PumpSelector
 
-	// the max retry time if write binlog failed.
+	// the max retry time if write binlog failed, obsolete now.
 	RetryTime int
 
 	// BinlogWriteTimeout is the max time binlog can use to write to pump.
@@ -238,7 +238,7 @@ func (c *PumpsClient) getPumpStatus(pctx context.Context) (revision int64, err e
 	return revision, nil
 }
 
-// WriteBinlog writes binlog to a situable pump.
+// WriteBinlog writes binlog to a situable pump. Tips: will never return error for commit/rollback binlog.
 func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 	var choosePump *PumpStatus
 	meetError := false
@@ -311,6 +311,7 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 		}
 	}
 
+	Logger.Info("[pumps client] write binlog to avaliable pumps all failed, will try unavaliable pumps")
 	pump, err1 := c.backoffWriteBinlog(req, binlog.Tp, binlog.StartTs)
 	if err1 == nil {
 		return nil

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -243,9 +243,9 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 	defer func() {
 		if meetError {
 			c.checkPumpAvaliable()
-			log.Infof("binlog type %s, ts %d choose pump %v", binlog.Tp, binlog.StartTs, choosePump)
-			c.Selector.Feedback(binlog.StartTs, binlog.Tp, choosePump)
 		}
+
+		c.Selector.Feedback(binlog.StartTs, binlog.Tp, choosePump)
 	}()
 
 	commitData, err := binlog.Marshal()
@@ -348,7 +348,7 @@ func (c *PumpsClient) backoffWriteBinlog(req *pb.WriteBinlogReq, binlogType pb.B
 		}
 	}
 
-	return nil, err
+	return nil, errors.New("write binlog to unavaliable pump failed")
 }
 
 func (c *PumpsClient) checkPumpAvaliable() {

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -345,7 +345,7 @@ func (c *PumpsClient) checkPumpAvaliable() {
 	c.Pumps.RUnlock()
 
 	for _, pump := range allPumps {
-		if !pump.IsAvaliable() {
+		if !pump.IsUsable() {
 			c.setPumpAvaliable(pump, false)
 		}
 	}

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -114,6 +114,8 @@ type PumpsClient struct {
 
 	// binlog socket file path, for compatible with kafka version pump.
 	binlogSocket string
+
+	nodePath string
 }
 
 // NewPumpsClient returns a PumpsClient.
@@ -152,6 +154,7 @@ func NewPumpsClient(etcdURLs string, timeout time.Duration, securityOpt pd.Secur
 		Selector:           NewSelector(Range),
 		BinlogWriteTimeout: timeout,
 		Security:           security,
+		nodePath:           path.Join(node.DefaultRootPath, node.NodePrefix[node.PumpNode]),
 	}
 
 	revision, err := newPumpsClient.getPumpStatus(ctx)
@@ -437,8 +440,7 @@ func (c *PumpsClient) exist(nodeID string) bool {
 // watchStatus watchs pump's status in etcd.
 func (c *PumpsClient) watchStatus(revision int64) {
 	defer c.wg.Done()
-	rootPath := path.Join(node.DefaultRootPath, node.NodePrefix[node.PumpNode])
-	rch := c.EtcdRegistry.WatchNode(c.ctx, rootPath, revision)
+	rch := c.EtcdRegistry.WatchNode(c.ctx, c.nodePath, revision)
 
 	for {
 		select {

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -450,7 +450,6 @@ func (c *PumpsClient) watchStatus(revision int64) {
 				c.Pumps.Unlock()
 				rch = c.EtcdRegistry.WatchNode(c.ctx, rootPath, revision)
 				needUpdatePumps = false
-				break
 			} else {
 				Logger.Warnf("[pumps client] get pumps from pd failed, error: %v", errors.Trace(err))
 				time.Sleep(time.Second)

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -113,7 +113,7 @@ func (*testClientSuite) testSelector(c *C, algorithm string) {
 		if nodeID != "" {
 			pumpsClient.setPumpAvaliable(pumpsClient.Pumps.Pumps[nodeID], tCase.setAvliable[i])
 		}
-		pump := pumpsClient.Selector.Select(tCase.binlogs[i])
+		pump := pumpsClient.Selector.Select(tCase.binlogs[i], 0)
 		c.Assert(pump, Equals, tCase.choosePumps[i])
 	}
 
@@ -127,13 +127,13 @@ func (*testClientSuite) testSelector(c *C, algorithm string) {
 			StartTs: int64(j),
 		}
 
-		pump1 := pumpsClient.Selector.Select(prewriteBinlog)
+		pump1 := pumpsClient.Selector.Select(prewriteBinlog, 0)
 		if j%2 == 0 {
-			pump1 = pumpsClient.Selector.Next(prewriteBinlog, 0)
+			pump1 = pumpsClient.Selector.Select(prewriteBinlog, 1)
 		}
 
 		pumpsClient.setPumpAvaliable(pump1, false)
-		pump2 := pumpsClient.Selector.Select(commitBinlog)
+		pump2 := pumpsClient.Selector.Select(commitBinlog, 0)
 		c.Assert(pump2.IsAvaliable, Equals, false)
 		// prewrite binlog and commit binlog with same start ts should choose same pump
 		c.Assert(pump1.NodeID, Equals, pump2.NodeID)
@@ -158,7 +158,8 @@ func (t *testClientSuite) TestWriteBinlog(c *C) {
 	}
 
 	// make test faster
-	RetryInterval = 100 * time.Millisecond
+	RetryIntervalEach = 100 * time.Millisecond
+	RetryIntervalTotal = 100 * time.Millisecond
 	CommitBinlogMaxRetryTime = time.Second
 
 	for _, cfg := range pumpServerConfig {

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -60,7 +60,6 @@ func (*testClientSuite) testSelector(c *C, algorithm string) {
 	pumpsClient := &PumpsClient{
 		Pumps:              NewPumpInfos(),
 		Selector:           NewSelector(algorithm),
-		RetryTime:          DefaultAllRetryTime,
 		BinlogWriteTimeout: DefaultBinlogWriteTimeout,
 	}
 

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -133,12 +133,9 @@ func (*testClientSuite) testSelector(c *C, algorithm string) {
 
 		pumpsClient.setPumpAvaliable(pump1, false)
 		pump2 := pumpsClient.Selector.Select(commitBinlog, 0)
-		c.Assert(pump2.IsAvaliable, Equals, false)
 		// prewrite binlog and commit binlog with same start ts should choose same pump
 		c.Assert(pump1.NodeID, Equals, pump2.NodeID)
-
 		pumpsClient.setPumpAvaliable(pump1, true)
-		c.Assert(pump2.IsAvaliable, Equals, true)
 	}
 }
 
@@ -283,8 +280,7 @@ func mockPumpsClient(client pb.PumpClient) *PumpsClient {
 			NodeID: nodeID1,
 			State:  node.Online,
 		},
-		IsAvaliable: true,
-		Client:      client,
+		Client: client,
 	}
 
 	// add a pump without grpc client
@@ -294,7 +290,6 @@ func mockPumpsClient(client pb.PumpClient) *PumpsClient {
 			NodeID: nodeID2,
 			State:  node.Online,
 		},
-		IsAvaliable: true,
 	}
 
 	pumpInfos := NewPumpInfos()

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -107,7 +107,7 @@ func (*testClientSuite) testSelector(c *C, algorithm string) {
 	tCase.setNodeID = []string{"pump0", "", "pump0", "pump1", "", "pump2"}
 	tCase.setAvliable = []bool{true, false, false, true, false, true}
 	tCase.choosePumps = []*PumpStatus{pumpsClient.Pumps.Pumps["pump0"], pumpsClient.Pumps.Pumps["pump0"], nil,
-		pumpsClient.Pumps.Pumps["pump1"], pumpsClient.Pumps.Pumps["pump1"], pumpsClient.Pumps.Pumps["pump1"]}
+		nil, pumpsClient.Pumps.Pumps["pump1"], pumpsClient.Pumps.Pumps["pump1"]}
 
 	for i, nodeID := range tCase.setNodeID {
 		if nodeID != "" {
@@ -158,9 +158,9 @@ func (t *testClientSuite) TestWriteBinlog(c *C) {
 	}
 
 	// make test faster
-	RetryIntervalEach = 100 * time.Millisecond
-	RetryIntervalTotal = 100 * time.Millisecond
+	RetryInterval = 100 * time.Millisecond
 	CommitBinlogMaxRetryTime = time.Second
+	PreWriteBinlogMaxRetryTime = time.Second
 
 	for _, cfg := range pumpServerConfig {
 		pumpServer, err := createMockPumpServer(cfg.addr, cfg.serverMode)

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -159,8 +159,7 @@ func (t *testClientSuite) TestWriteBinlog(c *C) {
 
 	// make test faster
 	RetryInterval = 100 * time.Millisecond
-	CommitBinlogMaxRetryTime = time.Second
-	PreWriteBinlogMaxRetryTime = time.Second
+	CommitBinlogTimeout = time.Second
 
 	for _, cfg := range pumpServerConfig {
 		pumpServer, err := createMockPumpServer(cfg.addr, cfg.serverMode)
@@ -306,12 +305,10 @@ func mockPumpsClient(client pb.PumpClient) *PumpsClient {
 	pumpInfos.AvaliablePumps[nodeID2] = pump2
 
 	pCli := &PumpsClient{
-		ClusterID: 1,
-		Pumps:     pumpInfos,
-		Selector:  NewSelector(Range),
-		// have two pump, so use 2 * testRetryTime
-		RetryTime:          2 * testRetryTime,
-		BinlogWriteTimeout: 15 * time.Second,
+		ClusterID:          1,
+		Pumps:              pumpInfos,
+		Selector:           NewSelector(Range),
+		BinlogWriteTimeout: time.Second,
 	}
 	pCli.Selector.SetPumps([]*PumpStatus{pump1, pump2})
 

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -113,6 +113,7 @@ func (*testClientSuite) testSelector(c *C, algorithm string) {
 			pumpsClient.setPumpAvaliable(pumpsClient.Pumps.Pumps[nodeID], tCase.setAvliable[i])
 		}
 		pump := pumpsClient.Selector.Select(tCase.binlogs[i], 0)
+		pumpsClient.Selector.Feedback(tCase.binlogs[i].StartTs, tCase.binlogs[i].Tp, pump)
 		c.Assert(pump, Equals, tCase.choosePumps[i])
 	}
 
@@ -130,9 +131,11 @@ func (*testClientSuite) testSelector(c *C, algorithm string) {
 		if j%2 == 0 {
 			pump1 = pumpsClient.Selector.Select(prewriteBinlog, 1)
 		}
+		pumpsClient.Selector.Feedback(prewriteBinlog.StartTs, prewriteBinlog.Tp, pump1)
 
 		pumpsClient.setPumpAvaliable(pump1, false)
 		pump2 := pumpsClient.Selector.Select(commitBinlog, 0)
+		pumpsClient.Selector.Feedback(commitBinlog.StartTs, commitBinlog.Tp, pump2)
 		// prewrite binlog and commit binlog with same start ts should choose same pump
 		c.Assert(pump1.NodeID, Equals, pump2.NodeID)
 		pumpsClient.setPumpAvaliable(pump1, true)

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -157,6 +157,10 @@ func (t *testClientSuite) TestWriteBinlog(c *C) {
 		},
 	}
 
+	// make test faster
+	RetryInterval = 100 * time.Millisecond
+	CommitBinlogMaxRetryTime = time.Second
+
 	for _, cfg := range pumpServerConfig {
 		pumpServer, err := createMockPumpServer(cfg.addr, cfg.serverMode)
 		c.Assert(err, IsNil)
@@ -209,7 +213,6 @@ func (t *testClientSuite) TestWriteBinlog(c *C) {
 		// test when pump is down
 		pumpServer.Close()
 
-		CommitBinlogMaxRetryTime = time.Second
 		// write commit binlog failed will not return error
 		err = pumpClient.WriteBinlog(commitBinlog)
 		c.Assert(err, IsNil)

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -136,13 +136,13 @@ func (p *PumpStatus) WriteBinlog(req *pb.WriteBinlogReq, timeout time.Duration) 
 
 	if client == nil {
 		p.Lock()
+		defer p.Unlock()
+
 		err := p.createGrpcClient()
 		if err != nil {
-			p.Unlock()
 			return nil, errors.Errorf("create grpc connection for pump %s failed, error %v", p.NodeID, err)
 		}
 		client = p.Client
-		p.Unlock()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -162,7 +162,7 @@ func (p *PumpStatus) WriteBinlog(req *pb.WriteBinlogReq, timeout time.Duration) 
 
 // IsUsable returns true if pump is usable.
 func (p *PumpStatus) IsUsable() bool {
-	if p.status.State != node.Online {
+	if p.Status.State != node.Online {
 		return false
 	}
 

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -120,7 +120,7 @@ func (p *PumpStatus) createGrpcClient() error {
 // ResetGrpcClient closes the pump's grpc connection.
 func (p *PumpStatus) ResetGrpcClient() {
 	p.Lock()
-	defer p.UnLock()
+	defer p.Unlock()
 
 	if p.grpcConn != nil {
 		p.grpcConn.Close()

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -74,15 +74,6 @@ func NewPumpStatus(status *node.Status, security *tls.Config) *PumpStatus {
 	pumpStatus.Status = *status
 	pumpStatus.security = security
 
-	if status.State != node.Online {
-		return pumpStatus
-	}
-
-	err := pumpStatus.createGrpcClient()
-	if err != nil {
-		Logger.Errorf("[pumps client] create grpc client for %s failed, error %v", status.NodeID, err)
-	}
-
 	return pumpStatus
 }
 
@@ -171,6 +162,10 @@ func (p *PumpStatus) WriteBinlog(req *pb.WriteBinlogReq, timeout time.Duration) 
 
 // IsUsable returns true if pump is usable.
 func (p *PumpStatus) IsUsable() bool {
+	if p.status.State != node.Online {
+		return false
+	}
+
 	if atomic.LoadInt64(&p.ErrNum) > defaultMaxErrNums {
 		return false
 	}

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -84,8 +84,6 @@ func (p *PumpStatus) createGrpcClient() error {
 		p.grpcConn.Close()
 	}
 
-	atomic.StoreInt64(&p.ErrNum, 0)
-
 	var dialerOpt grpc.DialOption
 	if p.NodeID == localPump {
 		dialerOpt = grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
@@ -124,6 +122,12 @@ func (p *PumpStatus) ResetGrpcClient() {
 		p.grpcConn.Close()
 		p.Client = nil
 	}
+}
+
+// Reset resets the pump's grpc conn and err num.
+func (p *PumpStatus) Reset() {
+	p.ResetGrpcClient()
+	atomic.StoreInt64(&p.ErrNum, 0)
 }
 
 // WriteBinlog write binlog by grpc client.

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -94,6 +94,7 @@ func (h *HashSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
 
 		// this should never happened
 		Logger.Warnf("[pumps client] %s binlog with start ts %d don't have matched prewrite binlog", binlog.Tp, binlog.StartTs)
+		return nil
 	}
 
 	if len(h.Pumps) == 0 {
@@ -163,6 +164,7 @@ func (r *RangeSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
 
 		// this should never happened
 		Logger.Warnf("[pumps client] %s binlog with start ts %d don't have matched prewrite binlog", binlog.Tp, binlog.StartTs)
+		return nil
 	}
 
 	if len(r.Pumps) == 0 {

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -149,11 +149,9 @@ func (r *RangeSelector) SetPumps(pumps []*PumpStatus) {
 
 // Select implement PumpSelector.Select.
 func (r *RangeSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
-	// TODO: use status' label to match situale pump.
+	// TODO: use status' label to match situable pump.
 	r.Lock()
-	defer func() {
-		r.Unlock()
-	}()
+	defer r.Unlock()
 
 	if binlog.Tp != pb.BinlogType_Prewrite {
 		// binlog is commit binlog or rollback binlog, choose the same pump by start ts map.

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -97,6 +97,7 @@ func (h *HashSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	}
 
 	if len(h.Pumps) == 0 {
+		h.TsMap[binlog.StartTs] = nil
 		return nil
 	}
 
@@ -165,6 +166,7 @@ func (r *RangeSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	}
 
 	if len(r.Pumps) == 0 {
+		r.TsMap[binlog.StartTs] = nil
 		return nil
 	}
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
the retry time interval is too small, may cause `no available pump` error when update the tidb cluster.
issue: https://internal.pingcap.net/jira/browse/TOOL-772

### What is changed and how it works?
1. use write binlog timeout config set in tidb 
2. when all pumps write binlog failed, use all the unavailable pump to try again
3. handle error for watch etcd
4. refine log and some code

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
