### PR TITLE
diff: minor update on table route

### DIFF
--- a/pkg/table-router/router_test.go
+++ b/pkg/table-router/router_test.go
@@ -42,38 +42,15 @@ func (t *testRouterSuite) TestRoute(c *C) {
 		table        string
 		targetSchema string
 		targetTable  string
-		matched     bool
-	}{{"test_1_a", "abc1", "t1", "abc", true}, {
-		"test_2_a",
-		"abc2",
-		"t1",
-		"abc",
-		true,
-	}, {
-		"test_1_a",
-		"test1",
-		"t2",
-		"test",
-		true,
-	}, {
-		"test_2_a",
-		"test2",
-		"t2",
-		"test",
-		true,
-	}, {
-		"test_1_a",
-		"xyz",
-		"test",
-		"xyz",
-		true,
-	}, {
-		"abc",
-		"abc",
-		"abc",
-		"abc",
-		false,
-	}}
+		matched      bool
+	}{
+		{"test_1_a", "abc1", "t1", "abc", true},
+		{"test_2_a", "abc2", "t1", "abc", true},
+		{"test_1_a", "test1", "t2", "test", true},
+		{"test_2_a", "test2", "t2", "test", true},
+		{"test_1_a", "xyz", "test", "xyz", true},
+		{"abc", "abc", "abc", "abc", false},
+	}
 
 	// initial table router
 	router, err := NewTableRouter(false, rules)

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -148,9 +148,13 @@ func (df *Diff) AdjustTableConfig(cfg *Config) (err error) {
 
 		for schema, allTables := range allSchemas {
 			for table := range allTables {
-				targetSchema, targetTable, err := df.tableRouter.Route(schema, table)
+				targetSchema, targetTable, findRule, err := df.tableRouter.Route(schema, table)
 				if err != nil {
 					return errors.Errorf("get route result for %s.%s.%s failed, error %v", instanceID, schema, table, err)
+				}
+
+				if !findRule {
+					continue
 				}
 
 				if _, ok := sourceTablesMap[targetSchema]; !ok {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
for example, we set
[[table-rules]]
schema-pattern = "test1"
target-schema = "test2"

we only want compare schema test1 on source with schema test2 on target, but now will also compare schema test2 on source, because route("test2") return "test2" although test2 mismatched the rules.


### What is changed and how it works?
return matched when execute route

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (use config in example above)
