### PR TITLE
diff: support auto_random in TiDB

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb-tools/pkg/dbutil"
 	"github.com/pingcap/tidb-tools/pkg/utils"
+	tidbconfig "github.com/pingcap/tidb/config"
 	"go.uber.org/zap"
 )
 
@@ -187,6 +188,11 @@ func (t *TableDiff) adjustConfig() {
 	if t.CheckThreadCount <= 0 {
 		t.CheckThreadCount = 4
 	}
+
+	// to support table with auto_random in TiDB
+	tidbCfg := tidbconfig.GetGlobalConfig()
+	tidbCfg.Experimental.AllowAutoRandom = true
+	tidbconfig.StoreGlobalConfig(tidbCfg)
 }
 
 func (t *TableDiff) getTableInfo(ctx context.Context) error {


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

diff will get `Invalid auto_random` error when getting table's schema with auto_random

### What is changed and how it works?

set `AllowAutoRandom = true` for tidb

