### PR TITLE
pkg: use case insensitive event in binlog filter

### DIFF
--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -265,7 +265,9 @@ func (b *BinlogEvent) Filter(schema, table string, event EventType, rawQuery str
 }
 
 func (b *BinlogEvent) matchEvent(tp, event EventType, rules []EventType) bool {
-	for _, rule := range rules {
+	for _, rawRule := range rules {
+		rule := EventType(strings.ToLower(string(rawRule)))
+
 		if rule == AllEvent {
 			return true
 		}

--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -99,7 +99,6 @@ func (b *BinlogEventRule) ToLower() {
 }
 
 // Valid checks validity of rule.
-// TODO: check validity of dml/ddl event.
 func (b *BinlogEventRule) Valid() error {
 	if len(b.SQLPattern) > 0 {
 		reg, err := regexp.Compile("(?i)" + strings.Join(b.SQLPattern, "|"))
@@ -111,6 +110,11 @@ func (b *BinlogEventRule) Valid() error {
 
 	if b.Action != Do && b.Action != Ignore {
 		return errors.Errorf("action of binlog event rule %+v should not be empty", b)
+	}
+
+	// TODO: check validity of dml/ddl event.
+	for i := range b.Events {
+		b.Events[i] = EventType(strings.ToLower(string(b.Events[i])))
 	}
 
 	return nil
@@ -265,9 +269,7 @@ func (b *BinlogEvent) Filter(schema, table string, event EventType, rawQuery str
 }
 
 func (b *BinlogEvent) matchEvent(tp, event EventType, rules []EventType) bool {
-	for _, rawRule := range rules {
-		rule := EventType(strings.ToLower(string(rawRule)))
-
+	for _, rule := range rules {
 		if rule == AllEvent {
 			return true
 		}

--- a/pkg/binlog-filter/filter_test.go
+++ b/pkg/binlog-filter/filter_test.go
@@ -73,6 +73,7 @@ func (t *testFilterSuite) TestFilter(c *C) {
 	// update rules
 	rules[0].Events = []EventType{}
 	rules[1].Action = Do
+	rules[2].Events = []EventType{"ALL DDL"}
 	for _, rule := range rules {
 		err = filter.UpdateRule(rule)
 		c.Assert(err, IsNil)
@@ -83,6 +84,8 @@ func (t *testFilterSuite) TestFilter(c *C) {
 	cases[3].action = Do      // create index
 	cases[9].action = Do      // match all event and insert
 	cases[10].action = Ignore // match none event and create index
+	cases[11].action = Ignore // no match
+	cases[12].action = Do     // match all ddl
 	for _, cs := range cases {
 		action, err := filter.Filter(cs.schema, cs.table, cs.event, cs.sql)
 		c.Assert(err, IsNil)

--- a/pkg/binlog-filter/filter_test.go
+++ b/pkg/binlog-filter/filter_test.go
@@ -31,6 +31,7 @@ func (t *testFilterSuite) TestFilter(c *C) {
 	rules := []*BinlogEventRule{
 		{"Test_1_*", "abc*", []EventType{DeleteEvent, InsertEvent, CreateIndex, DropIndex}, []string{"^DROP\\s+PROCEDURE", "^CREATE\\s+PROCEDURE"}, nil, Ignore},
 		{"xxx_*", "abc_*", []EventType{AllDML, NoneDDL}, nil, nil, Ignore},
+		{"yyy_*", "abc_*", []EventType{EventType("ALL DML")}, nil, nil, Do},
 	}
 
 	cases := []struct {
@@ -50,6 +51,8 @@ func (t *testFilterSuite) TestFilter(c *C) {
 		{"xxx_1", "abc_1", NullEvent, "create function abc", Do},
 		{"xxx_1", "abc_1", InsertEvent, "", Ignore},
 		{"xxx_1", "abc_1", CreateIndex, "", Do},
+		{"yyy_1", "abc_1", InsertEvent, "", Do},
+		{"yyy_1", "abc_1", CreateIndex, "", Ignore},
 	}
 
 	// initial binlog event filter


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

binlog event is lowercase only now. It is not harmful to be case insensitive.

### What is changed and how it works?

change the input rule to lowercase EventType before match.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

