### PR TITLE
filter: added options to disable regex and/or wildcard

### DIFF
--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -143,6 +143,40 @@ func (s *testFilterSuite) TestFilterOnSchema(c *C) {
 			Input:  []*Table{{"aB", "Ab"}, {"AaB", "aab"}, {"acB", "Afb"}},
 			Output: []*Table(nil),
 		},
+		// test disable regexp & wildcard
+		{
+			rules: &Rules{
+				DoDBs:   []string{"~foo?"},
+				NoRegex: true,
+			},
+			Input:  []*Table{{"~foo?", "a"}, {"~foo", "b"}, {"~fo", "c"}, {"~food", "d"}, {"foo", "e"}, {"fo", "f"}},
+			Output: []*Table{{"~foo?", "a"}, {"~food", "d"}},
+		},
+		{
+			rules: &Rules{
+				DoTables: []*Table{{"~foo", "~bar"}},
+				NoRegex:  true,
+			},
+			Input:  []*Table{{"~foo", "~bar"}, {"foo", "bar"}},
+			Output: []*Table{{"~foo", "~bar"}},
+		},
+		{
+			rules: &Rules{
+				DoDBs:      []string{"~^bar", "fo[o]"},
+				NoWildcard: true,
+			},
+			Input:  []*Table{{"bar", "a"}, {"~^bar", "b"}, {"foo", "c"}, {"fo[o]", "d"}, {"~^bark", "e"}},
+			Output: []*Table{{"bar", "a"}, {"fo[o]", "d"}},
+		},
+		{
+			rules: &Rules{
+				DoDBs:      []string{"~^bar", "fo[o]"},
+				NoRegex:    true,
+				NoWildcard: true,
+			},
+			Input:  []*Table{{"bar", "a"}, {"~^bar", "b"}, {"foo", "c"}, {"fo[o]", "d"}, {"~^bark", "e"}},
+			Output: []*Table{{"~^bar", "b"}, {"fo[o]", "d"}},
+		},
 	}
 
 	for _, t := range cases {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When the table name to match necessarily contains regex or wildcard characters (`~`, `*`, `?`, `[`), we need to escape the table name. This is quite inelegant.

### What is changed and how it works?

Add a feature to `filter` to disable regex and/or wildcard support from config, so we don't need to manually escape the input.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
 - Need to be included in the release note
    * All components relying on this component for black-white-list have two extra fields in the config.