### PR TITLE
diff: save summary info in memory

### DIFF
--- a/pkg/diff/checkpoint.go
+++ b/pkg/diff/checkpoint.go
@@ -235,8 +235,11 @@ func updateTableSummary(ctx context.Context, db *sql.DB, instanceID, schema, tab
 
 	log.Info("summary info", zap.String("instance_id", instanceID), zap.String("schema", schema), zap.String("table", table), zap.Int64("chunk num", total), zap.Int64("success num", successNum), zap.Int64("failed num", failedNum), zap.Int64("ignore num", ignoreNum))
 
-	state := notCheckedState
-	if total == successNum+failedNum+ignoreNum {
+	checkedNum := successNum + failedNum + ignoreNum
+	state := checkingState
+	if checkedNum == 0 {
+		state = notCheckedState
+	} else if checkedNum == total {
 		if total == successNum+ignoreNum {
 			state = successState
 		} else {

--- a/pkg/diff/checkpoint_test.go
+++ b/pkg/diff/checkpoint_test.go
@@ -83,21 +83,12 @@ func (s *testCheckpointSuite) testSaveAndLoadChunk(c *C, db *sql.DB) {
 }
 
 func (s *testCheckpointSuite) testUpdateSummary(c *C, db *sql.DB) {
-	failedChunk := &ChunkRange{
-		ID:    2,
-		State: failedState,
-	}
-	err := saveChunk(context.Background(), db, failedChunk.ID, "target", "test", "checkpoint", "", failedChunk)
-	c.Assert(err, IsNil)
+	summaryInfo := newTableSummaryInfo(3)
+	summaryInfo.addSuccessNum()
+	summaryInfo.addFailedNum()
+	summaryInfo.addIgnoreNum()
 
-	ignoreChunk := &ChunkRange{
-		ID:    3,
-		State: ignoreState,
-	}
-	err = saveChunk(context.Background(), db, ignoreChunk.ID, "target", "test", "checkpoint", "", ignoreChunk)
-	c.Assert(err, IsNil)
-
-	err = updateTableSummary(context.Background(), db, "target", "test", "checkpoint")
+	err := updateTableSummary(context.Background(), db, "target", "test", "checkpoint", summaryInfo)
 	c.Assert(err, IsNil)
 
 	total, successNum, failedNum, ignoreNum, state, err := getTableSummary(context.Background(), db, "test", "checkpoint")

--- a/pkg/diff/chunk.go
+++ b/pkg/diff/chunk.go
@@ -257,7 +257,7 @@ func splitRangeByRandom(db *sql.DB, chunk *ChunkRange, count int, schema string,
 			return nil, errors.Trace(err)
 		}
 
-		log.Debug("get split values by random", zap.Stringer("chunk", chunk), zap.String("column", column.Name.O), zap.Reflect("random values", randomValues[i]))
+		log.Debug("get split values by random", zap.Stringer("chunk", chunk), zap.String("column", column.Name.O), zap.Int("random values num", len(randomValues[i])))
 	}
 
 	for i := 0; i <= minLenInSlices(randomValues); i++ {
@@ -278,7 +278,7 @@ func splitRangeByRandom(db *sql.DB, chunk *ChunkRange, count int, schema string,
 		chunks = append(chunks, newChunk)
 	}
 
-	log.Debug("split range by random", zap.Stringer("origin chunk", chunk), zap.Reflect("chunks", chunks))
+	log.Debug("split range by random", zap.Stringer("origin chunk", chunk), zap.Int("split num", len(chunks)))
 
 	return chunks, nil
 }
@@ -460,6 +460,7 @@ func SplitChunks(ctx context.Context, table *TableInstance, splitFields, limits 
 
 	ctx1, cancel1 := context.WithTimeout(ctx, time.Duration(len(chunks))*dbutil.DefaultTimeout)
 	defer cancel1()
+
 	for i, chunk := range chunks {
 		conditions, args := chunk.toString(collation)
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -100,7 +100,7 @@ type TableDiff struct {
 
 	configHash string
 
-	CpDB *sql.DB
+	CpDB *sql.DB `json:"-"`
 
 	// 1 means true, 0 means false
 	checkpointLoaded int32
@@ -239,7 +239,7 @@ func (t *TableDiff) CheckTableData(ctx context.Context) (equal bool, err error) 
 	}
 
 	if len(chunks) == 0 {
-		log.Debug("don't have checkpoint info or config changed")
+		log.Info("don't have checkpoint info, or the last check success, or config changed, will split chunks")
 
 		fromCheckpoint = false
 		chunks, err = SplitChunks(ctx, table, t.Fields, t.Range, t.ChunkSize, t.Collation, useTiDB, t.CpDB)
@@ -462,21 +462,26 @@ func (t *TableDiff) checkChunkDataEqual(ctx context.Context, filterByRand bool, 
 
 func (t *TableDiff) compareChecksum(ctx context.Context, chunk *ChunkRange) (bool, error) {
 	// first check the checksum is equal or not
+	getSourceChecksumTime := time.Now()
 	sourceChecksum, err := t.getSourceTableChecksum(ctx, chunk)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
+	getSourceChecksumDuration := time.Since(getSourceChecksumTime)
 
+	getTargetChecksumTime := time.Now()
 	targetChecksum, err := dbutil.GetCRC32Checksum(ctx, t.TargetTable.Conn, t.TargetTable.Schema, t.TargetTable.Table, t.TargetTable.info, chunk.Where, utils.StringsToInterfaces(chunk.Args))
 	if err != nil {
 		return false, errors.Trace(err)
 	}
+	getTargetChecksumDuration := time.Since(getTargetChecksumTime)
+
 	if sourceChecksum == targetChecksum {
-		log.Info("checksum is equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", chunk.Where), zap.Reflect("args", chunk.Args), zap.Int64("checksum", sourceChecksum))
+		log.Info("checksum is equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", dbutil.ReplacePlaceholder(chunk.Where, chunk.Args)), zap.Int64("checksum", sourceChecksum), zap.Duration("get source checksum cost", getSourceChecksumDuration), zap.Duration("get target checksum cost", getTargetChecksumDuration))
 		return true, nil
 	}
 
-	log.Warn("checksum is not equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", chunk.Where), zap.Reflect("args", chunk.Args), zap.Int64("source checksum", sourceChecksum), zap.Int64("target checksum", targetChecksum))
+	log.Warn("checksum is not equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", dbutil.ReplacePlaceholder(chunk.Where, chunk.Args)), zap.Int64("source checksum", sourceChecksum), zap.Int64("target checksum", targetChecksum), zap.Duration("get source checksum cost", getSourceChecksumDuration), zap.Duration("get target checksum cost", getTargetChecksumDuration))
 
 	return false, nil
 }

--- a/tests/sync_diff_inspector/run.sh
+++ b/tests/sync_diff_inspector/run.sh
@@ -36,6 +36,12 @@ sync_diff_inspector --config=./config_base.toml > $OUT_DIR/diff.log
 # doesn't contain the table's result in check report
 check_not_contains "[table=should_not_compare]" $OUT_DIR/diff.log
 
+mysql -uroot -h 127.0.0.1 -P 4000 -e "select state from sync_diff_inspector.summary where \`schema\`='diff_test' and \`table\`='test'" | grep "success"
+if [ $? == 1 ]; then
+    echo "the state is not success in summary table"
+    exit 1
+fi
+
 for script in ./*/run.sh; do
     test_name="$(basename "$(dirname "$script")")"
     echo "---------------------------------------"


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fix issue https://github.com/pingcap/tidb-tools/issues/362
getting the wrong summary like 
```
[2020/06/18 07:46:23.864 +00:00] [INFO] [checkpoint.go:231] ["summary info"] [instance_id=target] [schema=db] [table=txn_history] ["chunk num"=247656] ["success num"=153326] ["failed num"=0] ["ignore num"=0]
[2020/06/18 07:46:33.810 +00:00] [INFO] [checkpoint.go:231] ["summary info"] [instance_id=target] [schema=db] [table=txn_history] ["chunk num"=247656] ["success num"=153496] ["failed num"=0] ["ignore num"=0]
[2020/06/18 07:46:43.873 +00:00] [INFO] [checkpoint.go:231] ["summary info"] [instance_id=target] [schema=db] [table=txn_history] ["chunk num"=247656] ["success num"=0] ["failed num"=0] ["ignore num"=0]
```
already get 153496 success num, but get 0 success num later, don't know why now, but we can save the summary information in memory instead of select the `chunk` table every time print summary information to fix this issue,  and this will save TiDB/MySQL's performance and diff can run faster.

### What is changed and how it works?

save summary info in memory

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test