### PR TITLE
restore-util: add on split hook

### DIFF
--- a/pkg/restore-util/split.go
+++ b/pkg/restore-util/split.go
@@ -66,7 +66,9 @@ func (rs *RegionSplitter) Split(
 		if rg == nil {
 			return false
 		}
-		onSplit(rg)
+		if onSplit != nil {
+			onSplit(rg)
+		}
 
 		var newRegion *RegionInfo
 		newRegion, err = rs.maybeSplitRegion(ctx, rg)

--- a/pkg/restore-util/split.go
+++ b/pkg/restore-util/split.go
@@ -40,11 +40,20 @@ func NewRegionSplitter(client Client) *RegionSplitter {
 	}
 }
 
+// OnSplitFunc is called before split a range.
+type OnSplitFunc func(*Range)
+
 // Split executes a region split. It will split regions by the rewrite rules,
 // then it will split regions by the end key of each range.
-// tableRules includes the prefix of a table, since some ranges may have a prefix with record sequence or index sequence.
+// tableRules includes the prefix of a table, since some ranges may have
+// a prefix with record sequence or index sequence.
 // note: all ranges and rewrite rules must have raw key.
-func (rs *RegionSplitter) Split(ctx context.Context, ranges []Range, rewriteRules *RewriteRules) error {
+func (rs *RegionSplitter) Split(
+	ctx context.Context,
+	ranges []Range,
+	rewriteRules *RewriteRules,
+	onSplit OnSplitFunc,
+) error {
 	rangeTree, ok := newRangeTreeWithRewrite(ranges, rewriteRules)
 	if !ok {
 		return errors.Errorf("ranges overlapped: %v", ranges)
@@ -57,6 +66,8 @@ func (rs *RegionSplitter) Split(ctx context.Context, ranges []Range, rewriteRule
 		if rg == nil {
 			return false
 		}
+		onSplit(rg)
+
 		var newRegion *RegionInfo
 		newRegion, err = rs.maybeSplitRegion(ctx, rg)
 		if err != nil {

--- a/pkg/restore-util/split_test.go
+++ b/pkg/restore-util/split_test.go
@@ -121,7 +121,17 @@ func TestSplit(t *testing.T) {
 	regionSplitter := NewRegionSplitter(client)
 
 	ctx := context.Background()
-	err := regionSplitter.Split(ctx, ranges, rewriteRules)
+	length := 0
+	err := regionSplitter.Split(ctx, ranges, rewriteRules,
+		func(rg *Range) {
+			length++
+			if rg == nil {
+				t.Fatal("nil Range")
+			}
+		})
+	if length != 4 {
+		t.Fatal("wrong length", length)
+	}
 	if err != nil {
 		t.Fatalf("split regions failed: %v", err)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Add a hook that will be called before splitting a range.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
