### PR TITLE
sync-diff: add option to check views

### DIFF
--- a/sync_diff_inspector/config.go
+++ b/sync_diff_inspector/config.go
@@ -195,6 +195,9 @@ type Config struct {
 	// ignore check table's data
 	IgnoreDataCheck bool `toml:"ignore-data-check" json:"ignore-data-check"`
 
+	// ignore check the difference of tables whose type is "View"
+	IgnoreViewCheck bool `toml:"ignore-view-check" json:"ignore-view-check"`
+
 	// set true will continue check from the latest checkpoint
 	UseCheckpoint bool `toml:"use-checkpoint" json:"use-checkpoint"`
 
@@ -221,6 +224,7 @@ func NewConfig() *Config {
 	fs.BoolVar(&cfg.PrintVersion, "V", false, "print version of sync_diff_inspector")
 	fs.BoolVar(&cfg.IgnoreDataCheck, "ignore-data-check", false, "ignore check table's data")
 	fs.BoolVar(&cfg.IgnoreStructCheck, "ignore-struct-check", false, "ignore check table's struct")
+	fs.BoolVar(&cfg.IgnoreViewCheck, "ignore-view-check", true, "ignore check the difference of views")
 	fs.BoolVar(&cfg.UseCheckpoint, "use-checkpoint", true, "set true will continue check from the latest checkpoint")
 
 	return cfg

--- a/sync_diff_inspector/config.toml
+++ b/sync_diff_inspector/config.toml
@@ -32,6 +32,9 @@ ignore-data-check = false
 # ignore check table's struct
 ignore-struct-check = false
 
+# ignore check the difference of views
+ignore-view-check = true
+
 # the name of the file which saves sqls used to fix different data.
 fix-sql-file = "fix.sql"
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`sync-diff` will filter views now and don't check them.

### What is changed and how it works?
Add an option `ignore-view-check` in config. The default value of `ignore-view-check` is true. When `ignore-view-check` is false sync-diff will fetch views of databases and check the difference.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 