### PR TITLE
make ParseMySQLReplicationRules able to parser nil rules

### DIFF
--- a/pkg/table-filter/compat.go
+++ b/pkg/table-filter/compat.go
@@ -213,6 +213,9 @@ func matcherFromLegacyPattern(pattern string) (matcher, error) {
 // ParseMySQLReplicationRules constructs up to 2 filters from the MySQLReplicationRules.
 // Tables have to pass *both* filters to be processed.
 func ParseMySQLReplicationRules(rules *MySQLReplicationRules) (Filter, error) {
+	if rules == nil {
+		return All(), nil
+	}
 	schemas := rules.DoDBs
 	positive := true
 	rulesLen := len(schemas)

--- a/pkg/table-filter/compat_test.go
+++ b/pkg/table-filter/compat_test.go
@@ -205,6 +205,10 @@ func (s *compatSuite) TestLegacyFilter(c *C) {
 		},
 	}
 
+	f, err := filter.ParseMySQLReplicationRules(nil)
+	c.Assert(err, IsNil)
+	c.Assert(f.MatchTable("foo", "bar"), IsTrue)
+
 	for _, tc := range cases {
 		c.Log("test case =", tc.rules)
 		f, err := filter.ParseMySQLReplicationRules(&tc.rules)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix ParseMySQLReplicationRules nil pointer.

### What is changed and how it works?
return `All()` filter when rules is nil.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
