### PR TITLE
restore-util: fix overlapped error message

### DIFF
--- a/pkg/restore-util/client.go
+++ b/pkg/restore-util/client.go
@@ -3,7 +3,6 @@ package restore_util
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/pingcap/errors"
@@ -100,7 +99,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		peer = regionInfo.Leader
 	} else {
 		if len(regionInfo.Region.Peers) == 0 {
-			return nil, errors.NewNoStackError("region does not have peer")
+			return nil, errors.New("region does not have peer")
 		}
 		peer = regionInfo.Region.Peers[0]
 	}
@@ -127,7 +126,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		return nil, err
 	}
 	if resp.RegionError != nil {
-		return nil, fmt.Errorf("split region failed: region=%v, key=%x, err=%v", regionInfo.Region, key, resp.RegionError)
+		return nil, errors.Errorf("split region failed: region=%v, key=%x, err=%v", regionInfo.Region, key, resp.RegionError)
 	}
 
 	// Assume the new region is the left one.
@@ -142,7 +141,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		}
 	}
 	if newRegion == nil {
-		return nil, errors.NewNoStackError("split region failed: new region is nil")
+		return nil, errors.New("split region failed: new region is nil")
 	}
 	var leader *metapb.Peer
 	// Assume the leaders will be at the same store.

--- a/pkg/restore-util/client.go
+++ b/pkg/restore-util/client.go
@@ -3,6 +3,7 @@ package restore_util
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/pingcap/errors"
@@ -99,7 +100,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		peer = regionInfo.Leader
 	} else {
 		if len(regionInfo.Region.Peers) == 0 {
-			return nil, errors.New("region does not have peer")
+			return nil, fmt.Errorf("region does not have peer")
 		}
 		peer = regionInfo.Region.Peers[0]
 	}
@@ -126,7 +127,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		return nil, err
 	}
 	if resp.RegionError != nil {
-		return nil, errors.Errorf("split region failed: region=%v, key=%x, err=%v", regionInfo.Region, key, resp.RegionError)
+		return nil, fmt.Errorf("split region failed: region=%v, key=%x, err=%v", regionInfo.Region, key, resp.RegionError)
 	}
 
 	// Assume the new region is the left one.
@@ -141,7 +142,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		}
 	}
 	if newRegion == nil {
-		return nil, errors.New("split region failed: new region is nil")
+		return nil, fmt.Errorf("split region failed: new region is nil")
 	}
 	var leader *metapb.Peer
 	// Assume the leaders will be at the same store.

--- a/pkg/restore-util/client.go
+++ b/pkg/restore-util/client.go
@@ -100,7 +100,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		peer = regionInfo.Leader
 	} else {
 		if len(regionInfo.Region.Peers) == 0 {
-			return nil, fmt.Errorf("region does not have peer")
+			return nil, errors.NewNoStackError("region does not have peer")
 		}
 		peer = regionInfo.Region.Peers[0]
 	}
@@ -142,7 +142,7 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 		}
 	}
 	if newRegion == nil {
-		return nil, fmt.Errorf("split region failed: new region is nil")
+		return nil, errors.NewNoStackError("split region failed: new region is nil")
 	}
 	var leader *metapb.Peer
 	// Assume the leaders will be at the same store.

--- a/pkg/restore-util/range.go
+++ b/pkg/restore-util/range.go
@@ -63,8 +63,8 @@ func (rt *RangeTree) Find(key []byte) *Range {
 // InsertRanges inserts ranges into the range tree.
 // it returns true if all ranges inserted successfully.
 // it returns false if there are some overlapped ranges.
-func (rt *RangeTree) InsertRange(rg Range) bool {
-	return rt.tree.ReplaceOrInsert(&rg) == nil
+func (rt *RangeTree) InsertRange(rg Range) btree.Item {
+	return rt.tree.ReplaceOrInsert(&rg)
 }
 
 // RangeIterator allows callers of Ascend to iterate in-order over portions of

--- a/pkg/restore-util/range_test.go
+++ b/pkg/restore-util/range_test.go
@@ -9,8 +9,8 @@ func TestRangeTreeNormal(t *testing.T) {
 	ranges := initRanges()
 	rangeTree := NewRangeTree()
 	for _, rg := range ranges {
-		if !rangeTree.InsertRange(rg) {
-			t.Fatalf("insert range failed")
+		if out := rangeTree.InsertRange(rg); out != nil {
+			t.Fatalf("insert range failed: %s %s", out.(*Range).String(), rg.String())
 		}
 	}
 	resRanges := make([]Range, 0)
@@ -45,10 +45,10 @@ func TestRangeOverlapped(t *testing.T) {
 		EndKey:   []byte("aag"),
 	}
 	rangeTree := NewRangeTree()
-	if !rangeTree.InsertRange(rg1) {
-		t.Fatalf("insert range failed")
+	if out := rangeTree.InsertRange(rg1); out != nil {
+		t.Fatalf("insert range failed: %s %s", out.(*Range).String(), rg1.String())
 	}
-	if rangeTree.InsertRange(rg2) {
-		t.Fatalf("overlapping not detected")
+	if out := rangeTree.InsertRange(rg2); out == nil {
+		t.Fatalf("overlapping not detected: %s %s", rg1.String(), rg2.String())
 	}
 }

--- a/pkg/restore-util/split.go
+++ b/pkg/restore-util/split.go
@@ -86,13 +86,13 @@ func (rs *RegionSplitter) Split(
 		return errors.Trace(err)
 	}
 	log.Info("splitting regions done, wait for scattering regions",
-		zap.Int("regions", len(scatterRegions)), zap.Duration("cost", time.Since(startTime)))
+		zap.Int("regions", len(scatterRegions)), zap.Duration("take", time.Since(startTime)))
 	startTime = time.Now()
 	for _, region := range scatterRegions {
 		rs.waitForScatterRegion(ctx, region)
 	}
 	log.Info("waiting for scattering regions done",
-		zap.Int("regions", len(scatterRegions)), zap.Duration("cost", time.Since(startTime)))
+		zap.Int("regions", len(scatterRegions)), zap.Duration("take", time.Since(startTime)))
 	return nil
 }
 
@@ -129,7 +129,7 @@ func newRangeTreeWithRewrite(ranges []Range, rewriteRules *RewriteRules) (*Range
 		rg.StartKey = replacePrefix(rg.StartKey, rewriteRules)
 		rg.EndKey = replacePrefix(rg.EndKey, rewriteRules)
 		if out := rangeTree.InsertRange(rg); out != nil {
-			return nil, errors.Errorf("ranges overlapped: %v, %v", out.(*Range), rg)
+			return nil, errors.Errorf("ranges overlapped: %v, %v", out.(*Range).String(), rg.String())
 		}
 	}
 	return rangeTree, nil

--- a/pkg/restore-util/split.go
+++ b/pkg/restore-util/split.go
@@ -55,9 +55,9 @@ func (rs *RegionSplitter) Split(
 	onSplit OnSplitFunc,
 ) error {
 	startTime := time.Now()
-	rangeTree, ok := newRangeTreeWithRewrite(ranges, rewriteRules)
-	if !ok {
-		return errors.Errorf("ranges overlapped: %v", ranges)
+	rangeTree, err := newRangeTreeWithRewrite(ranges, rewriteRules)
+	if err != nil {
+		return errors.Trace(err)
 	}
 	scatterRegions, err := rs.splitByRewriteRules(
 		ctx, rewriteRules.Data, onSplit)
@@ -123,16 +123,16 @@ func (rs *RegionSplitter) splitByRewriteRules(
 	return scatterRegions, nil
 }
 
-func newRangeTreeWithRewrite(ranges []Range, rewriteRules *RewriteRules) (*RangeTree, bool) {
+func newRangeTreeWithRewrite(ranges []Range, rewriteRules *RewriteRules) (*RangeTree, error) {
 	rangeTree := NewRangeTree()
 	for _, rg := range ranges {
 		rg.StartKey = replacePrefix(rg.StartKey, rewriteRules)
 		rg.EndKey = replacePrefix(rg.EndKey, rewriteRules)
-		if !rangeTree.InsertRange(rg) {
-			return nil, false
+		if out := rangeTree.InsertRange(rg); out != nil {
+			return nil, errors.Errorf("ranges overlapped: %v, %v", out.(*Range), rg)
 		}
 	}
-	return rangeTree, true
+	return rangeTree, nil
 }
 
 func (rs *RegionSplitter) hasRegion(ctx context.Context, regionID uint64) (bool, error) {
@@ -261,13 +261,14 @@ func replacePrefix(s []byte, rewriteRules *RewriteRules) []byte {
 	// We should search the dataRules firstly.
 	for _, rule := range rewriteRules.Data {
 		if bytes.HasPrefix(s, rule.GetOldKeyPrefix()) {
-			return append(rule.GetNewKeyPrefix(), s[len(rule.GetOldKeyPrefix()):]...)
+			return append(append([]byte{}, rule.GetNewKeyPrefix()...), s[len(rule.GetOldKeyPrefix()):]...)
 		}
 	}
 	for _, rule := range rewriteRules.Table {
 		if bytes.HasPrefix(s, rule.GetOldKeyPrefix()) {
-			return append(rule.GetNewKeyPrefix(), s[len(rule.GetOldKeyPrefix()):]...)
+			return append(append([]byte{}, rule.GetNewKeyPrefix()...), s[len(rule.GetOldKeyPrefix()):]...)
 		}
 	}
+
 	return s
 }

--- a/pkg/restore-util/split.go
+++ b/pkg/restore-util/split.go
@@ -3,7 +3,6 @@ package restore_util
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -130,7 +129,7 @@ func newRangeTreeWithRewrite(ranges []Range, rewriteRules *RewriteRules) (*Range
 		rg.StartKey = replacePrefix(rg.StartKey, rewriteRules)
 		rg.EndKey = replacePrefix(rg.EndKey, rewriteRules)
 		if out := rangeTree.InsertRange(rg); out != nil {
-			return nil, fmt.Errorf("ranges overlapped: %v, %v", out.(*Range).String(), rg.String())
+			return nil, errors.Errorf("ranges overlapped: %v, %v", out.(*Range).String(), rg.String())
 		}
 	}
 	return rangeTree, nil
@@ -204,7 +203,7 @@ func (rs *RegionSplitter) maybeSplitRegion(ctx context.Context, r *Range) (*Regi
 	interval := SplitRetryInterval
 	var err error
 	for i := 0; i < SplitRetryTimes; i++ {
-		if i > 0 {
+		if i > SplitRetryTimes/2 {
 			log.Warn("split region failed, retry it", zap.Error(err), zap.Reflect("key", r.StartKey))
 		}
 		var regionInfo *RegionInfo


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The error message is always too long.

### What is changed and how it works?

Make the error message more friendly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - Breaking backward compatibility

Related changes

N/A