### PR TITLE
restore-util: call onSplit on splitByRewriteRules

### DIFF
--- a/pkg/restore-util/split_test.go
+++ b/pkg/restore-util/split_test.go
@@ -129,7 +129,7 @@ func TestSplit(t *testing.T) {
 				t.Fatal("nil Range")
 			}
 		})
-	if length != 4 {
+	if length != 4+2 { // Ranges + Rules
 		t.Fatal("wrong length", length)
 	}
 	if err != nil {


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Call onSplit on splitByRewriteRules.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
