### PR TITLE
restore-util: add upper bound time for waiting for scatter

### DIFF
--- a/pkg/restore-util/client.go
+++ b/pkg/restore-util/client.go
@@ -217,16 +217,16 @@ func (c *pdClient) BatchSplitRegions(ctx context.Context, regionInfo *RegionInfo
 	}
 
 	regions := resp.GetRegions()
-	newRegionInfos := make([]*RegionInfo, 0)
-	for i := range regions {
+	newRegionInfos := make([]*RegionInfo, 0, len(regions))
+	for _, region := range regions {
 		// Skip the original region
-		if regions[i].GetId() == regionInfo.Region.GetId() {
+		if region.GetId() == regionInfo.Region.GetId() {
 			continue
 		}
 		var leader *metapb.Peer
 		// Assume the leaders will be at the same store.
 		if regionInfo.Leader != nil {
-			for _, p := range regions[i].GetPeers() {
+			for _, p := range region.GetPeers() {
 				if p.GetStoreId() == regionInfo.Leader.GetStoreId() {
 					leader = p
 					break
@@ -234,7 +234,7 @@ func (c *pdClient) BatchSplitRegions(ctx context.Context, regionInfo *RegionInfo
 			}
 		}
 		newRegionInfos = append(newRegionInfos, &RegionInfo{
-			Region: regions[i],
+			Region: region,
 			Leader: leader,
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some scatter operators always run to timeout in PD. 

### What is changed and how it works?
Add upper bound time for waiting for scatter

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Side effects

 - Possible performance regression