### PR TITLE
diff: escape column name

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -218,7 +218,7 @@ func GetRandomValues(ctx context.Context, db *sql.DB, schemaName, table, column 
 	}
 
 	query := fmt.Sprintf("SELECT %[1]s FROM (SELECT %[1]s, rand() rand_value FROM %[2]s WHERE %[3]s ORDER BY rand_value LIMIT %[4]d)rand_tmp ORDER BY %[1]s%[5]s",
-		escapeName(column), TableName(schemaName, table), limitRange, num, collation)
+		ColumnName(column), TableName(schemaName, table), limitRange, num, collation)
 	log.Debug("get random values", zap.String("sql", query), zap.Reflect("args", limitArgs))
 
 	rows, err := db.QueryContext(ctx, query, limitArgs...)
@@ -618,6 +618,11 @@ func IsTiDB(ctx context.Context, db *sql.DB) (bool, error) {
 // TableName returns `schema`.`table`
 func TableName(schema, table string) string {
 	return fmt.Sprintf("`%s`.`%s`", escapeName(schema), escapeName(table))
+}
+
+// ColumnName returns `column`
+func ColumnName(column string) string {
+	return fmt.Sprintf("`%s`", escapeName(column))
 }
 
 func escapeName(name string) string {

--- a/pkg/dbutil/common_test.go
+++ b/pkg/dbutil/common_test.go
@@ -76,6 +76,31 @@ func (*testDBSuite) TestTableName(c *C) {
 	}
 }
 
+func (*testDBSuite) TestColumnName(c *C) {
+	testCases := []struct {
+		column        string
+		expectColName string
+	}{
+		{
+			"test",
+			"`test`",
+		},
+		{
+			"test-1",
+			"`test-1`",
+		},
+		{
+			"t`esta",
+			"`t``esta`",
+		},
+	}
+
+	for _, testCase := range testCases {
+		colName := ColumnName(testCase.column)
+		c.Assert(colName, Equals, testCase.expectColName)
+	}
+}
+
 func newMysqlErr(number uint16, message string) *mysql.MySQLError {
 	return &mysql.MySQLError{
 		Number:  number,

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -821,7 +821,7 @@ func getChunkRows(ctx context.Context, db *sql.DB, schema, table string, tableIn
 
 	columnNames := make([]string, 0, len(tableInfo.Columns))
 	for _, col := range tableInfo.Columns {
-		columnNames = append(columnNames, col.Name.O)
+		columnNames = append(columnNames, dbutil.ColumnName(col.Name.O))
 	}
 	columns := strings.Join(columnNames, ", ")
 
@@ -833,8 +833,8 @@ func getChunkRows(ctx context.Context, db *sql.DB, schema, table string, tableIn
 		orderKeys[i] = dbutil.ColumnName(key)
 	}
 
-	query := fmt.Sprintf("SELECT /*!40001 SQL_NO_CACHE */ %s FROM `%s`.`%s` WHERE %s ORDER BY %s%s",
-		columns, schema, table, where, strings.Join(orderKeys, ","), collation)
+	query := fmt.Sprintf("SELECT /*!40001 SQL_NO_CACHE */ %s FROM %s WHERE %s ORDER BY %s%s",
+		columns, dbutil.TableName(schema, table), where, strings.Join(orderKeys, ","), collation)
 
 	log.Debug("select data", zap.String("sql", query), zap.Reflect("args", args))
 	rows, err := db.QueryContext(ctx, query, args...)

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -829,6 +829,10 @@ func getChunkRows(ctx context.Context, db *sql.DB, schema, table string, tableIn
 		collation = fmt.Sprintf(" COLLATE \"%s\"", collation)
 	}
 
+	for i, key := range orderKeys {
+		orderKeys[i] = dbutil.ColumnName(key)
+	}
+
 	query := fmt.Sprintf("SELECT /*!40001 SQL_NO_CACHE */ %s FROM `%s`.`%s` WHERE %s ORDER BY %s%s",
 		columns, schema, table, where, strings.Join(orderKeys, ","), collation)
 

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -267,6 +267,7 @@ func generateData(ctx context.Context, db *sql.DB, dbCfg dbutil.DBConfig, source
 		d varchar(10) COLLATE latin1_bin DEFAULT NULL,
 		e int(10) DEFAULT NULL,
 		h year(4) DEFAULT NULL,
+		\`table\` varchar(10),
 		PRIMARY KEY (a))`, targetTable)
 
 	cfg := &importer.Config{
@@ -311,7 +312,7 @@ func generateData(ctx context.Context, db *sql.DB, dbCfg dbutil.DBConfig, source
 
 	// if hasEmptyTable is true, the last source table will be empty.
 	for j, condition := range conditions {
-		_, err = db.ExecContext(ctx, fmt.Sprintf("INSERT INTO `test`.`%s` (`a`, `b`, `c`, `d`, `e`, `h`) SELECT `a`, `b`, `c`, `d`, `e`, `h` FROM `test`.`%s` WHERE %s", sourceTables[j], targetTable, condition))
+		_, err = db.ExecContext(ctx, fmt.Sprintf("INSERT INTO `test`.`%s` (`a`, `b`, `c`, `d`, `e`, `h`, `table`) SELECT `a`, `b`, `c`, `d`, `e`, `h`, `table` FROM `test`.`%s` WHERE %s", sourceTables[j], targetTable, condition))
 		if err != nil {
 			return err
 		}

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -267,7 +267,7 @@ func generateData(ctx context.Context, db *sql.DB, dbCfg dbutil.DBConfig, source
 		d varchar(10) COLLATE latin1_bin DEFAULT NULL,
 		e int(10) DEFAULT NULL,
 		h year(4) DEFAULT NULL,
-		\`table\` varchar(10),
+		"table" varchar(10),
 		PRIMARY KEY (a))`, targetTable)
 
 	cfg := &importer.Config{

--- a/tests/sync_diff_inspector/run.sh
+++ b/tests/sync_diff_inspector/run.sh
@@ -11,6 +11,7 @@ mkdir $OUT_DIR || true
 echo "use importer to generate test data"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create database if not exists diff_test"
 importer -t "create table diff_test.test(a int, b varchar(10), c float, d datetime, primary key(a));" -c 10 -n 10000 -P 4000 -h 127.0.0.1 -D diff_test -b 1000
+mysql -uroot -h 127.0.0.1 -P 4000 -e "alter table diff_test.test change column a \`table\` int"
 
 echo "dump data and then load to tidb"
 mydumper --host 127.0.0.1 --port 4000 --user root --outputdir $OUT_DIR/dump_diff -B diff_test -T test

--- a/tests/sync_diff_inspector/run.sh
+++ b/tests/sync_diff_inspector/run.sh
@@ -10,6 +10,8 @@ mkdir $OUT_DIR || true
 
 echo "use importer to generate test data"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create database if not exists diff_test"
+# TODO: run `importer -t "create table diff_test.test(\`table\` int, b varchar(10), c float, d datetime, primary key(a));" -c 10 -n 10000 -P 4000 -h 127.0.0.1 -D diff_test -b 1000`
+# will exit with parser error, need to fix it in importer later, just change column name by mysql client now
 importer -t "create table diff_test.test(a int, b varchar(10), c float, d datetime, primary key(a));" -c 10 -n 10000 -P 4000 -h 127.0.0.1 -D diff_test -b 1000
 mysql -uroot -h 127.0.0.1 -P 4000 -e "alter table diff_test.test change column a \`table\` int"
 

--- a/tests/sync_diff_inspector/shard/run.sh
+++ b/tests/sync_diff_inspector/shard/run.sh
@@ -7,12 +7,12 @@ cd "$(dirname "$0")"
 OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector
 
 echo "generate data to sharding tables"
-mysql -uroot -h 127.0.0.1 -P 4001 -e "create table diff_test.shard_test1(a int, b varchar(10), c float, d datetime, primary key(a));"
-mysql -uroot -h 127.0.0.1 -P 4001 -e "create table diff_test.shard_test2(a int, b varchar(10), c float, d datetime, primary key(a));"
+mysql -uroot -h 127.0.0.1 -P 4001 -e "create table diff_test.shard_test1(\`table\` int, b varchar(10), c float, d datetime, primary key(\`table\`));"
+mysql -uroot -h 127.0.0.1 -P 4001 -e "create table diff_test.shard_test2(\`table\` int, b varchar(10), c float, d datetime, primary key(\`table\`));"
 
 # each table only have part of data
-mysql -uroot -h 127.0.0.1 -P 4001 -e "insert into diff_test.shard_test1 (a, b, c, d) SELECT a, b, c, d FROM diff_test.test WHERE a%2=0"
-mysql -uroot -h 127.0.0.1 -P 4001 -e "insert into diff_test.shard_test2 (a, b, c, d) SELECT a, b, c, d FROM diff_test.test WHERE a%2=1"
+mysql -uroot -h 127.0.0.1 -P 4001 -e "insert into diff_test.shard_test1 (\`table\`, b, c, d) SELECT \`table\`, b, c, d FROM diff_test.test WHERE \`table\`%2=0"
+mysql -uroot -h 127.0.0.1 -P 4001 -e "insert into diff_test.shard_test2 (\`table\`, b, c, d) SELECT \`table\`, b, c, d FROM diff_test.test WHERE \`table\`%2=1"
 
 
 echo "compare sharding tables with one table in downstream, check result should be pass"


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

if the column name is keyword in mysql/tidb, will return error when select data.

### What is changed and how it works?

escape column name

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
