### PR TITLE
check: support verify grant without password

### DIFF
--- a/pkg/check/privilege.go
+++ b/pkg/check/privilege.go
@@ -113,6 +113,14 @@ func verifyPrivileges(result *Result, grants []string, expectedGrants []string) 
 	// We do not need the password in grant statement, so we can replace it.
 	firstGrant := strings.Replace(grants[0], "IDENTIFIED BY PASSWORD <secret>", "IDENTIFIED BY PASSWORD 'secret'", 1)
 
+	// support parse `IDENTIFIED BY PASSWORD WITH {GRANT OPTION | resource_option} ...`
+	firstGrant = strings.Replace(firstGrant, "IDENTIFIED BY PASSWORD WITH", "IDENTIFIED BY PASSWORD 'secret' WITH", 1)
+
+	// support parse `IDENTIFIED BY PASSWORD`
+	if strings.HasSuffix(firstGrant, "IDENTIFIED BY PASSWORD") {
+		firstGrant = firstGrant + " 'secret'"
+	}
+
 	// get username and hostname
 	node, err := parser.New().ParseOneStmt(firstGrant, "", "")
 	if err != nil {

--- a/pkg/check/privilege_test.go
+++ b/pkg/check/privilege_test.go
@@ -90,7 +90,28 @@ func (t *testCheckSuite) TestVerifyPrivileges(c *tc.C) {
 		},
 		{
 			grants: []string{ // IDENTIFIED BY PASSWORD
+				"GRANT ALL PRIVILEGES ON *.* TO 'user'@'%' IDENTIFIED BY PASSWORD",
+			},
+			dumpState:       StateSuccess,
+			replcationState: StateSuccess,
+		},
+		{
+			grants: []string{ // IDENTIFIED BY PASSWORD
+				"GRANT ALL PRIVILEGES ON *.* TO 'user'@'%' IDENTIFIED BY PASSWORD WITH GRANT OPTION",
+			},
+			dumpState:       StateSuccess,
+			replcationState: StateSuccess,
+		},
+		{
+			grants: []string{ // IDENTIFIED BY PASSWORD
 				"GRANT ALL PRIVILEGES ON *.* TO 'user'@'%' IDENTIFIED BY PASSWORD 'password'",
+			},
+			dumpState:       StateSuccess,
+			replcationState: StateSuccess,
+		},
+		{
+			grants: []string{ // IDENTIFIED BY PASSWORD
+				"GRANT ALL PRIVILEGES ON *.* TO 'user'@'%' IDENTIFIED BY PASSWORD 'password' WITH GRANT OPTION",
 			},
 			dumpState:       StateSuccess,
 			replcationState: StateSuccess,
@@ -98,6 +119,13 @@ func (t *testCheckSuite) TestVerifyPrivileges(c *tc.C) {
 		{
 			grants: []string{ // IDENTIFIED BY PASSWORD with <secret> mark
 				"GRANT ALL PRIVILEGES ON *.* TO 'user'@'%' IDENTIFIED BY PASSWORD <secret>",
+			},
+			dumpState:       StateSuccess,
+			replcationState: StateSuccess,
+		},
+		{
+			grants: []string{ // IDENTIFIED BY PASSWORD with <secret> mark
+				"GRANT ALL PRIVILEGES ON *.* TO 'user'@'%' IDENTIFIED BY PASSWORD <secret> WITH GRANT OPTION",
 			},
 			dumpState:       StateSuccess,
 			replcationState: StateSuccess,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`show grants` from some database (percona or user customed version) may  drop password value

### What is changed and how it works?

add support to the following scenario:

- `GRANT SELECT ON *.* TO 'hello'@'%' IDENTIFIED BY PASSWORD`
- `GRANT SELECT ON *.* TO 'hello'@'%' IDENTIFIED BY PASSWORD WITH GRANT OPTION`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility