### PR TITLE
restore-util: wait for scatter region sequentially 

### DIFF
--- a/pkg/restore-util/client.go
+++ b/pkg/restore-util/client.go
@@ -109,6 +109,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		return nil, err
 	}
 	conn, err := grpc.Dial(store.GetAddress(), grpc.WithInsecure())
+	defer conn.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		}
 	}
 	if newRegion == nil {
-		return nil, errors.New("split region failed")
+		return nil, errors.New("split region failed: new region is nil")
 	}
 	var leader *metapb.Peer
 	// Assume the leaders will be at the same store.

--- a/pkg/restore-util/split.go
+++ b/pkg/restore-util/split.go
@@ -59,12 +59,13 @@ func (rs *RegionSplitter) Split(ctx context.Context, ranges []Range, rewriteRule
 		}
 		var newRegion *RegionInfo
 		newRegion, err = rs.maybeSplitRegion(ctx, rg)
-		if err == nil {
-			if newRegion != nil {
-				scatterRegions = append(scatterRegions, newRegion)
-			}
+		if err != nil {
+			return false
 		}
-		return err == nil
+		if newRegion != nil {
+			scatterRegions = append(scatterRegions, newRegion)
+		}
+		return true
 	})
 	if err != nil {
 		return errors.Trace(err)
@@ -87,7 +88,6 @@ func (rs *RegionSplitter) splitByRewriteRules(ctx context.Context, rules []*impo
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		//fmt.Printf("split done, scatter region: %v\n", newRegion.Region)
 		if newRegion != nil {
 			scatterRegions = append(scatterRegions, newRegion)
 		}

--- a/pkg/restore-util/split.go
+++ b/pkg/restore-util/split.go
@@ -3,7 +3,6 @@ package restore_util
 import (
 	"bytes"
 	"context"
-	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -46,12 +45,11 @@ func NewRegionSplitter(client Client) *RegionSplitter {
 // tableRules includes the prefix of a table, since some ranges may have a prefix with record sequence or index sequence.
 // note: all ranges and rewrite rules must have raw key.
 func (rs *RegionSplitter) Split(ctx context.Context, ranges []Range, rewriteRules *RewriteRules) error {
-	var wg sync.WaitGroup
 	rangeTree, ok := newRangeTreeWithRewrite(ranges, rewriteRules)
 	if !ok {
 		return errors.Errorf("ranges overlapped: %v", ranges)
 	}
-	err := rs.splitByRewriteRules(ctx, &wg, rewriteRules.Data)
+	scatterRegions, err := rs.splitByRewriteRules(ctx, rewriteRules.Data)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -59,30 +57,42 @@ func (rs *RegionSplitter) Split(ctx context.Context, ranges []Range, rewriteRule
 		if rg == nil {
 			return false
 		}
-		err = rs.maybeSplitRegion(ctx, rg, &wg)
+		var newRegion *RegionInfo
+		newRegion, err = rs.maybeSplitRegion(ctx, rg)
+		if err == nil {
+			if newRegion != nil {
+				scatterRegions = append(scatterRegions, newRegion)
+			}
+		}
 		return err == nil
 	})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	// Wait for all regions scatter success
-	wg.Wait()
+	for _, region := range scatterRegions {
+		rs.waitForScatterRegion(ctx, region)
+	}
 	return nil
 }
 
 // Split regions by the rewrite rules, to ensure all keys of one region only have one prefix.
-func (rs *RegionSplitter) splitByRewriteRules(ctx context.Context, wg *sync.WaitGroup, rules []*import_sstpb.RewriteRule) error {
+func (rs *RegionSplitter) splitByRewriteRules(ctx context.Context, rules []*import_sstpb.RewriteRule) ([]*RegionInfo, error) {
+	scatterRegions := make([]*RegionInfo, 0)
 	for _, rule := range rules {
-		err := rs.maybeSplitRegion(ctx, &Range{
+		newRegion, err := rs.maybeSplitRegion(ctx, &Range{
 			StartKey: rule.GetNewKeyPrefix(),
 			EndKey:   rule.GetNewKeyPrefix(),
-		}, wg)
+		})
 		if err != nil {
-			return errors.Trace(err)
+			return nil, errors.Trace(err)
+		}
+		//fmt.Printf("split done, scatter region: %v\n", newRegion.Region)
+		if newRegion != nil {
+			scatterRegions = append(scatterRegions, newRegion)
 		}
 	}
-	return nil
+	return scatterRegions, nil
 }
 
 func newRangeTreeWithRewrite(ranges []Range, rewriteRules *RewriteRules) (*RangeTree, bool) {
@@ -140,37 +150,28 @@ func (rs *RegionSplitter) waitForSplit(ctx context.Context, regionID uint64) err
 	return nil
 }
 
-func (rs *RegionSplitter) tryToScatterRegion(ctx context.Context, wg *sync.WaitGroup, regionInfo *RegionInfo) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		err := rs.client.ScatterRegion(ctx, regionInfo)
+func (rs *RegionSplitter) waitForScatterRegion(ctx context.Context, regionInfo *RegionInfo) {
+	interval := ScatterWaitInterval
+	regionID := regionInfo.Region.GetId()
+	for i := 0; i < ScatterWaitMaxRetryTimes; i++ {
+		ok, err := rs.isScatterRegionFinished(ctx, regionID)
 		if err != nil {
-			log.Warn("scatter region failed", zap.Error(err), zap.Reflect("region", regionInfo.Region))
+			log.Warn("scatter region failed: do not have the region", zap.Reflect("region", regionInfo.Region))
 			return
 		}
-		interval := ScatterWaitInterval
-		regionID := regionInfo.Region.GetId()
-		for i := 0; i < ScatterWaitMaxRetryTimes; i++ {
-			ok, err := rs.hasRegion(ctx, regionID)
-			if err != nil {
-				log.Warn("scatter region failed: do not have the region", zap.Reflect("region", regionInfo.Region))
-				return
+		if ok {
+			break
+		} else {
+			interval = 2 * interval
+			if interval > ScatterMaxWaitInterval {
+				interval = ScatterMaxWaitInterval
 			}
-			if ok {
-				break
-			} else {
-				interval = 2 * interval
-				if interval > ScatterMaxWaitInterval {
-					interval = ScatterMaxWaitInterval
-				}
-				time.Sleep(interval)
-			}
+			time.Sleep(interval)
 		}
-	}()
+	}
 }
 
-func (rs *RegionSplitter) maybeSplitRegion(ctx context.Context, r *Range, wg *sync.WaitGroup) error {
+func (rs *RegionSplitter) maybeSplitRegion(ctx context.Context, r *Range) (*RegionInfo, error) {
 	interval := SplitRetryInterval
 	var err error
 	for i := 0; i < SplitRetryTimes; i++ {
@@ -182,11 +183,11 @@ func (rs *RegionSplitter) maybeSplitRegion(ctx context.Context, r *Range, wg *sy
 		if err == nil {
 			splitKey := r.EndKey
 			if !needSplit(codec.EncodeBytes([]byte{}, splitKey), regionInfo) {
-				return nil
+				return nil, nil
 			}
-			err = rs.splitAndScatterRegion(ctx, regionInfo, splitKey, wg)
+			newRegion, err := rs.splitAndScatterRegion(ctx, regionInfo, splitKey)
 			if err == nil {
-				return nil
+				return newRegion, nil
 			}
 		}
 		interval = 2 * interval
@@ -195,21 +196,20 @@ func (rs *RegionSplitter) maybeSplitRegion(ctx context.Context, r *Range, wg *sy
 		}
 		time.Sleep(interval)
 	}
-	return err
+	return nil, err
 }
 
-func (rs *RegionSplitter) splitAndScatterRegion(ctx context.Context, regionInfo *RegionInfo, key []byte, wg *sync.WaitGroup) error {
+func (rs *RegionSplitter) splitAndScatterRegion(ctx context.Context, regionInfo *RegionInfo, key []byte) (*RegionInfo, error) {
 	newRegion, err := rs.client.SplitRegion(ctx, regionInfo, key)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	// Wait for a while until the region successfully splits.
 	err = rs.waitForSplit(ctx, newRegion.Region.GetId())
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	rs.tryToScatterRegion(ctx, wg, newRegion)
-	return err
+	return newRegion, rs.client.ScatterRegion(ctx, regionInfo)
 }
 
 func needSplit(splitKey []byte, regionInfo *RegionInfo) bool {


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Waiting for scatter region sequentially to avoid to create goroutine by RegionSplitter



### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test