### PR TITLE
diff: fix block

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -150,9 +150,12 @@ func (t *TableDiff) Equal(ctx context.Context, writeFixSQL func(string) error) (
 
 		select {
 		case <-ctx.Done():
-		default:
-			stopWriteSqlsCh <- true
-			stopUpdateSummaryCh <- true
+		case stopWriteSqlsCh <- true:
+		}
+
+		select {
+		case <-ctx.Done():
+		case stopUpdateSummaryCh <- true:
 		}
 	}
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -148,8 +148,12 @@ func (t *TableDiff) Equal(ctx context.Context, writeFixSQL func(string) error) (
 			return false, false, errors.Trace(err)
 		}
 
-		stopWriteSqlsCh <- true
-		stopUpdateSummaryCh <- true
+		select {
+		case <-ctx.Done():
+		default:
+			stopWriteSqlsCh <- true
+			stopUpdateSummaryCh <- true
+		}
 	}
 
 	t.wg.Wait()


### PR DESCRIPTION


### What problem does this PR solve? <!--add issue link with summary if exists-->

when `ctx.Done()`, will exit `UpdateSummaryInfo`, and `stopUpdateSummaryCh <- true` will be blocked because of no one read data from this channel.

### What is changed and how it works?

only when ctx is not done send true to `stopUpdateSummaryCh`

