### PR TITLE
filter/: fix filter panic error

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -292,6 +292,10 @@ func (f *Filter) ApplyOn(stbs []*Table) []*Table {
 
 // Match returns true if the specified table should not be removed.
 func (f *Filter) Match(tb *Table) bool {
+	if f == nil || f.rules == nil {
+		return true
+	}
+
 	name := tb.String()
 	do, exist := f.c.query(name)
 	if !exist {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -218,4 +218,7 @@ func (s *testFilterSuite) TestMatchReturnsBool(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(f.Match(&Table{Schema: "sns"}), IsTrue)
 	c.Assert(f.Match(&Table{Schema: "other"}), IsFalse)
+	f, err = New(true, nil)
+	c.Assert(err, IsNil)
+	c.Assert(f.Match(&Table{Schema: "other"}), IsTrue)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix panic error when `filter` or `filter.rule` is nil.

### What is changed and how it works?
Add check.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
