### PR TITLE
column-mapping: set schemaID/tableID to 0 if numeric suffix is missing

### DIFF
--- a/pkg/column-mapping/README.md
+++ b/pkg/column-mapping/README.md
@@ -33,13 +33,16 @@ add prefix, with arguments[prefix]
 
 add suffix, with arguments[suffix]
 
-partition id, with arguments [instance_id, prefix of schema, prefix of table]
+partition id, with arguments [instance_id, prefix of schema, prefix of table, separator]
 [1:1 bit][2:9 bits][3:10 bits][4:44 bits] int64  (using default bits length)
 - 1: useless, no reason
 - 2: schema ID (schema suffix)
 - 3: table ID (table suffix)
 - 4: origin ID (>= 0, <= 17592186044415)
-And schema = arguments[1] + schema suffix, table = arguments[2] + table suffix
+And
+- schema = arguments[1] + arguments[3] + schema suffix    or    arguments[1]
+- table  = arguments[2] + arguments[3] + table suffix     or    arguments[2]
+The separator argument defaults to an empty string if omitted.
 ```
 
 ## notice

--- a/pkg/column-mapping/column.go
+++ b/pkg/column-mapping/column.go
@@ -120,6 +120,14 @@ func (r *Rule) Valid() error {
 	return nil
 }
 
+// Adjust normalizes the rule into an easier-to-process form, e.g. filling in
+// optional arguments with the default values.
+func (r *Rule) Adjust() {
+	if r.Expression == PartitionID && len(r.Arguments) == 3 {
+		r.Arguments = append(r.Arguments, "")
+	}
+}
+
 // check source and target position
 func (r *Rule) adjustColumnPosition(source, target int) (int, int, error) {
 	// if not found target, ignore it
@@ -182,9 +190,7 @@ func (m *Mapping) addOrUpdateRule(rule *Rule, isUpdate bool) error {
 	if !m.caseSensitive {
 		rule.ToLower()
 	}
-	if rule.Expression == PartitionID && len(rule.Arguments) == 3 {
-		rule.Arguments = append(rule.Arguments, "")
-	}
+	rule.Adjust()
 
 	m.resetCache()
 	err = m.Insert(rule.PatternSchema, rule.PatternTable, rule, isUpdate)

--- a/pkg/column-mapping/column.go
+++ b/pkg/column-mapping/column.go
@@ -506,7 +506,13 @@ func computePartitionID(schema, table string, rule *Rule) (instanceID int64, sch
 }
 
 func computeID(name string, prefix string, bitSize int, shiftCount uint) (int64, error) {
-	if len(prefix) >= len(name) || prefix != name[:len(prefix)] {
+	switch {
+	case len(prefix) >= len(name):
+		if prefix[:len(name)] == name {
+			return 0, nil
+		}
+		fallthrough
+	case prefix != name[:len(prefix)]:
 		return 0, errors.NotValidf("%s is not the prefix of %s", prefix, name)
 	}
 

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -191,7 +191,7 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 
 	SetPartitionRule(4, 0, 8)
 	rule = &Rule{
-		Arguments: []string{"2", "test_", "t_"},
+		Arguments: []string{"2", "test_", "t_", ""},
 	}
 	instanceID, schemaID, tableID, err = computePartitionID("test_1", "t_1", rule)
 	c.Assert(err, IsNil)
@@ -208,7 +208,7 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 	// test ignore instance ID
 	SetPartitionRule(4, 7, 8)
 	rule = &Rule{
-		Arguments: []string{"", "test_", "t_"},
+		Arguments: []string{"", "test_", "t_", ""},
 	}
 	instanceID, schemaID, tableID, err = computePartitionID("test_1", "t_1", rule)
 	c.Assert(err, IsNil)
@@ -218,7 +218,7 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 
 	// test ignore schema ID
 	rule = &Rule{
-		Arguments: []string{"2", "", "t_"},
+		Arguments: []string{"2", "", "t_", ""},
 	}
 	instanceID, schemaID, tableID, err = computePartitionID("test_1", "t_1", rule)
 	c.Assert(err, IsNil)
@@ -228,7 +228,7 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 
 	// test ignore schema ID
 	rule = &Rule{
-		Arguments: []string{"2", "test_", ""},
+		Arguments: []string{"2", "test_", "", ""},
 	}
 	instanceID, schemaID, tableID, err = computePartitionID("test_1", "t_1", rule)
 	c.Assert(err, IsNil)

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -161,6 +161,28 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 	c.Assert(schemaID, Equals, int64(1<<52))
 	c.Assert(tableID, Equals, int64(1<<44))
 
+	// test default partition ID to zero
+	instanceID, schemaID, tableID, err = computePartitionID("test", "t_3", rule)
+	c.Assert(err, IsNil)
+	c.Assert(instanceID, Equals, int64(2<<59))
+	c.Assert(schemaID, Equals, int64(0))
+	c.Assert(tableID, Equals, int64(3<<44))
+
+	instanceID, schemaID, tableID, err = computePartitionID("test_5", "t", rule)
+	c.Assert(err, IsNil)
+	c.Assert(instanceID, Equals, int64(2<<59))
+	c.Assert(schemaID, Equals, int64(5<<52))
+	c.Assert(tableID, Equals, int64(0))
+
+	_, _, _, err = computePartitionID("unrelated", "t_6", rule)
+	c.Assert(err, ErrorMatches, "test_ is not the prefix of unrelated.*")
+
+	_, _, _, err = computePartitionID("test", "x", rule)
+	c.Assert(err, ErrorMatches, "t_ is not the prefix of x.*")
+
+	_, _, _, err = computePartitionID("test_0", "t_0xa", rule)
+	c.Assert(err, ErrorMatches, "the suffix of 0xa can't be converted to int64.*")
+
 	SetPartitionRule(4, 0, 8)
 	rule = &Rule{
 		Arguments: []string{"2", "test_", "t_"},

--- a/pkg/column-mapping/column_test.go
+++ b/pkg/column-mapping/column_test.go
@@ -153,7 +153,7 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 	c.Assert(err, NotNil)
 
 	rule = &Rule{
-		Arguments: []string{"2", "test_", "t_"},
+		Arguments: []string{"2", "test", "t", "_"},
 	}
 	instanceID, schemaID, tableID, err := computePartitionID("test_1", "t_1", rule)
 	c.Assert(err, IsNil)
@@ -183,6 +183,12 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 	_, _, _, err = computePartitionID("test_0", "t_0xa", rule)
 	c.Assert(err, ErrorMatches, "the suffix of 0xa can't be converted to int64.*")
 
+	_, _, _, err = computePartitionID("test_0", "t_", rule)
+	c.Assert(err, ErrorMatches, "t_ is not the prefix of t_.*") // needs a better error message
+
+	_, _, _, err = computePartitionID("testx", "t_3", rule)
+	c.Assert(err, ErrorMatches, "test_ is not the prefix of testx.*")
+
 	SetPartitionRule(4, 0, 8)
 	rule = &Rule{
 		Arguments: []string{"2", "test_", "t_"},
@@ -192,6 +198,12 @@ func (t *testColumnMappingSuit) TestComputePartitionID(c *C) {
 	c.Assert(instanceID, Equals, int64(2<<59))
 	c.Assert(schemaID, Equals, int64(0))
 	c.Assert(tableID, Equals, int64(1<<51))
+
+	instanceID, schemaID, tableID, err = computePartitionID("test_", "t_", rule)
+	c.Assert(err, IsNil)
+	c.Assert(instanceID, Equals, int64(2<<59))
+	c.Assert(schemaID, Equals, int64(0))
+	c.Assert(tableID, Equals, int64(0))
 
 	// test ignore instance ID
 	SetPartitionRule(4, 7, 8)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

(TOOL-1134) Support mixing names with and without numeric suffix.

### What is changed and how it works?

Added an optional *separator* argument to column mapping. The suffix is extracted as *prefix* + *separator* + *suffix*.

If the *name* equals to *prefix* (without the separator), we treat this to mean using a zero numeric suffix, i.e. if `prefix == "money", separator == "_"`:

* `money` → 0
* `money_` → error
* `money_5` → 5
* `money_6` → 6
* `money_7` → 7
* `money_money_money` → error
* `mon` → error
* `not_money` → error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

 - Need to update the documentation
