### PR TITLE
refine reader.go to avoid message blocking

### DIFF
--- a/tidb-binlog/driver/reader/reader.go
+++ b/tidb-binlog/driver/reader/reader.go
@@ -160,6 +160,7 @@ func (r *Reader) run() {
 			partitionConsumer.Close()
 			close(r.msgs)
 			log.Info("reader stop to run")
+			return
 		case kmsg := <-partitionConsumer.Messages():
 			log.Debug("get kafka message", zap.Int64("offset", kmsg.Offset))
 			binlog := new(pb.Binlog)
@@ -184,5 +185,6 @@ func (r *Reader) run() {
 					continue
 			}
 		}
+
 	}
 }

--- a/tidb-binlog/driver/reader/reader.go
+++ b/tidb-binlog/driver/reader/reader.go
@@ -179,10 +179,10 @@ func (r *Reader) run() {
 				Offset: kmsg.Offset,
 			}
 			select {
-				case r.msgs <- msg:
-				case <-r.stop:
-					// In the next iteration, the <-r.stop would match again and prepare to quit
-					continue
+			case r.msgs <- msg:
+			case <-r.stop:
+				// In the next iteration, the <-r.stop would match again and prepare to quit
+				continue
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Refine kafka reader. The current version may block when the consumer thread exits.
Issue link: [TOOL-1402](https://internal.pingcap.net/jira/browse/TOOL-1402)

### What is changed and how it works?
Add one more select to listen signal from both downstream and stop channel.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes
