### PR TITLE
diff: update column's length for checkpoint table

### DIFF
--- a/pkg/diff/checkpoint.go
+++ b/pkg/diff/checkpoint.go
@@ -268,7 +268,7 @@ func createCheckpointTable(ctx context.Context, db *sql.DB) error {
 	*/
 	createSummaryTableSQL :=
 		"CREATE TABLE IF NOT EXISTS `sync_diff_inspector`.`summary`(" +
-			"`schema` varchar(30), `table` varchar(30)," +
+			"`schema` varchar(50), `table` varchar(50)," +
 			"`chunk_num` int not null default 0," +
 			"`check_success_num` int not null default 0," +
 			"`check_failed_num` int not null default 0," +
@@ -295,9 +295,9 @@ func createCheckpointTable(ctx context.Context, db *sql.DB) error {
 	createChunkTableSQL :=
 		"CREATE TABLE IF NOT EXISTS `sync_diff_inspector`.`chunk`(" +
 			"`chunk_id` int," +
-			"`instance_id` varchar(30)," +
-			"`schema` varchar(30)," +
-			"`table` varchar(30)," +
+			"`instance_id` varchar(50)," +
+			"`schema` varchar(50)," +
+			"`table` varchar(50)," +
 			"`range` varchar(100)," +
 			"`checksum` varchar(20)," +
 			"`chunk_str` text," +

--- a/pkg/diff/checkpoint.go
+++ b/pkg/diff/checkpoint.go
@@ -268,7 +268,7 @@ func createCheckpointTable(ctx context.Context, db *sql.DB) error {
 	*/
 	createSummaryTableSQL :=
 		"CREATE TABLE IF NOT EXISTS `sync_diff_inspector`.`summary`(" +
-			"`schema` varchar(50), `table` varchar(50)," +
+			"`schema` varchar(64), `table` varchar(64)," +
 			"`chunk_num` int not null default 0," +
 			"`check_success_num` int not null default 0," +
 			"`check_failed_num` int not null default 0," +
@@ -295,9 +295,9 @@ func createCheckpointTable(ctx context.Context, db *sql.DB) error {
 	createChunkTableSQL :=
 		"CREATE TABLE IF NOT EXISTS `sync_diff_inspector`.`chunk`(" +
 			"`chunk_id` int," +
-			"`instance_id` varchar(50)," +
-			"`schema` varchar(50)," +
-			"`table` varchar(50)," +
+			"`instance_id` varchar(64)," +
+			"`schema` varchar(64)," +
+			"`table` varchar(64)," +
 			"`range` varchar(100)," +
 			"`checksum` varchar(20)," +
 			"`chunk_str` text," +


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
user meet error `Check data difference failed "Error 1406: Data too long, field len 30, data len 31"`
need increase some columns' length in checkpoint table


### What is changed and how it works?
update some columns' length from 30 to 64（the max schema/table name length in mysql and tidb https://dev.mysql.com/doc/refman/8.0/en/identifiers.html）

