### PR TITLE
diff: remove tidb-instance-id config and find tidb instance automatic

### DIFF
--- a/sync_diff_inspector/config.go
+++ b/sync_diff_inspector/config.go
@@ -200,9 +200,6 @@ type Config struct {
 	// set true will continue check from the latest checkpoint
 	UseCheckpoint bool `toml:"use-checkpoint" json:"use-checkpoint"`
 
-	// use this tidb's statistics information to split chunk
-	TiDBInstanceID string `toml:"tidb-instance-id" json:"tidb-instance-id"`
-
 	// config file
 	ConfigFile string
 

--- a/sync_diff_inspector/config.toml
+++ b/sync_diff_inspector/config.toml
@@ -33,8 +33,6 @@ ignore-struct-check = false
 # the name of the file which saves sqls used to fix different data.
 fix-sql-file = "fix.sql"
 
-# use this tidb's statistics information to split chunk
-# tidb-instance-id = ""
 
 # uncomment this if comparing data with different database name or table name
 #[[table-rules]]

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -382,9 +382,7 @@ func (df *Diff) Equal() (err error) {
 				log.Warn("judge instance is tidb failed", zap.Error(err))
 			} else if isTiDB {
 				tidbStatsSource = targetTableInstance
-			}
-
-			if tidbStatsSource == nil && len(sourceTables) == 1 {
+			} else if len(sourceTables) == 1 {
 				isTiDB, err := dbutil.IsTiDB(ctx, sourceTables[0].Conn)
 				if err != nil {
 					log.Warn("judge instance is tidb failed", zap.Error(err))

--- a/tests/_utils/check_not_contains
+++ b/tests/_utils/check_not_contains
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# argument 1 is the string need grep
+# argument 2 is the filename
+
+set -eu
+OUT_DIR=/tmp/tidb_binlog_test
+
+if grep -Fq "$1" "$2"; then
+    echo "TEST FAILED: '$2' CONTAIN '$1'"
+    echo "____________________________________"
+    cat "$2"
+    echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+    exit 1
+fi

--- a/tests/sync_diff_inspector/config_base.toml
+++ b/tests/sync_diff_inspector/config_base.toml
@@ -24,8 +24,6 @@ use-checkpoint = false
 # the name of the file which saves sqls used to fix different data.
 fix-sql-file = "/tmp/tidb_tools_test/sync_diff_inspector/fix.sql"
 
-# use this tidb's statistics information to split chunk
-tidb-instance-id = "target-1"
 
 # tables need to check.
 [[check-tables]]

--- a/tests/sync_diff_inspector/run.sh
+++ b/tests/sync_diff_inspector/run.sh
@@ -14,14 +14,18 @@ importer -t "create table diff_test.test(a int, b varchar(10), c float, d dateti
 
 echo "dump data and then load to tidb"
 mydumper --host 127.0.0.1 --port 4000 --user root --outputdir $OUT_DIR/dump_diff -B diff_test -T test
-
 loader -h 127.0.0.1 -P 4001 -u root -d $OUT_DIR/dump_diff
 
 echo "use sync_diff_inspector to compare data"
-
 sync_diff_inspector --config=./config_base.toml > $OUT_DIR/diff.log
-
 check_contains "test pass!!!" $OUT_DIR/diff.log
+
+echo "analyze table, and will use tidb's statistical information to split chunks"
+check_contains "will split chunk by random again" $OUT_DIR/diff.log
+mysql -uroot -h 127.0.0.1 -P 4000 -e "analyze table diff_test.test"
+sync_diff_inspector --config=./config_base.toml > $OUT_DIR/diff.log
+check_contains "test pass!!!" $OUT_DIR/diff.log
+check_not_contains "will split chunk by random again" $OUT_DIR/diff.log
 
 for script in ./*/run.sh; do
     test_name="$(basename "$(dirname "$script")")"


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
can find tidb instance by select version(), so don't need user to set tidb-instance-id manually.

### What is changed and how it works?
1. remove tidb-instance-id config and find tidb instance by IsTiDB function
2. execute analyze table in integration test, so can use tidb's statistics information to split chunk

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test