### PR TITLE
dbutil: mark `ErrInfoSchemaChanged` as un-retryable

### DIFF
--- a/pkg/dbutil/retry.go
+++ b/pkg/dbutil/retry.go
@@ -25,7 +25,6 @@ var (
 	// Retryable1105Msgs list the error messages of some retryable error with `1105` code (`ErrUnknown`).
 	Retryable1105Msgs = []string{
 		"Information schema is out of date",
-		"Information schema is changed",
 	}
 )
 
@@ -36,6 +35,7 @@ var (
 // - tmysql.ErrWriteConflictInTiDB
 // - tmysql.ErrTableLocked
 // - tmysql.ErrWriteConflict
+// - tmysql.ErrInfoSchemaChanged
 //
 // some errors are un-retryable:
 // - tmysql.ErrQueryInterrupted
@@ -55,8 +55,7 @@ func IsRetryableError(err error) bool {
 	case tmysql.ErrPDServerTimeout,
 		tmysql.ErrTiKVServerBusy,
 		tmysql.ErrResolveLockTimeout,
-		tmysql.ErrInfoSchemaExpired,
-		tmysql.ErrInfoSchemaChanged:
+		tmysql.ErrInfoSchemaExpired:
 		return true // retryable error in TiDB
 	case tmysql.ErrUnknown: // the old version of TiDB uses `1105` frequently, this should be compatible.
 		for _, msg := range Retryable1105Msgs {

--- a/pkg/dbutil/retry_test.go
+++ b/pkg/dbutil/retry_test.go
@@ -85,6 +85,10 @@ func (t *testRetrySuite) TestIsRetryableError(c *C) {
 			err:       newMysqlErr(tmysql.ErrWriteConflict, "Write conflict, txnStartTS=412719757964869700, conflictStartTS=412719757964869700, conflictCommitTS=412719757964869950, key=488636541"),
 			retryable: false,
 		},
+		{
+			err:       newMysqlErr(tmysql.ErrInfoSchemaChanged, "Information schema is changed"),
+			retryable: false,
+		},
 		// un-retryable
 		{
 			err:       newMysqlErr(tmysql.ErrQueryInterrupted, "Query execution was interrupted"),
@@ -100,22 +104,18 @@ func (t *testRetrySuite) TestIsRetryableError(c *C) {
 			err:       newMysqlErr(tmysql.ErrUnknown, "i/o timeout"),
 			retryable: false,
 		},
+		{
+			err:       newMysqlErr(tmysql.ErrUnknown, "Information schema is changed"),
+			retryable: false,
+		},
 		// 1105, retryable
 		{
 			err:       newMysqlErr(tmysql.ErrUnknown, "Information schema is out of date"),
 			retryable: true,
 		},
-		{
-			err:       newMysqlErr(tmysql.ErrUnknown, "Information schema is changed"),
-			retryable: true,
-		},
 		// 1105 --> unique error code
 		{
 			err:       newMysqlErr(tmysql.ErrInfoSchemaExpired, "Information schema is out of date"),
-			retryable: true,
-		},
-		{
-			err:       newMysqlErr(tmysql.ErrInfoSchemaChanged, "Information schema is changed"),
 			retryable: true,
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

retry on `ErrInfoSchemaChanged` may fail, like `ADD COLUMN` happened.

### What is changed and how it works?

mark `ErrInfoSchemaChanged` as un-retryable

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change