### PR TITLE
schemacmp: properly support PKIsHandle columns

### DIFF
--- a/pkg/schemacmp/table_test.go
+++ b/pkg/schemacmp/table_test.go
@@ -354,6 +354,34 @@ func (s *tableSchema) TestJoinSchemas(c *C) {
 				e2 SET('abc', 'def') NOT NULL DEFAULT ''
 			)`,
 		},
+		{
+			name: "test case 2020-03-17",
+			a:    `CREATE TABLE bar (id INT PRIMARY KEY)`,
+			b:    `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT)`,
+			cmp:  -1,
+			join: `CREATE TABLE bar (id INT PRIMARY KEY, c1 INT)`,
+		},
+		{
+			name: "test case 2020-03-17-alt",
+			a:    `CREATE TABLE bar (id VARCHAR(10) PRIMARY KEY)`,
+			b:    `CREATE TABLE bar (id VARCHAR(10) PRIMARY KEY, c1 INT)`,
+			cmp:  -1,
+			join: `CREATE TABLE bar (id VARCHAR(10) PRIMARY KEY, c1 INT)`,
+		},
+		{
+			name: "test case 2020-03-17-alt-2",
+			a:    `CREATE TABLE bar (id INT PRIMARY KEY)`,
+			b:    `CREATE TABLE bar (id INT, c1 INT)`,
+			cmp:  -1,
+			join: `CREATE TABLE bar (id INT, c1 INT)`,
+		},
+		{
+			name:   "test case 2020-03-17-alt-3",
+			a:      `CREATE TABLE bar (id1 INT PRIMARY KEY, id2 INT)`,
+			b:      `CREATE TABLE bar (id1 INT, id2 INT PRIMARY KEY)`,
+			cmpErr: `.*combining contradicting orders.*`,
+			join:   `CREATE TABLE bar (id1 INT, id2 INT)`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Previously, an `INT PRIMARY KEY` column was not counted as index, causing the join to lose its "Primary key" flag, and making it not the tightest bound.

### What is changed and how it works?

These PKIsHandle columns are now included into the index map in the encoded representation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

