### PR TITLE
diff: fix panic when get empty random value for split chunk

### DIFF
--- a/pkg/diff/chunk.go
+++ b/pkg/diff/chunk.go
@@ -265,6 +265,9 @@ func splitRangeByRandom(db *sql.DB, chunk *ChunkRange, count int, schema string,
 
 		for j, column := range columns {
 			if i == 0 {
+				if len(randomValues[j]) == 0 {
+					break
+				}
 				newChunk.update(column.Name.O, "", randomValues[j][i], false, true)
 			} else if i == len(randomValues[0]) {
 				newChunk.update(column.Name.O, randomValues[j][i-1], "", true, false)

--- a/pkg/diff/spliter_test.go
+++ b/pkg/diff/spliter_test.go
@@ -82,6 +82,22 @@ func (s *testSpliterSuite) TestSplitRangeByRandom(c *C) {
 			},
 		}, {
 			"create table `test`.`test`(`a` int, `b` varchar(10), `c` float, `d` datetime, primary key(`b`))",
+			2,
+			NewChunkRange().copyAndUpdate("b", "a", "z", true, true),
+			[][]interface{}{
+				{"g"},
+			},
+			[]chunkResult{
+				{
+					"((`b` > ?)) AND ((`b` <= ?))",
+					[]string{"a", "g"},
+				}, {
+					"((`b` > ?)) AND ((`b` <= ?))",
+					[]string{"g", "z"},
+				},
+			},
+		}, {
+			"create table `test`.`test`(`a` int, `b` varchar(10), `c` float, `d` datetime, primary key(`b`))",
 			3,
 			NewChunkRange().copyAndUpdate("b", "a", "z", true, true),
 			[][]interface{}{

--- a/pkg/diff/spliter_test.go
+++ b/pkg/diff/spliter_test.go
@@ -80,6 +80,19 @@ func (s *testSpliterSuite) TestSplitRangeByRandom(c *C) {
 					[]string{"n", "z"},
 				},
 			},
+		}, {
+			"create table `test`.`test`(`a` int, `b` varchar(10), `c` float, `d` datetime, primary key(`b`))",
+			3,
+			NewChunkRange().copyAndUpdate("b", "a", "z", true, true),
+			[][]interface{}{
+				{},
+			},
+			[]chunkResult{
+				{
+					"((`b` > ?)) AND ((`b` <= ?))",
+					[]string{"a", "z"},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION


### What problem does this PR solve? <!--add issue link with summary if exists-->

when executing `splitRangeByRandom`, if `randomValues` is empty will panic at https://github.com/pingcap/tidb-tools/blob/330c1a4a8ec0692d83d0f91fdf2ad9d297475faf/pkg/diff/chunk.go#L268

### What is changed and how it works?

add a judgement

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
