### PR TITLE
table-filter: added filter.All() to conveniently make a match-all filter

### DIFF
--- a/pkg/table-filter/compat.go
+++ b/pkg/table-filter/compat.go
@@ -106,7 +106,7 @@ func (f schemasFilter) toLower() Filter {
 }
 
 // NewSchemasFilter creates a filter which only accepts a list of schemas.
-func NewSchemasFilter(schemas ...string) schemasFilter {
+func NewSchemasFilter(schemas ...string) Filter {
 	schemaMap := make(map[string]struct{}, len(schemas))
 	for _, schema := range schemas {
 		schemaMap[schema] = struct{}{}

--- a/pkg/table-filter/filter.go
+++ b/pkg/table-filter/filter.go
@@ -107,3 +107,22 @@ func (f loweredFilter) MatchSchema(schema string) bool {
 func (f loweredFilter) toLower() Filter {
 	return f
 }
+
+type allFilter struct{}
+
+func (allFilter) MatchTable(string, string) bool {
+	return true
+}
+
+func (allFilter) MatchSchema(string) bool {
+	return true
+}
+
+func (f allFilter) toLower() Filter {
+	return f
+}
+
+// All creates a filter which matches everything.
+func All() Filter {
+	return allFilter{}
+}

--- a/pkg/table-filter/filter_test.go
+++ b/pkg/table-filter/filter_test.go
@@ -446,3 +446,13 @@ func (s *filterSuite) TestRecursiveImport(c *C) {
 	_, err = filter.Parse([]string{"@" + filepath.Join(dir, "5.txt")})
 	c.Assert(err, ErrorMatches, `.*: cannot open filter file: open .*5\.txt: .*`)
 }
+
+func (s *filterSuite) TestAll(c *C) {
+	f := filter.All()
+	c.Assert(f.MatchTable("db1", "tbl1"), IsTrue)
+	c.Assert(f.MatchSchema("db1"), IsTrue)
+
+	f = filter.CaseInsensitive(f)
+	c.Assert(f.MatchTable("db1", "tbl1"), IsTrue)
+	c.Assert(f.MatchSchema("db1"), IsTrue)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add a function `filter.All()` which creates a match-all filter. This is used as the default value of `filter.Filter` in a config, which has the same effect as `f, _ := filter.Parse([]string{"*.*"})`.

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes

