### PR TITLE
pkg/etcd: support do some operations in one transaction

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -258,6 +258,10 @@ func (e *Client) DoTxn(ctx context.Context, operations []*Operation) (int64, err
 		operation.Key = keyWithPrefix(e.rootPath, operation.Key)
 
 		if operation.TTL > 0 {
+			if operation.Tp == DeleteOp {
+				return 0, errors.Errorf("unexpected TTL in delete operation")
+			}
+
 			lcr, err := e.client.Lease.Grant(ctx, operation.TTL)
 			if err != nil {
 				return 0, errors.Trace(err)

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -69,6 +69,11 @@ func (e *Client) Close() error {
 	return nil
 }
 
+// GetClient returns client
+func (e *Client) GetClient() *clientv3.Client {
+	return e.client
+}
+
 // Create guarantees to set a key = value with some options(like ttl)
 func (e *Client) Create(ctx context.Context, key string, val string, opts []clientv3.OpOption) (int64, error) {
 	key = keyWithPrefix(e.rootPath, key)

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -305,17 +305,20 @@ func (t *testEtcdSuite) TestDoTxn(c *C) {
 	ops = []*Operation{
 		{
 			Tp:    CreateOp,
-			Key:   "test5",
-			Value: "5",
+			Key:   "test6",
+			Value: "6",
 		}, {
 			Tp:    UpdateOp,
-			Key:   "test5",
-			Value: "55",
+			Key:   "test6",
+			Value: "66",
 		},
 	}
 
 	_, err = etcdCli.DoTxn(context.Background(), ops)
 	c.Assert(err, ErrorMatches, "etcdserver: duplicate key given in txn request")
+
+	_, _, err = etcdCli.Get(context.Background(), "test6")
+	c.Assert(err, ErrorMatches, ".* not found")
 }
 
 func testSetup(t *testing.T) (context.Context, *Client, *integration.ClusterV3) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

dm-master embed etcd, and need to do some operations in one transaction.

support do some etcd operations in one transaction


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change
