### PR TITLE
diff: judge whether column exist when sort data

### DIFF
--- a/pkg/diff/merge.go
+++ b/pkg/diff/merge.go
@@ -39,8 +39,17 @@ func (r RowDatas) Less(i, j int) bool {
 	var data1, data2 []byte
 
 	for _, col := range r.OrderKeyCols {
-		data1 = r.Rows[i].Data[col.Name.O].Data
-		data2 = r.Rows[j].Data[col.Name.O].Data
+		col1, ok := r.Rows[i].Data[col.Name.O]
+		if !ok {
+			log.Fatal("data don't have column", zap.String("column", col.Name.O), zap.Reflect("data", r.Rows[i].Data))
+		}
+		col2, ok := r.Rows[j].Data[col.Name.O]
+		if !ok {
+			log.Fatal("data don't have column", zap.String("column", col.Name.O), zap.Reflect("data", r.Rows[j].Data))
+		}
+		data1 = col1.Data
+		data2 = col2.Data
+
 		if needQuotes(col.FieldType) {
 			strData1 := string(data1)
 			strData2 := string(data2)

--- a/pkg/diff/util.go
+++ b/pkg/diff/util.go
@@ -80,3 +80,13 @@ func getColumnsFromIndex(index *model.IndexInfo, tableInfo *model.TableInfo) []*
 func needQuotes(ft types.FieldType) bool {
 	return !(dbutil.IsNumberType(ft.Tp) || dbutil.IsFloatType(ft.Tp))
 }
+
+func rowContainsCols(row map[string]*dbutil.ColumnData, cols []*model.ColumnInfo) bool {
+	for _, col := range cols {
+		if _, ok := row[col.Name.O]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/diff/util_test.go
+++ b/pkg/diff/util_test.go
@@ -16,6 +16,7 @@ package diff
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb-tools/pkg/dbutil"
+	"github.com/pingcap/parser/model"
 )
 
 var _ = Suite(&testUtilSuite{})
@@ -43,4 +44,29 @@ func (s *testUtilSuite) TestRemoveColumns(c *C) {
 	tbInfo = removeColumns(tableInfo3, []string{"b", "c"})
 	c.Assert(len(tbInfo.Columns), Equals, 2)
 	c.Assert(len(tbInfo.Indices), Equals, 1)
+}
+
+func (s *testUtilSuite) TestRowContainsCols(c *C) {
+	row := map[string]*dbutil.ColumnData {
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	}
+
+	cols := []*model.ColumnInfo {
+		{
+			Name: model.NewCIStr("a"),
+		}, {
+			Name: model.NewCIStr("b"),
+		},{
+			Name: model.NewCIStr("c"),
+		},
+	}
+
+	contain := rowContainsCols(row, cols)
+	c.Assert(contain, Equals, true)
+
+	delete(row, "a")
+	contain = rowContainsCols(row, cols)
+	c.Assert(contain, Equals, false)
 }

--- a/pkg/diff/util_test.go
+++ b/pkg/diff/util_test.go
@@ -15,8 +15,8 @@ package diff
 
 import (
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb-tools/pkg/dbutil"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/tidb-tools/pkg/dbutil"
 )
 
 var _ = Suite(&testUtilSuite{})
@@ -47,18 +47,18 @@ func (s *testUtilSuite) TestRemoveColumns(c *C) {
 }
 
 func (s *testUtilSuite) TestRowContainsCols(c *C) {
-	row := map[string]*dbutil.ColumnData {
+	row := map[string]*dbutil.ColumnData{
 		"a": nil,
 		"b": nil,
 		"c": nil,
 	}
 
-	cols := []*model.ColumnInfo {
+	cols := []*model.ColumnInfo{
 		{
 			Name: model.NewCIStr("a"),
 		}, {
 			Name: model.NewCIStr("b"),
-		},{
+		}, {
 			Name: model.NewCIStr("c"),
 		},
 	}


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
will panic if data don't have column

### What is changed and how it works?
add a judge, will fatal if don't have column key

Related changes

 - Need to cherry-pick to the release branch