### PR TITLE
filter: use TiDB's IsMemOrSysDB() method in IsSystemSchema()

### DIFF
--- a/pkg/filter/schema.go
+++ b/pkg/filter/schema.go
@@ -13,7 +13,11 @@
 
 package filter
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/pingcap/tidb/util"
+)
 
 // DM heartbeat schema / table name
 var (
@@ -21,19 +25,15 @@ var (
 	DMHeartbeatTable  = "heartbeat"
 )
 
-// mysql system schema
-var systemSchemas = map[string]struct{}{
-	"information_schema": {},
-	"mysql":              {},
-	"performance_schema": {},
-	"sys":                {},
-	DMHeartbeatSchema:    {}, // do not create table in it manually
-}
-
-// IsSystemSchema judge schema is system shema or not
+// IsSystemSchema checks whether schema is system schema or not.
 // case insensitive
 func IsSystemSchema(schema string) bool {
 	schema = strings.ToLower(schema)
-	_, ok := systemSchemas[schema]
-	return ok
+	switch schema {
+	case DMHeartbeatSchema, // do not create table in it manually
+		"sys": // https://dev.mysql.com/doc/refman/8.0/en/sys-schema.html
+		return true
+	default:
+		return util.IsMemOrSysDB(schema)
+	}
 }

--- a/pkg/filter/schema_test.go
+++ b/pkg/filter/schema_test.go
@@ -41,10 +41,12 @@ func (s *testFilterSuite) TestIsSystemSchema(c *C) {
 		{"MYSQL", true},
 		{"SYS", true},
 		{"not_system_schema", false},
+		{"METRIC_SCHEMA", true},
+		{"INSPECTION_SCHEMA", true},
 	}
 
 	for _, t := range cases {
-		c.Assert(IsSystemSchema(t.name), Equals, t.expected)
+		c.Assert(IsSystemSchema(t.name), Equals, t.expected, Commentf("schema name = %s", t.name))
 	}
 
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiDB introduced two additional system schemas in pingcap/tidb#13757 (`metrics_schema`) and pingcap/tidb#14147 (`inspection_schema`), which `filter.IsSystemSchema()` currently cannot recognize.

### What is changed and how it works?

To avoid playing catch up with TiDB in the future, we changed the implementation of `filter.IsSystemSchema()` to forward to the standard `"github.com/pingcap/tidb/util".IsMemOrSysDB()`. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

Related changes
