### PR TITLE
pkg/etcd: return revision when create key

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -90,7 +90,7 @@ func (e *Client) Create(ctx context.Context, key string, val string, opts []clie
 	}
 
 	// impossible to happen
-	return -1, nil
+	return 0, errors.New("revision is unknown")
 }
 
 // Get returns a key/value matchs the given key

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -70,7 +70,7 @@ func (e *Client) Close() error {
 }
 
 // Create guarantees to set a key = value with some options(like ttl)
-func (e *Client) Create(ctx context.Context, key string, val string, opts []clientv3.OpOption) error {
+func (e *Client) Create(ctx context.Context, key string, val string, opts []clientv3.OpOption) (int64, error) {
 	key = keyWithPrefix(e.rootPath, key)
 	txnResp, err := e.client.KV.Txn(ctx).If(
 		clientv3.Compare(clientv3.ModRevision(key), "=", 0),
@@ -78,14 +78,19 @@ func (e *Client) Create(ctx context.Context, key string, val string, opts []clie
 		clientv3.OpPut(key, val, opts...),
 	).Commit()
 	if err != nil {
-		return errors.Trace(err)
+		return 0, errors.Trace(err)
 	}
 
 	if !txnResp.Succeeded {
-		return errors.AlreadyExistsf("key %s in etcd", key)
+		return 0, errors.AlreadyExistsf("key %s in etcd", key)
 	}
 
-	return nil
+	if txnResp.Header != nil {
+		return txnResp.Header.Revision, nil
+	}
+
+	// impossible to happen
+	return -1, nil
 }
 
 // Get returns a key/value matchs the given key

--- a/tidb-binlog/node/registry.go
+++ b/tidb-binlog/node/registry.go
@@ -129,7 +129,7 @@ func (r *EtcdRegistry) createNode(ctx context.Context, prefix string, status *St
 		return errors.Annotatef(err, "error marshal NodeStatus(%v)", status)
 	}
 	key := r.prefixed(prefix, status.NodeID)
-	err = r.client.Create(ctx, key, string(objstr), nil)
+	_, err = r.client.Create(ctx, key, string(objstr), nil)
 	return errors.Trace(err)
 }
 


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
return revision when creating a key. used for dm


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test