### PR TITLE
pump client: add bench mark test

### DIFF
--- a/tidb-binlog/pump_client/bench_test.go
+++ b/tidb-binlog/pump_client/bench_test.go
@@ -1,0 +1,103 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/pingcap/tipb/go-binlog"
+	"google.golang.org/grpc"
+)
+
+func Benchmark100Thread(b *testing.B) {
+	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
+	writeFakeBinlog(b, pumpClient, 100, b.N)
+	pumpServer.Close()
+}
+
+func Benchmark200Thread(b *testing.B) {
+	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
+	writeFakeBinlog(b, pumpClient, 200, b.N)
+	pumpServer.Close()
+}
+
+func Benchmark300Thread(b *testing.B) {
+	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
+	writeFakeBinlog(b, pumpClient, 300, b.N)
+	pumpServer.Close()
+}
+
+func Benchmark400Thread(b *testing.B) {
+	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
+	writeFakeBinlog(b, pumpClient, 400, b.N)
+	pumpServer.Close()
+}
+
+func writeFakeBinlog(b *testing.B, pumpClient *PumpsClient, threadCount int, num int) {
+	var wg sync.WaitGroup
+	wg.Add(threadCount)
+	for i := 0; i < threadCount; i++ {
+		go func(baseTS int) {
+			for j := 0; j < num/threadCount; j++ {
+				pBinlog := &pb.Binlog{
+					Tp:      pb.BinlogType_Prewrite,
+					StartTs: int64(baseTS + j),
+				}
+				err := pumpClient.WriteBinlog(pBinlog)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				cBinlog := &pb.Binlog{
+					Tp:       pb.BinlogType_Commit,
+					StartTs:  int64(baseTS + j),
+					CommitTs: int64(baseTS + j),
+				}
+				err = pumpClient.WriteBinlog(cBinlog)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			wg.Done()
+		}(10000000 * i)
+	}
+
+	wg.Wait()
+}
+
+func createMockPumpsClientAndServer(b *testing.B) (*PumpsClient, *mockPumpServer) {
+	addr := "127.0.0.1:15049"
+	pumpServer, err := createMockPumpServer(addr, "tcp", false)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	opt := grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+		return net.DialTimeout("tcp", addr, timeout)
+	})
+
+	clientCon, err := grpc.Dial(addr, opt, grpc.WithInsecure())
+	if err != nil {
+		b.Fatal(err)
+	}
+	if clientCon == nil {
+		b.Fatal("grpc client is nil")
+	}
+	pumpClient := mockPumpsClient(pb.NewPumpClient(clientCon), false)
+
+	return pumpClient, pumpServer
+}

--- a/tidb-binlog/pump_client/bench_test.go
+++ b/tidb-binlog/pump_client/bench_test.go
@@ -24,26 +24,24 @@ import (
 )
 
 func Benchmark100Thread(b *testing.B) {
-	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
-	writeFakeBinlog(b, pumpClient, 100, b.N)
-	pumpServer.Close()
+	benchmarkTest(b, 100)
 }
 
 func Benchmark200Thread(b *testing.B) {
-	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
-	writeFakeBinlog(b, pumpClient, 200, b.N)
-	pumpServer.Close()
+	benchmarkTest(b, 200)
 }
 
 func Benchmark300Thread(b *testing.B) {
-	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
-	writeFakeBinlog(b, pumpClient, 300, b.N)
-	pumpServer.Close()
+	benchmarkTest(b, 300)
 }
 
 func Benchmark400Thread(b *testing.B) {
+	benchmarkTest(b, 400)
+}
+
+func benchmarkTest(b *testing.B, threadCount int) {
 	pumpClient, pumpServer := createMockPumpsClientAndServer(b)
-	writeFakeBinlog(b, pumpClient, 400, b.N)
+	writeFakeBinlog(b, pumpClient, threadCount, b.N)
 	pumpServer.Close()
 }
 


### PR DESCRIPTION
result in my computer:

go test -bench=. -run=none -benchtime=5s
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb-tools/tidb-binlog/pump_client
Benchmark100Thread-4      200000             59376 ns/op
Benchmark200Thread-4      100000             64627 ns/op
Benchmark300Thread-4      200000             49917 ns/op
Benchmark400Thread-4      200000             57376 ns/op
PASS
ok      github.com/pingcap/tidb-tools/tidb-binlog/pump_client   52.303s