### PR TITLE
Fix: watcher's modify event condition won't trigger on macOS

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -198,7 +198,10 @@ func (w *Watcher) pollEvents(currFileList map[string]os.FileInfo) {
 			continue
 		}
 
-		if !latestFi.ModTime().Equal(currFi.ModTime()) {
+		// ModTime may return timestamp in second level on some file system
+		// So use ModTime + Size to judge modify event will be more precisely
+		if !latestFi.ModTime().Equal(currFi.ModTime()) ||
+			latestFi.Size() != currFi.Size() {
 			// modify
 			select {
 			case <-w.closed:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
watcher on macOS (HFS+) won't send modify event in some case due to the file may change in the same second and HFS+ only stores [second level timestamp](https://stackoverflow.com/questions/18403588/how-to-return-millisecond-information-for-file-access-on-mac-os-x-in-java)

```package main
import "fmt"
import "os"

func main() {
    fileName := "test"
    f, _ := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
    stat, _ := os.Stat(fileName)
    for i := 0; i < 10; i ++ {
        f.Write([]byte("test\n"))
    }
    stat2, _ := os.Stat(fileName)
    fmt.Println(stat.ModTime() == stat2.ModTime())
}
```

code above may return true on my computer sometimes
### What is changed and how it works?
Use ModTime() + Size() can reduce error scenarios on macOS

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note