### PR TITLE
diff: get table info before check

### DIFF
--- a/pkg/diff/chunk.go
+++ b/pkg/diff/chunk.go
@@ -247,7 +247,6 @@ func (s *randomSpliter) splitRange(db *sql.DB, chunk *chunkRange, count int, sch
 			return append(chunks, chunk), nil
 		}
 
-
 		// choose the next column to split data
 		useNewColumn = true
 		splitCol = columns[colNum].Name.O

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -93,7 +93,10 @@ type TableDiff struct {
 
 // Equal tests whether two database have same data and schema.
 func (t *TableDiff) Equal(ctx context.Context, writeFixSQL func(string) error) (bool, bool, error) {
-	t.adjustConfig()
+	err := t.adjustConfig(ctx)
+	if err != nil {
+		return false, false, errors.Trace(err)
+	}
 
 	t.sqlCh = make(chan string)
 	t.wg.Add(1)
@@ -104,7 +107,6 @@ func (t *TableDiff) Equal(ctx context.Context, writeFixSQL func(string) error) (
 
 	structEqual := true
 	dataEqual := true
-	var err error
 
 	if !t.IgnoreStructCheck {
 		structEqual, err = t.CheckTableStruct(ctx)
@@ -127,18 +129,7 @@ func (t *TableDiff) Equal(ctx context.Context, writeFixSQL func(string) error) (
 
 // CheckTableStruct checks table's struct
 func (t *TableDiff) CheckTableStruct(ctx context.Context) (bool, error) {
-	tableInfo, err := dbutil.GetTableInfoWithRowID(ctx, t.TargetTable.Conn, t.TargetTable.Schema, t.TargetTable.Table, t.UseRowID)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	t.TargetTable.info = removeColumns(tableInfo, t.RemoveColumns)
-
 	for _, sourceTable := range t.SourceTables {
-		tableInfo, err := dbutil.GetTableInfoWithRowID(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, t.UseRowID)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		sourceTable.info = removeColumns(tableInfo, t.RemoveColumns)
 		eq := dbutil.EqualTableInfo(sourceTable.info, t.TargetTable.info)
 		if !eq {
 			return false, nil
@@ -148,7 +139,7 @@ func (t *TableDiff) CheckTableStruct(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (t *TableDiff) adjustConfig() {
+func (t *TableDiff) adjustConfig(ctx context.Context) error {
 	if t.ChunkSize <= 0 {
 		t.ChunkSize = 100
 	}
@@ -163,6 +154,26 @@ func (t *TableDiff) adjustConfig() {
 	if t.CheckThreadCount <= 0 {
 		t.CheckThreadCount = 4
 	}
+
+	return t.getTableInfo(ctx)
+}
+
+func (t *TableDiff) getTableInfo(ctx context.Context) error {
+	tableInfo, err := dbutil.GetTableInfoWithRowID(ctx, t.TargetTable.Conn, t.TargetTable.Schema, t.TargetTable.Table, t.UseRowID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	t.TargetTable.info = removeColumns(tableInfo, t.RemoveColumns)
+
+	for _, sourceTable := range t.SourceTables {
+		tableInfo, err := dbutil.GetTableInfoWithRowID(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, t.UseRowID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		sourceTable.info = removeColumns(tableInfo, t.RemoveColumns)
+	}
+
+	return nil
 }
 
 // CheckTableData checks table's data


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
issue: https://github.com/pingcap/tidb-tools/issues/187
when `ignore-struct-check = true` or some table's struct is not equal, some table's info may be nil.

### What is changed and how it works?
get all table's info when adjust config in source and target.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (set ignore-struct-check = true)

