### PR TITLE
filter: fix caseSensitive not work on match (#335)

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -292,6 +292,14 @@ func (f *Filter) ApplyOn(stbs []*Table) []*Table {
 
 // Match returns true if the specified table should not be removed.
 func (f *Filter) Match(tb *Table) bool {
+	if f == nil || f.rules == nil {
+		return true
+	}
+	if !f.caseSensitive {
+		tb.Schema = strings.ToLower(tb.Schema)
+		tb.Name = strings.ToLower(tb.Name)
+	}
+
 	name := tb.String()
 	do, exist := f.c.query(name)
 	if !exist {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -187,6 +187,22 @@ func (s *testFilterSuite) TestCaseSensitive(c *C) {
 	expected := []*Table{{"foo2", "b"}, {"Foo4", "dfoo"}, {"5", "5"}}
 	c.Logf("got %+v, expected %+v", actual, expected)
 	c.Assert(actual, DeepEquals, expected)
+
+	inputTable := &Table{"FOO", "a"}
+	c.Assert(r.Match(inputTable), IsFalse)
+
+	rules = &Rules{
+		DoDBs: []string{"BAR"},
+	}
+
+	r, err = New(false, rules)
+	inputTable = &Table{"bar", "a"}
+	c.Assert(r.Match(inputTable), IsTrue)
+
+	c.Assert(err, IsNil)
+
+	inputTable = &Table{"BAR", "a"}
+	c.Assert(r.Match(inputTable), IsTrue)
 }
 
 func (s *testFilterSuite) TestInvalidRegex(c *C) {


### PR DESCRIPTION
cherry-pick #335  to release-3.1

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
caseSensitive not work on Match 

### What is changed and how it works?
add ToLower if !caseSensitive

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch

