### PR TITLE
pkg/filter: Add a Match method for checking if a table should be kept

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -198,19 +198,23 @@ func (f *Filter) ApplyOn(stbs []*Table) []*Table {
 
 	var tbs []*Table
 	for _, tb := range stbs {
-		name := tb.String()
-		do, exist := f.c.query(name)
-		if !exist {
-			do = ActionType(f.filterOnSchemas(tb) && f.filterOnTables(tb))
-			f.c.set(tb.String(), do)
-		}
-
-		if do {
+		if f.Match(tb) {
 			tbs = append(tbs, tb)
 		}
 	}
 
 	return tbs
+}
+
+// Match returns true if the specified table should not be removed.
+func (f *Filter) Match(tb *Table) bool {
+	name := tb.String()
+	do, exist := f.c.query(name)
+	if !exist {
+		do = ActionType(f.filterOnSchemas(tb) && f.filterOnTables(tb))
+		f.c.set(tb.String(), do)
+	}
+	return do == Do
 }
 
 func (f *Filter) filterOnSchemas(tb *Table) bool {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -173,3 +173,13 @@ func (s *testFilterSuite) TestInvalidRegex(c *C) {
 		c.Assert(err, NotNil)
 	}
 }
+
+func (s *testFilterSuite) TestMatchReturnsBool(c *C) {
+	rules := &Rules{
+		DoDBs: []string{"sns"},
+	}
+	f, err := New(true, rules)
+	c.Assert(err, IsNil)
+	c.Assert(f.Match(&Table{Schema: "sns"}), IsTrue)
+	c.Assert(f.Match(&Table{Schema: "other"}), IsFalse)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In many use cases of `pkg/filter`, we don't really want the `ApplyOn` method.
Instead, we often need to check tables or schemas one by one and see whether they should be kept or removed.

### What is changed and how it works?

Add a `Match` method.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test