### PR TITLE
diff: save summary info in memory

### DIFF
--- a/pkg/diff/checkpoint_test.go
+++ b/pkg/diff/checkpoint_test.go
@@ -83,21 +83,12 @@ func (s *testCheckpointSuite) testSaveAndLoadChunk(c *C, db *sql.DB) {
 }
 
 func (s *testCheckpointSuite) testUpdateSummary(c *C, db *sql.DB) {
-	failedChunk := &ChunkRange{
-		ID:    2,
-		State: failedState,
-	}
-	err := saveChunk(context.Background(), db, failedChunk.ID, "target", "test", "checkpoint", "", failedChunk)
-	c.Assert(err, IsNil)
+	summaryInfo := newTableSummaryInfo(3)
+	summaryInfo.addSuccessNum()
+	summaryInfo.addFailedNum()
+	summaryInfo.addIgnoreNum()
 
-	ignoreChunk := &ChunkRange{
-		ID:    3,
-		State: ignoreState,
-	}
-	err = saveChunk(context.Background(), db, ignoreChunk.ID, "target", "test", "checkpoint", "", ignoreChunk)
-	c.Assert(err, IsNil)
-
-	err = updateTableSummary(context.Background(), db, "target", "test", "checkpoint")
+	err := updateTableSummary(context.Background(), db, "target", "test", "checkpoint", summaryInfo)
 	c.Assert(err, IsNil)
 
 	total, successNum, failedNum, ignoreNum, state, err := getTableSummary(context.Background(), db, "test", "checkpoint")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fix issue https://github.com/pingcap/tidb-tools/issues/362
getting the wrong summary like 
```
[2020/06/18 07:46:23.864 +00:00] [INFO] [checkpoint.go:231] ["summary info"] [instance_id=target] [schema=db] [table=txn_history] ["chunk num"=247656] ["success num"=153326] ["failed num"=0] ["ignore num"=0]
[2020/06/18 07:46:33.810 +00:00] [INFO] [checkpoint.go:231] ["summary info"] [instance_id=target] [schema=db] [table=txn_history] ["chunk num"=247656] ["success num"=153496] ["failed num"=0] ["ignore num"=0]
[2020/06/18 07:46:43.873 +00:00] [INFO] [checkpoint.go:231] ["summary info"] [instance_id=target] [schema=db] [table=txn_history] ["chunk num"=247656] ["success num"=0] ["failed num"=0] ["ignore num"=0]
```
already get 153496 success num, but get 0 success num later, don't know why now, but we can save the summary information in memory instead of select the `chunk` table every time print summary information to fix this issue,  and this will save TiDB/MySQL's performance and diff can run faster.

### What is changed and how it works?

save summary info in memory

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test