### PR TITLE
diff: some minor fix

### DIFF
--- a/pkg/dbutil/table.go
+++ b/pkg/dbutil/table.go
@@ -134,6 +134,8 @@ func columnDefToCol(offset int, colDef *ast.ColumnDef) (*model.ColumnInfo, []*as
 			case ast.ColumnOptionComment:
 				// do nothing
 			case ast.ColumnOptionGenerated:
+				// FIXME: use a default string now to make col.IsGenerated() return true, will use real generated expr string later
+				col.GeneratedExprString = "Generated"
 				// do nothing
 			case ast.ColumnOptionFulltext:
 				// do nothing

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -684,7 +684,7 @@ func generateDML(tp string, data map[string]*dbutil.ColumnData, keys []*model.Co
 			}
 
 			if needQuotes(col.FieldType) {
-				values = append(values, fmt.Sprintf("'%s'", string(data[col.Name.O].Data)))
+				values = append(values, fmt.Sprintf("'%s'", strings.Replace(string(data[col.Name.O].Data), "'", "\\'", -1)))
 			} else {
 				values = append(values, string(data[col.Name.O].Data))
 			}
@@ -704,7 +704,7 @@ func generateDML(tp string, data map[string]*dbutil.ColumnData, keys []*model.Co
 			}
 
 			if needQuotes(col.FieldType) {
-				kvs = append(kvs, fmt.Sprintf("`%s` = '%s'", col.Name.O, string(data[col.Name.O].Data)))
+				kvs = append(kvs, fmt.Sprintf("`%s` = '%s'", col.Name.O, strings.Replace(string(data[col.Name.O].Data), "'", "\\'", -1)))
 			} else {
 				kvs = append(kvs, fmt.Sprintf("`%s` = %s", col.Name.O, string(data[col.Name.O].Data)))
 			}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -673,6 +673,10 @@ func generateDML(tp string, data map[string]*dbutil.ColumnData, keys []*model.Co
 		colNames := make([]string, 0, len(table.Columns))
 		values := make([]string, 0, len(table.Columns))
 		for _, col := range table.Columns {
+			if col.IsGenerated() {
+				continue
+			}
+
 			colNames = append(colNames, fmt.Sprintf("`%s`", col.Name.O))
 			if data[col.Name.O].IsNull {
 				values = append(values, "NULL")
@@ -690,6 +694,10 @@ func generateDML(tp string, data map[string]*dbutil.ColumnData, keys []*model.Co
 	case "delete":
 		kvs := make([]string, 0, len(keys))
 		for _, col := range keys {
+			if col.IsGenerated() {
+				continue
+			}
+
 			if data[col.Name.O].IsNull {
 				kvs = append(kvs, fmt.Sprintf("`%s` is NULL", col.Name.O))
 				continue

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -35,7 +35,7 @@ var _ = Suite(&testDiffSuite{})
 type testDiffSuite struct{}
 
 func (*testDiffSuite) TestGenerateSQLs(c *C) {
-	createTableSQL := "CREATE TABLE `test`.`atest` (`id` int(24), `name` varchar(24), `birthday` datetime, `update_time` time, `money` decimal(20,2), primary key(`id`))"
+	createTableSQL := "CREATE TABLE `test`.`atest` (`id` int(24), `name` varchar(24), `birthday` datetime, `update_time` time, `money` decimal(20,2), `id_gen` int(11) GENERATED ALWAYS AS ((`id` + 1)) VIRTUAL, primary key(`id`))"
 	tableInfo, err := dbutil.GetTableInfoBySQL(createTableSQL)
 	c.Assert(err, IsNil)
 
@@ -45,6 +45,7 @@ func (*testDiffSuite) TestGenerateSQLs(c *C) {
 		"birthday":    {Data: []byte("2018-01-01 00:00:00"), IsNull: false},
 		"update_time": {Data: []byte("10:10:10"), IsNull: false},
 		"money":       {Data: []byte("11.1111"), IsNull: false},
+		"id_gen":      {Data: []byte("2"), IsNull: false}, // generated column should not be contained in fix sql
 	}
 
 	_, orderKeyCols := dbutil.SelectUniqueOrderKey(tableInfo)
@@ -77,9 +78,9 @@ func (*testDiffSuite) TestGenerateSQLs(c *C) {
 	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` is NULL;")
 
 	// test value with "'"
-	rowsData["name"] = &dbutil.ColumnData{Data: []byte("a'a"), IsNull: true}
+	rowsData["name"] = &dbutil.ColumnData{Data: []byte("a'a"), IsNull: false}
 	replaceSQL = generateDML("replace", rowsData, orderKeyCols, tableInfo, "test")
-	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,'a\'a','2018-01-01 00:00:00','10:10:10',11.1111);")
+	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,'a\\'a','2018-01-01 00:00:00','10:10:10',11.1111);")
 }
 
 func (t *testDiffSuite) testDiff(c *C) {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -75,6 +75,11 @@ func (*testDiffSuite) TestGenerateSQLs(c *C) {
 	deleteSQL = generateDML("delete", rowsData, orderKeyCols, tableInfo, "test")
 	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,NULL,'2018-01-01 00:00:00','10:10:10',11.1111);")
 	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` is NULL;")
+
+	// test value with "'"
+	rowsData["name"] = &dbutil.ColumnData{Data: []byte("a'a"), IsNull: true}
+	replaceSQL = generateDML("replace", rowsData, orderKeyCols, tableInfo, "test")
+	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,'a\'a','2018-01-01 00:00:00','10:10:10',11.1111);")
 }
 
 func (t *testDiffSuite) testDiff(c *C) {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -35,7 +35,7 @@ var _ = Suite(&testDiffSuite{})
 type testDiffSuite struct{}
 
 func (*testDiffSuite) TestGenerateSQLs(c *C) {
-	createTableSQL := "CREATE TABLE `test`.`atest` (`id` int(24), `name` varchar(24), `birthday` datetime, `update_time` time, `money` decimal(20,2), `id_gen` int(11) GENERATED ALWAYS AS ((`id` + 1)) VIRTUAL, primary key(`id`))"
+	createTableSQL := "CREATE TABLE `test`.`atest` (`id` int(24), `name` varchar(24), `birthday` datetime, `update_time` time, `money` decimal(20,2), `id_gen` int(11) GENERATED ALWAYS AS ((`id` + 1)) VIRTUAL, primary key(`id`, `name`))"
 	tableInfo, err := dbutil.GetTableInfoBySQL(createTableSQL)
 	c.Assert(err, IsNil)
 
@@ -52,7 +52,7 @@ func (*testDiffSuite) TestGenerateSQLs(c *C) {
 	replaceSQL := generateDML("replace", rowsData, orderKeyCols, tableInfo, "test")
 	deleteSQL := generateDML("delete", rowsData, orderKeyCols, tableInfo, "test")
 	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,'xxx','2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` = 1;")
+	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` = 1 AND `name` = 'xxx';")
 
 	// test the unique key
 	createTableSQL2 := "CREATE TABLE `test`.`atest` (`id` int(24), `name` varchar(24), `birthday` datetime, `update_time` time, `money` decimal(20,2), unique key(`id`, `name`))"
@@ -69,18 +69,20 @@ func (*testDiffSuite) TestGenerateSQLs(c *C) {
 	replaceSQL = generateDML("replace", rowsData, orderKeyCols, tableInfo, "test")
 	deleteSQL = generateDML("delete", rowsData, orderKeyCols, tableInfo, "test")
 	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,NULL,'2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` = 1;")
+	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` = 1 AND `name` is NULL;")
 
 	rowsData["id"] = &dbutil.ColumnData{Data: []byte(""), IsNull: true}
 	replaceSQL = generateDML("replace", rowsData, orderKeyCols, tableInfo, "test")
 	deleteSQL = generateDML("delete", rowsData, orderKeyCols, tableInfo, "test")
 	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,NULL,'2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` is NULL;")
+	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` is NULL AND `name` is NULL;")
 
 	// test value with "'"
 	rowsData["name"] = &dbutil.ColumnData{Data: []byte("a'a"), IsNull: false}
 	replaceSQL = generateDML("replace", rowsData, orderKeyCols, tableInfo, "test")
+	deleteSQL = generateDML("delete", rowsData, orderKeyCols, tableInfo, "test")
 	c.Assert(replaceSQL, Equals, "REPLACE INTO `test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,'a\\'a','2018-01-01 00:00:00','10:10:10',11.1111);")
+	c.Assert(deleteSQL, Equals, "DELETE FROM `test`.`atest` WHERE `id` is NULL AND `name` = 'a\\'a';")
 }
 
 func (t *testDiffSuite) testDiff(c *C) {

--- a/pkg/diff/util.go
+++ b/pkg/diff/util.go
@@ -61,9 +61,6 @@ func removeColumns(tableInfo *model.TableInfo, columns []string) *model.TableInf
 	for j := 0; j < len(tableInfo.Columns); j++ {
 		col := tableInfo.Columns[j]
 		if _, ok := removeColMap[col.Name.O]; ok {
-			//for _, column := range tableInfo.Columns[j+1:] {
-			//	column.Offset--
-			//}
 			tableInfo.Columns = append(tableInfo.Columns[:j], tableInfo.Columns[j+1:]...)
 			j--
 		}

--- a/pkg/diff/util.go
+++ b/pkg/diff/util.go
@@ -67,7 +67,7 @@ func removeColumns(tableInfo *model.TableInfo, columns []string) *model.TableInf
 	}
 
 	// calculate column offset
-	colMap := make(map[string]int)
+	colMap := make(map[string]int, len(tableInfo.Columns))
 	for i, col := range tableInfo.Columns {
 		col.Offset = i
 		colMap[col.Name.O] = i

--- a/pkg/diff/util_test.go
+++ b/pkg/diff/util_test.go
@@ -28,22 +28,25 @@ func (s *testUtilSuite) TestRemoveColumns(c *C) {
 	tableInfo1, err := dbutil.GetTableInfoBySQL(createTableSQL1)
 	c.Assert(err, IsNil)
 	tbInfo := removeColumns(tableInfo1, []string{"a"})
-	c.Assert(len(tbInfo.Columns), Equals, 3)
-	c.Assert(len(tbInfo.Indices), Equals, 0)
+	c.Assert(tbInfo.Columns, HasLen, 3)
+	c.Assert(tbInfo.Indices, HasLen, 0)
+	c.Assert(tbInfo.Columns[2].Offset, Equals, 2)
 
 	createTableSQL2 := "CREATE TABLE `test`.`atest` (`a` int, `b` int, `c` int, `d` int, primary key(`a`), index idx(`b`, `c`))"
 	tableInfo2, err := dbutil.GetTableInfoBySQL(createTableSQL2)
 	c.Assert(err, IsNil)
 	tbInfo = removeColumns(tableInfo2, []string{"a", "b"})
-	c.Assert(len(tbInfo.Columns), Equals, 2)
-	c.Assert(len(tbInfo.Indices), Equals, 1)
+	c.Assert(tbInfo.Columns, HasLen, 2)
+	c.Assert(tbInfo.Indices, HasLen, 1)
+	c.Assert(tbInfo.Indices[0].Columns, HasLen, 1)
+	c.Assert(tbInfo.Indices[0].Columns[0].Offset, Equals, 0)
 
 	createTableSQL3 := "CREATE TABLE `test`.`atest` (`a` int, `b` int, `c` int, `d` int, primary key(`a`), index idx(`b`, `c`))"
 	tableInfo3, err := dbutil.GetTableInfoBySQL(createTableSQL3)
 	c.Assert(err, IsNil)
 	tbInfo = removeColumns(tableInfo3, []string{"b", "c"})
-	c.Assert(len(tbInfo.Columns), Equals, 2)
-	c.Assert(len(tbInfo.Indices), Equals, 1)
+	c.Assert(tbInfo.Columns, HasLen, 2)
+	c.Assert(tbInfo.Indices, HasLen, 1)
 }
 
 func (s *testUtilSuite) TestRowContainsCols(c *C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
1. fix issue https://github.com/pingcap/tidb-tools/issues/234
2. when fix sql contain generated column can't execute in mysql/tidb
3. when column's value have `'`, the fix sql don't have escape charset, so can't execute in mysql/tidb

### What is changed and how it works?
fix these bugs

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Related changes

 - Need to cherry-pick to the release branch