### PR TITLE
pkg: move tidb error code from the parser/mysql to tidb/errno

### DIFF
--- a/go.mod1
+++ b/go.mod1
@@ -21,9 +21,9 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
 	github.com/pingcap/kvproto v0.0.0-20200228095611-2cf9a243b8d5
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
-	github.com/pingcap/parser v0.0.0-20200305120128-bde9faa0df84
+	github.com/pingcap/parser v0.0.0-20200317021010-cd90cc2a7d87
 	github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3
-	github.com/pingcap/tidb v1.1.0-beta.0.20200311125547-6c67561ee0df
+	github.com/pingcap/tidb v1.1.0-beta.0.20200318081823-de474b42bcae
 	github.com/pingcap/tipb v0.0.0-20200212061130-c4d518eb1d60
 	github.com/prometheus/client_golang v1.2.1 // indirect
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect

--- a/go.sum1
+++ b/go.sum1
@@ -329,8 +329,8 @@ github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20200305120128-bde9faa0df84 h1:u5FOwUw9muF8mBTZVV1dQhoAKiEo2Ci54CxN9XchEEY=
-github.com/pingcap/parser v0.0.0-20200305120128-bde9faa0df84/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
+github.com/pingcap/parser v0.0.0-20200317021010-cd90cc2a7d87 h1:533jEUp3mtfWjk0el+awLbyGVxiHcUIGWcR1Y7gB+fg=
+github.com/pingcap/parser v0.0.0-20200317021010-cd90cc2a7d87/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3 h1:Yrp99FnjHAEuDrSBql2l0IqCtJX7KwJbTsD5hIArkvk=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3/go.mod h1:25GfNw6+Jcr9kca5rtmTb4gKCJ4jOpow2zV2S9Dgafs=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd h1:k7CIHMFVKjHsda3PKkiN4zv++NEnexlUwiJEhryWpG0=
@@ -338,8 +338,8 @@ github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NM
 github.com/pingcap/sysutil v0.0.0-20200302022240-21c8c70d0ab1/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200309085538-962fd285f3bb h1:bDbgLaNTRNK6Qw7KjvEqqfCQstY8WMEcXyXTU7yzYKg=
 github.com/pingcap/sysutil v0.0.0-20200309085538-962fd285f3bb/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
-github.com/pingcap/tidb v1.1.0-beta.0.20200311125547-6c67561ee0df h1:PADbR890puZ+cm8HevzPqbowbhLCyCY+tWVYiCg2XmY=
-github.com/pingcap/tidb v1.1.0-beta.0.20200311125547-6c67561ee0df/go.mod h1:WTmfs5zrUGMPw3Enn5FI3buzkU8BDuJ6BhsO/JC239U=
+github.com/pingcap/tidb v1.1.0-beta.0.20200318081823-de474b42bcae h1:80gsdfO52wrhgYYp2edXKU6FDSfSYdf7NoVP2wenCGU=
+github.com/pingcap/tidb v1.1.0-beta.0.20200318081823-de474b42bcae/go.mod h1:4CGOiKZSaOU/Da3QYMtp0c3uBE2SxpcLOpESXmeQhcs=
 github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200212061130-c4d518eb1d60 h1:aJPXrT1u4VfUSGFA2oQVwl4pOXzqe+YI6wed01cjDH4=
@@ -456,6 +456,7 @@ github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
+github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -584,8 +585,8 @@ golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200301222351-066e0c02454c h1:FD7jysxM+EJqg5UYYy3XYDsAiUickFsn4UiaanJkf8c=
 golang.org/x/tools v0.0.0-20200301222351-066e0c02454c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb h1:iKlO7ROJc6SttHKlxzwGytRtBUqX4VARrNTgP2YLX5M=
-golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200313205530-4303120df7d8 h1:gkI/wGGwpcG5W4hLCzZNGxA4wzWBGGDStRI1MrjDl2Q=
+golang.org/x/tools v0.0.0-20200313205530-4303120df7d8/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/dbutil/retry.go
+++ b/pkg/dbutil/retry.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
-	tmysql "github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/errno"
 )
 
 var (
@@ -32,16 +32,16 @@ var (
 // IsRetryableError checks whether the SQL statement can be retry directly when encountering this error.
 // NOTE: this should be compatible with different TiDB versions.
 // some errors are only retryable in some special cases, then we mark it as un-retryable:
-// - tmysql.ErrTiKVServerTimeout
-// - tmysql.ErrWriteConflictInTiDB
-// - tmysql.ErrTableLocked
-// - tmysql.ErrWriteConflict
+// - errno.ErrTiKVServerTimeout
+// - errno.ErrWriteConflictInTiDB
+// - errno.ErrTableLocked
+// - errno.ErrWriteConflict
 //
 // some errors are un-retryable:
-// - tmysql.ErrQueryInterrupted
+// - errno.ErrQueryInterrupted
 //
 // some errors are unknown:
-// - tmysql.ErrRegionUnavailable
+// - errno.ErrRegionUnavailable
 func IsRetryableError(err error) bool {
 	err = errors.Cause(err) // check the original error
 	mysqlErr, ok := err.(*mysql.MySQLError)
@@ -50,15 +50,15 @@ func IsRetryableError(err error) bool {
 	}
 
 	switch mysqlErr.Number {
-	case tmysql.ErrLockDeadlock: // https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks.html
+	case errno.ErrLockDeadlock: // https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks.html
 		return true // retryable error in MySQL
-	case tmysql.ErrPDServerTimeout,
-		tmysql.ErrTiKVServerBusy,
-		tmysql.ErrResolveLockTimeout,
-		tmysql.ErrInfoSchemaExpired,
-		tmysql.ErrInfoSchemaChanged:
+	case errno.ErrPDServerTimeout,
+		errno.ErrTiKVServerBusy,
+		errno.ErrResolveLockTimeout,
+		errno.ErrInfoSchemaExpired,
+		errno.ErrInfoSchemaChanged:
 		return true // retryable error in TiDB
-	case tmysql.ErrUnknown: // the old version of TiDB uses `1105` frequently, this should be compatible.
+	case errno.ErrUnknown: // the old version of TiDB uses `1105` frequently, this should be compatible.
 		for _, msg := range Retryable1105Msgs {
 			if strings.Contains(mysqlErr.Message, msg) {
 				return true

--- a/pkg/dbutil/retry_test.go
+++ b/pkg/dbutil/retry_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	. "github.com/pingcap/check"
-	tmysql "github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/errno"
 )
 
 var _ = Suite(&testRetrySuite{})
@@ -40,7 +40,7 @@ func (t *testRetrySuite) TestIsRetryableError(c *C) {
 			retryable: false,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrNoDB, "No database selected"),
+			err:       newMysqlErr(errno.ErrNoDB, "No database selected"),
 			retryable: false,
 		},
 		{
@@ -53,69 +53,69 @@ func (t *testRetrySuite) TestIsRetryableError(c *C) {
 		},
 		// retryable
 		{
-			err:       newMysqlErr(tmysql.ErrLockDeadlock, "Deadlock found when trying to get lock; try restarting transaction"),
+			err:       newMysqlErr(errno.ErrLockDeadlock, "Deadlock found when trying to get lock; try restarting transaction"),
 			retryable: true,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrPDServerTimeout, "pd server timeout"),
+			err:       newMysqlErr(errno.ErrPDServerTimeout, "pd server timeout"),
 			retryable: true,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrTiKVServerBusy, "tikv server busy"),
+			err:       newMysqlErr(errno.ErrTiKVServerBusy, "tikv server busy"),
 			retryable: true,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrResolveLockTimeout, "resolve lock timeout"),
+			err:       newMysqlErr(errno.ErrResolveLockTimeout, "resolve lock timeout"),
 			retryable: true,
 		},
 		// only retryable in some special cases, then we mark it as un-retryable
 		{
-			err:       newMysqlErr(tmysql.ErrTiKVServerTimeout, "tikv server timeout"),
+			err:       newMysqlErr(errno.ErrTiKVServerTimeout, "tikv server timeout"),
 			retryable: false,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrWriteConflictInTiDB, "Write conflict, txnStartTS 412719757964869950 is stale"),
+			err:       newMysqlErr(errno.ErrWriteConflictInTiDB, "Write conflict, txnStartTS 412719757964869950 is stale"),
 			retryable: false,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrTableLocked, "Table 'tbl' was locked in aaa by bbb"),
+			err:       newMysqlErr(errno.ErrTableLocked, "Table 'tbl' was locked in aaa by bbb"),
 			retryable: false,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrWriteConflict, "Write conflict, txnStartTS=412719757964869700, conflictStartTS=412719757964869700, conflictCommitTS=412719757964869950, key=488636541"),
+			err:       newMysqlErr(errno.ErrWriteConflict, "Write conflict, txnStartTS=412719757964869700, conflictStartTS=412719757964869700, conflictCommitTS=412719757964869950, key=488636541"),
 			retryable: false,
 		},
 		// un-retryable
 		{
-			err:       newMysqlErr(tmysql.ErrQueryInterrupted, "Query execution was interrupted"),
+			err:       newMysqlErr(errno.ErrQueryInterrupted, "Query execution was interrupted"),
 			retryable: false,
 		},
 		// unknown
 		{
-			err:       newMysqlErr(tmysql.ErrRegionUnavailable, "region unavailable"),
+			err:       newMysqlErr(errno.ErrRegionUnavailable, "region unavailable"),
 			retryable: false,
 		},
 		// 1105, un-retryable
 		{
-			err:       newMysqlErr(tmysql.ErrUnknown, "i/o timeout"),
+			err:       newMysqlErr(errno.ErrUnknown, "i/o timeout"),
 			retryable: false,
 		},
 		// 1105, retryable
 		{
-			err:       newMysqlErr(tmysql.ErrUnknown, "Information schema is out of date"),
+			err:       newMysqlErr(errno.ErrUnknown, "Information schema is out of date"),
 			retryable: true,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrUnknown, "Information schema is changed"),
+			err:       newMysqlErr(errno.ErrUnknown, "Information schema is changed"),
 			retryable: true,
 		},
 		// 1105 --> unique error code
 		{
-			err:       newMysqlErr(tmysql.ErrInfoSchemaExpired, "Information schema is out of date"),
+			err:       newMysqlErr(errno.ErrInfoSchemaExpired, "Information schema is out of date"),
 			retryable: true,
 		},
 		{
-			err:       newMysqlErr(tmysql.ErrInfoSchemaChanged, "Information schema is changed"),
+			err:       newMysqlErr(errno.ErrInfoSchemaChanged, "Information schema is changed"),
 			retryable: true,
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiDB error code has been moved from parser/mysql to tidb/errno. ref: https://github.com/pingcap/tidb/pull/15277, https://github.com/pingcap/parser/pull/764.
This repo should catch up with the latest TiDB/parser code.

### What is changed and how it works?
move tidb error code from the parser/mysql to tidb/errno, update go.mod1 and go.sum1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test