### PR TITLE
diff: refine log && minor fix

### DIFF
--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -435,6 +435,8 @@ func (df *Diff) Equal() (err error) {
 
 			if err != nil {
 				log.Error("check failed", zap.String("table", dbutil.TableName(table.Schema, table.Table)), zap.Error(err))
+				df.report.SetTableMeetError(table.Schema, table.Table, err)
+				df.report.FailedNum++
 				continue
 			}
 

--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -63,9 +63,10 @@ func main() {
 
 	ctx := context.Background()
 	if !checkSyncState(ctx, cfg) {
+		log.Error("check failed!!!")
 		os.Exit(1)
 	}
-	log.Info("test pass!!!")
+	log.Info("check pass!!!")
 }
 
 func checkSyncState(ctx context.Context, cfg *Config) bool {

--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	ctx := context.Background()
 	if !checkSyncState(ctx, cfg) {
-		log.Fatal("sourceDB don't equal targetDB")
+		os.Exit(1)
 	}
 	log.Info("test pass!!!")
 }
@@ -84,7 +84,7 @@ func checkSyncState(ctx context.Context, cfg *Config) bool {
 		log.Fatal("check data difference failed", zap.Error(err))
 	}
 
-	log.Info("check report", zap.Stringer("report", d.report))
+	d.report.Print()
 
 	return d.report.Result == Pass
 }

--- a/sync_diff_inspector/report.go
+++ b/sync_diff_inspector/report.go
@@ -82,7 +82,7 @@ func (r *Report) Print() {
 	for schema, tableMap := range r.TableResults {
 		for table, result := range tableMap {
 			if result.MeetError != nil {
-				log.Info("table check result", zap.String("schema", schema), zap.String("table", table), zap.String("meet error", result.MeetError.Error()))
+				log.Error("table check result", zap.String("schema", schema), zap.String("table", table), zap.String("meet error", result.MeetError.Error()))
 			} else {
 				log.Info("table check result", zap.String("schema", schema), zap.String("table", table), zap.Bool("struct equal", result.StructEqual), zap.Bool("data equal", result.DataEqual))
 			}

--- a/sync_diff_inspector/report.go
+++ b/sync_diff_inspector/report.go
@@ -14,8 +14,10 @@
 package main
 
 import (
-	"fmt"
 	"sync"
+
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
 )
 
 const (
@@ -31,6 +33,7 @@ type TableResult struct {
 	Table       string
 	StructEqual bool
 	DataEqual   bool
+	MeetError   error
 }
 
 // Report saves the check results.
@@ -52,8 +55,8 @@ func NewReport() *Report {
 	}
 }
 
-// String returns a string of this Report.
-func (r *Report) String() (report string) {
+// Print prints the check report.
+func (r *Report) Print() {
 	r.RLock()
 	defer r.RUnlock()
 	/*
@@ -73,35 +76,18 @@ func (r *Report) String() (report string) {
 		table's struct equal
 		table's data equal
 	*/
-	report = fmt.Sprintf("\ncheck result: %s!\n", r.Result)
-	report += fmt.Sprintf("%d tables' check passed, %d tables' check failed.\n", r.PassNum, r.FailedNum)
 
-	var failTableRsult, passTableResult string
+	log.Info("check result summary", zap.Int32("check passed num", r.PassNum), zap.Int32("check failed num", r.FailedNum))
+
 	for schema, tableMap := range r.TableResults {
 		for table, result := range tableMap {
-			var structResult, dataResult string
-			if !result.StructEqual {
-				structResult = "table's struct not equal"
+			if result.MeetError != nil {
+				log.Info("table check result", zap.String("schema", schema), zap.String("table", table), zap.String("meet error", result.MeetError.Error()))
 			} else {
-				structResult = "table's struct equal"
-			}
-
-			if !result.DataEqual {
-				dataResult = "table's data not equal"
-			} else {
-				dataResult = "table's data equal"
-			}
-
-			if !result.StructEqual || !result.DataEqual {
-				failTableRsult = fmt.Sprintf("%stable: %s.%s\n%s\n%s\n\n", failTableRsult, schema, table, structResult, dataResult)
-			} else {
-				passTableResult = fmt.Sprintf("%stable: %s.%s\n%s\n%s\n\n", passTableResult, schema, table, structResult, dataResult)
+				log.Info("table check result", zap.String("schema", schema), zap.String("table", table), zap.Bool("struct equal", result.StructEqual), zap.Bool("data equal", result.DataEqual))
 			}
 		}
 	}
-
-	// first print the check failed table's information
-	report += fmt.Sprintf("\n%s%s", failTableRsult, passTableResult)
 
 	return
 }
@@ -148,4 +134,21 @@ func (r *Report) SetTableDataCheckResult(schema, table string, equal bool) {
 	if !equal {
 		r.Result = Fail
 	}
+}
+
+// SetTableMeetError sets meet error when check the table.
+func (r *Report) SetTableMeetError(schema, table string, err error) {
+	if _, ok := r.TableResults[schema]; !ok {
+		r.TableResults[schema] = make(map[string]*TableResult)
+	}
+
+	if tableResult, ok := r.TableResults[schema][table]; ok {
+		tableResult.MeetError = err
+	} else {
+		r.TableResults[schema][table] = &TableResult{
+			MeetError: err,
+		}
+	}
+
+	r.Result = Fail
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

1. fix issue https://github.com/pingcap/tidb-tools/issues/357, don't print this log
2. refine log for check report, the old log like:

`[2020/06/24 16:36:23.332 +08:00] [INFO] [main.go:87] ["check report"] [report="\ncheck result: fail!\n0 tables' check passed, 1 tables' check failed.\n\ntable: diff_test.t_10\ntable's struct equal\ntable's data not equal\n\n"]`

after this PR, it will be:

`[2020/06/24 17:50:47.149 +08:00] [INFO] [report.go:80] ["check result summary"] ["check passed num"=0] ["check failed num"=1]
[2020/06/24 17:50:47.149 +08:00] [INFO] [report.go:87] ["table check result"] [schema=diff_test] [table=t_10] ["struct equal"=true] ["data equal"=false]`

3. a minor fix, after this pr https://github.com/pingcap/tidb-tools/pull/346/files#r444783910, if meet error will continue and doesn't save the check result. 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (check log)

