### PR TITLE
*: support global sql-pattern filter

### DIFF
--- a/pkg/table-rule-selector/trie_selector.go
+++ b/pkg/table-rule-selector/trie_selector.go
@@ -222,12 +222,6 @@ func (t *trieSelector) Match(schema, table string) RuleSet {
 
 	rules = append(rules, matchedSchemaResult.rules...)
 
-	// only need to find schema level matched rule
-	if len(table) == 0 {
-		t.addToCache(cacheKey, rules)
-		return rules.clone()
-	}
-
 	for _, si := range matchedSchemaResult.nodes {
 		matchedTableResult := &matchedResult{
 			rules: make(RuleSet, 0, 4),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

support set `*` to match global rules.

### What is changed and how it works?

remove `len(table) == 0` check to support match empty schema and empty table.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
