### PR TITLE
diff: increase the default timeout for db operate

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -41,7 +41,7 @@ const (
 	DefaultRetryTime = 10
 
 	// DefaultTimeout is the default timeout for execute sql
-	DefaultTimeout time.Duration = 5 * time.Second
+	DefaultTimeout time.Duration = 10 * time.Second
 
 	// SlowWarnLog defines the duration to log warn log of sql when exec time greater than
 	SlowWarnLog = 100 * time.Millisecond


### PR DESCRIPTION


### What problem does this PR solve? <!--add issue link with summary if exists-->

users feedback that the 5 second is not enough for database operate some times.

### What is changed and how it works?

increase to 10 second

