### PR TITLE
pump_client: bug fix and enhancement...

### DIFF
--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -358,7 +358,7 @@ func (c *PumpsClient) backoffWriteBinlog(req *pb.WriteBinlogReq, binlogType pb.B
 				err = errors.New(resp.Errmsg)
 			} else {
 				// if this pump can write binlog success, set this pump to avaliable.
-				log.Info("[pumps client] write binlog to unavaliable pump success, set this pump to avaliable", zap.String("NodeID", pump.NodeID))
+				log.Info("[pumps client] write binlog to pump success, set this pump to avaliable", zap.String("NodeID", pump.NodeID))
 				c.setPumpAvaliable(pump, true)
 				return pump, nil
 			}

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -321,6 +321,7 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 	var err1 error
 	pump, err1 = c.backoffWriteBinlog(req, binlog.Tp, binlog.StartTs)
 	if err1 == nil {
+		meetError = false
 		log.Info("[pumps client] backoff write binlog successfully", zap.Stringer("binlog type", binlog.Tp), zap.Int64("start ts", binlog.StartTs))
 		return nil
 	} else {

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -250,7 +250,6 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 	c.RUnlock()
 
 	var pump *PumpStatus
-	meetError := false
 	pumpError := false
 
 	defer func() {
@@ -258,7 +257,7 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			c.checkPumpAvaliable()
 		}
 
-		if pump != nil && meetError {
+		if pump != nil {
 			selector.Feedback(binlog.StartTs, binlog.Tp, pump)
 		}
 	}()
@@ -301,7 +300,6 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			time.Sleep(RetryInterval * 10)
 		} else {
 			if !isRetryableError(err) {
-				meetError = true
 				// this kind of error is not retryable, return directly.
 				return errors.Trace(err)
 			}
@@ -327,7 +325,6 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 		log.Info("[pumps client] backoff write binlog successfully", zap.Stringer("binlog type", binlog.Tp), zap.Int64("start ts", binlog.StartTs))
 		return nil
 	}
-	meetError = true
 	log.Error("[pumps client] backoff write binlog failed", zap.Stringer("binlog type", binlog.Tp), zap.Int64("start ts", binlog.StartTs))
 
 	return errors.Errorf("write binlog failed, the last error %v", err)

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -296,8 +296,8 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			// Retry on this pump if err code is `codes.Unavailable`
 			// This is a most likely a transient condition and may be corrected
 			// by retrying with a backoff.
-			if status.Code(err) == codes.Unavailable {
-				log.Warn("[pump client] write binlog unavailable", zap.String("NodeID", pump.NodeID))
+			if status.Code(err) == codes.Unavailable || status.Code(err) == codes.DeadlineExceeded {
+				log.Warn("[pump client] write binlog undetermined failed", zap.String("NodeID", pump.NodeID))
 				continue
 			} else {
 				break

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -626,6 +626,5 @@ func copyPumps(pumps map[string]*PumpStatus) []*PumpStatus {
 
 // InitLogger initializes logger.
 func InitLogger(cfg *logutil.LogConfig) error {
-	//return logutil.InitZapLogger(cfg)
-	return nil
+	return logutil.InitZapLogger(cfg)
 }

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -258,7 +258,7 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			c.checkPumpAvaliable()
 		}
 
-		if pump != nil && meetError {
+		if pump != nil && !meetError {
 			selector.Feedback(binlog.StartTs, binlog.Tp, pump)
 		}
 	}()

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -439,12 +439,7 @@ func (c *PumpsClient) updatePump(status *node.Status) (pump *PumpStatus, avaliab
 
 	if pump.Status.State != status.State {
 		avaliableChanged = true
-		avaliable = true
-		if pump.ShouldBeUsable() {
-			avaliable = true
-		} else {
-			avaliable = false
-		}
+		avaliable = pump.ShouldBeUsable()
 	}
 
 	if status.Addr != pump.Status.Addr {

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
 	binlog "github.com/pingcap/tipb/go-binlog"
 	pb "github.com/pingcap/tipb/go-binlog"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 )
@@ -323,7 +324,12 @@ func createMockPumpServer(addr string, mode string, writeSuccessPer int64) (*moc
 		writeSuccessPer: writeSuccessPer,
 	}
 	pb.RegisterPumpServer(serv, pump)
-	go serv.Serve(l)
+	go func() {
+		err := serv.Serve(l)
+		if err != nil {
+			log.Error("serve err", zap.Error(err))
+		}
+	}()
 
 	return pump, nil
 }

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -67,7 +67,11 @@ func (*testClientSuite) testSelector(c *C, strategy string) {
 		BinlogWriteTimeout: DefaultBinlogWriteTimeout,
 	}
 
-	pumps := []*PumpStatus{{}, {}, {}}
+	pumps := []*PumpStatus{
+		NewPumpStatus(&node.Status{}, nil),
+		NewPumpStatus(&node.Status{}, nil),
+		NewPumpStatus(&node.Status{}, nil),
+	}
 	for i, pump := range pumps {
 		pump.NodeID = fmt.Sprintf("pump%d", i)
 		pump.State = node.Offline

--- a/tidb-binlog/pump_client/client_test.go
+++ b/tidb-binlog/pump_client/client_test.go
@@ -187,23 +187,23 @@ func (t *testClientSuite) TestWriteBinlog(c *C) {
 	log.SetLevel(zapcore.DebugLevel)
 	pumpServerConfig := []pumpInstance{
 		{
-			localPump,
-			node.Online,
-			"/tmp/mock-pump.sock",
-			"unix",
-			1,
+			nodeID:          localPump,
+			Status:          node.Online,
+			addr:            "/tmp/mock-pump.sock",
+			serverMode:      "unix",
+			writeSuccessPer: 1,
 		}, {
-			"Node-1",
-			node.Online,
-			"127.0.0.1:15049",
-			"tcp",
-			1,
+			nodeID:          "Node-1",
+			Status:          node.Online,
+			addr:            "127.0.0.1:15049",
+			serverMode:      "tcp",
+			writeSuccessPer: 1,
 		}, {
-			"Node-2",
-			node.Online,
-			"127.0.0.1:15050",
-			"tcp",
-			math.MinInt64, // never return success
+			nodeID:          "Node-2",
+			Status:          node.Online,
+			addr:            "127.0.0.1:15050",
+			serverMode:      "tcp",
+			writeSuccessPer: math.MinInt64, // never return success
 		},
 	}
 

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -149,10 +149,10 @@ func (p *PumpStatus) WriteBinlog(req *pb.WriteBinlogReq, timeout time.Duration) 
 				log.Info("[pumps client] write binlog to unavailable pump success, set this pump to avaliable", zap.String("NodeID", p.NodeID))
 				return nil, errors.Trace(err)
 			}
-
-			p.Unlock()
-			p.RLock()
 		}
+
+		p.Unlock()
+		p.RLock()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -107,6 +107,7 @@ func (p *PumpStatus) createGrpcClient() error {
 		})
 	} else {
 		dialerOpt = grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			log.Debug("dial tcp", zap.String("addr", addr))
 			return net.DialTimeout("tcp", addr, timeout)
 		})
 	}

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -83,7 +83,9 @@ func NewPumpStatus(status *node.Status, security *tls.Config) *PumpStatus {
 }
 
 func (p *PumpStatus) markReCreateClient() {
+	p.Lock()
 	p.reCreateClient = true
+	p.Unlock()
 }
 
 func (p *PumpStatus) close() {

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -141,7 +141,7 @@ func (p *PumpStatus) WriteBinlog(req *pb.WriteBinlogReq, timeout time.Duration) 
 		p.RUnlock()
 		p.Lock()
 		if p.reCreateClient || p.grpcConn == nil {
-			p.reCreateClient = true
+			p.reCreateClient = false
 			err := p.createGrpcClient()
 			if err != nil {
 				p.Unlock()

--- a/tidb-binlog/pump_client/pump.go
+++ b/tidb-binlog/pump_client/pump.go
@@ -169,7 +169,7 @@ func (p *PumpStatus) createGrpcClient() error {
 	return nil
 }
 
-// Reset resets the pump's err num.
+// Reset resets the pump's real state.
 func (p *PumpStatus) Reset() {
 	p.state.markAvailable()
 }
@@ -185,7 +185,7 @@ func (p *PumpStatus) WriteBinlog(req *pb.WriteBinlogReq, timeout time.Duration) 
 			err := p.createGrpcClient()
 			if err != nil {
 				p.Unlock()
-				log.Info("[pumps client] write binlog to unavailable pump success, set this pump to avaliable", zap.String("NodeID", p.NodeID))
+				log.Info("[pumps client] fail to create grpc client", zap.String("NodeID", p.NodeID))
 				return nil, errors.Trace(err)
 			}
 		}
@@ -220,9 +220,5 @@ func (p *PumpStatus) IsUsable() bool {
 
 // ShouldBeUsable returns true if pump should be usable
 func (p *PumpStatus) ShouldBeUsable() bool {
-	if p.Status.State != node.Online {
-		return false
-	}
-
-	return true
+	return p.Status.State == node.Online
 }

--- a/tidb-binlog/pump_client/pump_test.go
+++ b/tidb-binlog/pump_client/pump_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"math"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testPumpClient{})
+
+type testPumpClient struct{}
+
+func (t *testPumpClient) TestPumpState(c *C) {
+	s := &realPumpState{}
+
+	c.Assert(s.failedTS, Equals, int64(0))
+	c.Assert(s.isAvaliable(), IsTrue)
+
+	s.markUnAvailable()
+	c.Assert(s.isAvaliable(), IsFalse)
+
+	s.markAvailable()
+	c.Assert(s.isAvaliable(), IsTrue)
+
+	c.Assert(s.failedTS, Equals, int64(0))
+	s.updateFailedTS(1)
+	c.Assert(s.failedTS, Equals, int64(1))
+	c.Assert(s.isAvaliable(), IsTrue)
+
+	s.updateFailedTS(2)
+	c.Assert(s.failedTS, Equals, int64(1))
+	c.Assert(s.isAvaliable(), IsTrue)
+
+	s.updateFailedTS(301)
+	c.Assert(s.failedTS, Equals, int64(1))
+	c.Assert(s.isAvaliable(), IsTrue)
+
+	s.updateFailedTS(302)
+	c.Assert(s.failedTS, Equals, int64(math.MaxInt64))
+	c.Assert(s.isAvaliable(), IsFalse)
+
+	s.markAvailable()
+	c.Assert(s.isAvaliable(), IsTrue)
+	c.Assert(s.failedTS, Equals, int64(0))
+}

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -133,6 +133,8 @@ func (r *RangeSelector) SetPumps(pumps []*PumpStatus) {
 // Select implement PumpSelector.Select.
 func (r *RangeSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	// TODO: use status' label to match suitable pump.
+	// FIXME: for concurrent Write, may return the same pump instance for one binlog, so will not
+	// try every pump instance if call Select to get another pump instance an retry.
 	selectorLock.Lock()
 	defer selectorLock.Unlock()
 

--- a/tidb-binlog/pump_client/selector.go
+++ b/tidb-binlog/pump_client/selector.go
@@ -49,7 +49,7 @@ type PumpSelector interface {
 	SetPumps([]*PumpStatus)
 
 	// Select returns a situable pump. Tips: should call this function only one time for commit/rollback binlog.
-	Select(binlog *pb.Binlog, retryTime int) *PumpStatus
+	Select(binlog *pb.Binlog) *PumpStatus
 
 	// Feedback set the corresponding relations between startTS and pump.
 	Feedback(startTS int64, binlogType pb.BinlogType, pump *PumpStatus)
@@ -76,7 +76,7 @@ func (h *HashSelector) SetPumps(pumps []*PumpStatus) {
 }
 
 // Select implement PumpSelector.Select.
-func (h *HashSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
+func (h *HashSelector) Select(binlog *pb.Binlog) *PumpStatus {
 	// TODO: use status' label to match suitable pump.
 	selectorLock.Lock()
 	defer selectorLock.Unlock()
@@ -95,7 +95,7 @@ func (h *HashSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
 	if len(h.Pumps) == 0 {
 		return nil
 	}
-	i := (binlog.StartTs + int64(retryTime)) % int64(len(h.Pumps))
+	i := binlog.StartTs % int64(len(h.Pumps))
 	pump := h.Pumps[int(i)]
 	return pump
 }
@@ -131,7 +131,7 @@ func (r *RangeSelector) SetPumps(pumps []*PumpStatus) {
 }
 
 // Select implement PumpSelector.Select.
-func (r *RangeSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
+func (r *RangeSelector) Select(binlog *pb.Binlog) *PumpStatus {
 	// TODO: use status' label to match suitable pump.
 	// FIXME: for concurrent Write, may return the same pump instance for one binlog, so will not
 	// try every pump instance if call Select to get another pump instance an retry.
@@ -191,7 +191,7 @@ func (u *LocalUnixSelector) SetPumps(pumps []*PumpStatus) {
 }
 
 // Select implement PumpSelector.Select.
-func (u *LocalUnixSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
+func (u *LocalUnixSelector) Select(binlog *pb.Binlog) *PumpStatus {
 	selectorLock.RLock()
 	defer selectorLock.RUnlock()
 
@@ -217,7 +217,7 @@ func (s *ScoreSelector) SetPumps(pumps []*PumpStatus) {
 }
 
 // Select implement PumpSelector.Select.
-func (s *ScoreSelector) Select(binlog *pb.Binlog, retryTime int) *PumpStatus {
+func (s *ScoreSelector) Select(binlog *pb.Binlog) *PumpStatus {
 	// TODO
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We often encounter replication delay problems caused by the misacth of p-binlog and c-binlog in one pump  in internal tests.

there are two reasons
* c-binlog write failed. If the grpc connection is unavailable in the previous  implementation, then c-binlog will definitely fail to write. This is a bug.

* write more than one p-binlog in more than one pumps, but only write down one c-binlog, it would caused by pump client selector strategy

### What is changed and how it works?

1. don't recreate ClientConn unless Addr is change, ClientConn will maintain the connections to server and reconnect if need.
2,. only choose pump once, try all pumps at last

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
Code changes


