### PR TITLE
diff: refine performance and memory usage

### DIFF
--- a/pkg/diff/checkpoint.go
+++ b/pkg/diff/checkpoint.go
@@ -146,8 +146,8 @@ func initChunks(ctx context.Context, db *sql.DB, instanceID, schema, table strin
 				return errors.Trace(err)
 			}
 			num = 0
-			valuesPlaceholdersArray = make([]string, 0, batch)
-			values = make([]interface{}, 0, 9*batch)
+			valuesPlaceholdersArray = valuesPlaceholdersArray[:0]
+			values = values[:0]
 		}
 	}
 

--- a/pkg/diff/checkpoint.go
+++ b/pkg/diff/checkpoint.go
@@ -235,8 +235,11 @@ func updateTableSummary(ctx context.Context, db *sql.DB, instanceID, schema, tab
 
 	log.Info("summary info", zap.String("instance_id", instanceID), zap.String("schema", schema), zap.String("table", table), zap.Int64("chunk num", total), zap.Int64("success num", successNum), zap.Int64("failed num", failedNum), zap.Int64("ignore num", ignoreNum))
 
-	state := notCheckedState
-	if total == successNum+failedNum+ignoreNum {
+	checkedNum := successNum + failedNum + ignoreNum
+	state := checkingState
+	if checkedNum == 0 {
+		state = notCheckedState
+	} else if checkedNum == total {
 		if total == successNum+ignoreNum {
 			state = successState
 		} else {

--- a/pkg/diff/checkpoint_test.go
+++ b/pkg/diff/checkpoint_test.go
@@ -119,3 +119,28 @@ func (s *testUtilSuite) TestloadFromCheckPoint(c *C) {
 	useCheckpoint, err = loadFromCheckPoint(context.Background(), db, "test", "test", "123")
 	c.Assert(useCheckpoint, Equals, true)
 }
+
+func (s *testUtilSuite) TestInitChunks(c *C) {
+	db, _, err := sqlmock.New()
+	c.Assert(err, IsNil)
+
+	chunks := []*ChunkRange{
+		{
+			ID:           1,
+			Bounds:       []*Bound{{Column: "a", Lower: "1"}},
+			State:        notCheckedState,
+			columnOffset: map[string]int{"a": 0},
+		}, {
+			ID:           2,
+			Bounds:       []*Bound{{Column: "a", Lower: "0", Upper: "1"}},
+			State:        notCheckedState,
+			columnOffset: map[string]int{"a": 0},
+		},
+	}
+
+	// init chunks will insert chunk's information with update time, which use time.Now(), so can't know the value and can't fill the `WithArgs`
+	// so just skip the `ExpectQuery` and check the error message
+	//mock.ExpectQuery("INSERT INTO `sync_diff_inspector`.`chunk` VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?)").WithArgs(......)
+	err = initChunks(context.Background(), db, "target", "diff_test", "test", chunks)
+	c.Assert(err, ErrorMatches, ".*INSERT INTO `sync_diff_inspector`.`chunk` VALUES\\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\), \\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\).*")
+}

--- a/pkg/diff/checkpoint_test.go
+++ b/pkg/diff/checkpoint_test.go
@@ -83,21 +83,12 @@ func (s *testCheckpointSuite) testSaveAndLoadChunk(c *C, db *sql.DB) {
 }
 
 func (s *testCheckpointSuite) testUpdateSummary(c *C, db *sql.DB) {
-	failedChunk := &ChunkRange{
-		ID:    2,
-		State: failedState,
-	}
-	err := saveChunk(context.Background(), db, failedChunk.ID, "target", "test", "checkpoint", "", failedChunk)
-	c.Assert(err, IsNil)
+	summaryInfo := newTableSummaryInfo(3)
+	summaryInfo.addSuccessNum()
+	summaryInfo.addFailedNum()
+	summaryInfo.addIgnoreNum()
 
-	ignoreChunk := &ChunkRange{
-		ID:    3,
-		State: ignoreState,
-	}
-	err = saveChunk(context.Background(), db, ignoreChunk.ID, "target", "test", "checkpoint", "", ignoreChunk)
-	c.Assert(err, IsNil)
-
-	err = updateTableSummary(context.Background(), db, "target", "test", "checkpoint")
+	err := updateTableSummary(context.Background(), db, "target", "test", "checkpoint", summaryInfo)
 	c.Assert(err, IsNil)
 
 	total, successNum, failedNum, ignoreNum, state, err := getTableSummary(context.Background(), db, "test", "checkpoint")

--- a/pkg/diff/chunk.go
+++ b/pkg/diff/chunk.go
@@ -257,7 +257,7 @@ func splitRangeByRandom(db *sql.DB, chunk *ChunkRange, count int, schema string,
 			return nil, errors.Trace(err)
 		}
 
-		log.Debug("get split values by random", zap.Stringer("chunk", chunk), zap.String("column", column.Name.O), zap.Reflect("random values", randomValues[i]))
+		log.Debug("get split values by random", zap.Stringer("chunk", chunk), zap.String("column", column.Name.O), zap.Int("random values num", len(randomValues[i])))
 	}
 
 	for i := 0; i <= minLenInSlices(randomValues); i++ {
@@ -278,7 +278,7 @@ func splitRangeByRandom(db *sql.DB, chunk *ChunkRange, count int, schema string,
 		chunks = append(chunks, newChunk)
 	}
 
-	log.Debug("split range by random", zap.Stringer("origin chunk", chunk), zap.Reflect("chunks", chunks))
+	log.Debug("split range by random", zap.Stringer("origin chunk", chunk), zap.Int("split num", len(chunks)))
 
 	return chunks, nil
 }
@@ -460,6 +460,7 @@ func SplitChunks(ctx context.Context, table *TableInstance, splitFields, limits 
 
 	ctx1, cancel1 := context.WithTimeout(ctx, time.Duration(len(chunks))*dbutil.DefaultTimeout)
 	defer cancel1()
+
 	for i, chunk := range chunks {
 		conditions, args := chunk.toString(collation)
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -100,7 +100,7 @@ type TableDiff struct {
 
 	configHash string
 
-	CpDB *sql.DB
+	CpDB *sql.DB `json:"-"`
 
 	// 1 means true, 0 means false
 	checkpointLoaded int32
@@ -239,7 +239,7 @@ func (t *TableDiff) CheckTableData(ctx context.Context) (equal bool, err error) 
 	}
 
 	if len(chunks) == 0 {
-		log.Debug("don't have checkpoint info or config changed")
+		log.Info("don't have checkpoint info, or the last check success, or config changed, will split chunks")
 
 		fromCheckpoint = false
 		chunks, err = SplitChunks(ctx, table, t.Fields, t.Range, t.ChunkSize, t.Collation, useTiDB, t.CpDB)
@@ -462,21 +462,26 @@ func (t *TableDiff) checkChunkDataEqual(ctx context.Context, filterByRand bool, 
 
 func (t *TableDiff) compareChecksum(ctx context.Context, chunk *ChunkRange) (bool, error) {
 	// first check the checksum is equal or not
+	getSourceChecksumTime := time.Now()
 	sourceChecksum, err := t.getSourceTableChecksum(ctx, chunk)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
+	getSourceChecksumDuration := time.Since(getSourceChecksumTime)
 
+	getTargetChecksumTime := time.Now()
 	targetChecksum, err := dbutil.GetCRC32Checksum(ctx, t.TargetTable.Conn, t.TargetTable.Schema, t.TargetTable.Table, t.TargetTable.info, chunk.Where, utils.StringsToInterfaces(chunk.Args))
 	if err != nil {
 		return false, errors.Trace(err)
 	}
+	getTargetChecksumDuration := time.Since(getTargetChecksumTime)
+
 	if sourceChecksum == targetChecksum {
-		log.Info("checksum is equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", chunk.Where), zap.Reflect("args", chunk.Args), zap.Int64("checksum", sourceChecksum))
+		log.Info("checksum is equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", dbutil.ReplacePlaceholder(chunk.Where, chunk.Args)), zap.Int64("checksum", sourceChecksum), zap.Duration("get source checksum cost", getSourceChecksumDuration), zap.Duration("get target checksum cost", getTargetChecksumDuration))
 		return true, nil
 	}
 
-	log.Warn("checksum is not equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", chunk.Where), zap.Reflect("args", chunk.Args), zap.Int64("source checksum", sourceChecksum), zap.Int64("target checksum", targetChecksum))
+	log.Warn("checksum is not equal", zap.String("table", dbutil.TableName(t.TargetTable.Schema, t.TargetTable.Table)), zap.String("where", dbutil.ReplacePlaceholder(chunk.Where, chunk.Args)), zap.Int64("source checksum", sourceChecksum), zap.Int64("target checksum", targetChecksum), zap.Duration("get source checksum cost", getSourceChecksumDuration), zap.Duration("get target checksum cost", getTargetChecksumDuration))
 
 	return false, nil
 }

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -177,6 +177,7 @@ func (t *TableDiff) CheckTableStruct(ctx context.Context) (bool, error) {
 			log.Warn("table struct is not equal", zap.String("reason", msg))
 			return false, nil
 		}
+		log.Info("table struct is equal", zap.Reflect("source", sourceTable.info), zap.Reflect("target", t.TargetTable.info))
 	}
 
 	return true, nil
@@ -602,7 +603,7 @@ func (t *TableDiff) compareRows(ctx context.Context, chunk *ChunkRange) (bool, e
 			delete(sourceMap, i)
 		}
 
-		// all the sources had read to the end, not data to return
+		// all the sources had read to the end, no data to return
 		if len(sourceRowDatas.Rows) == 0 {
 			return nil, nil
 		}

--- a/pkg/diff/merge.go
+++ b/pkg/diff/merge.go
@@ -25,7 +25,7 @@ import (
 // RowData is the struct of rows selected from mysql/tidb
 type RowData struct {
 	Data   map[string]*dbutil.ColumnData
-	Source string
+	Source int
 }
 
 // RowDatas is a heap of MergeItems.
@@ -100,6 +100,9 @@ func (r *RowDatas) Push(x interface{}) {
 
 // Pop implements heap.Interface's Pop function
 func (r *RowDatas) Pop() interface{} {
+	if len(r.Rows) == 0 {
+		return nil
+	}
 	old := r.Rows
 	n := len(old)
 	x := old[n-1]

--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	ctx := context.Background()
 	if !checkSyncState(ctx, cfg) {
-		log.Error("check failed!!!")
+		log.Info("check failed!!!")
 		os.Exit(1)
 	}
 	log.Info("check pass!!!")

--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	ctx := context.Background()
 	if !checkSyncState(ctx, cfg) {
-		log.Info("check failed!!!")
+		log.Warn("check failed!!!")
 		os.Exit(1)
 	}
 	log.Info("check pass!!!")

--- a/tests/sync_diff_inspector/run.sh
+++ b/tests/sync_diff_inspector/run.sh
@@ -36,6 +36,12 @@ sync_diff_inspector --config=./config_base.toml > $OUT_DIR/diff.log
 # doesn't contain the table's result in check report
 check_not_contains "[table=should_not_compare]" $OUT_DIR/diff.log
 
+mysql -uroot -h 127.0.0.1 -P 4000 -e "select state from sync_diff_inspector.summary where \`schema\`='diff_test' and \`table\`='test'" | grep "success"
+if [ $? == 1 ]; then
+    echo "the state is not success in summary table"
+    exit 1
+fi
+
 for script in ./*/run.sh; do
     test_name="$(basename "$(dirname "$script")")"
     echo "---------------------------------------"


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

1. Refine the performance
2. Optimize memory usage https://github.com/pingcap/tidb-tools/issues/356

### What is changed and how it works?

1. initial chunks information to the checkpoint table with batch insert SQL, it will save much time if have too many chunks.
2. calculate checksum in source and target database at the same time by use goroutine.
3. read data from the database only when needed, instead of select all the chunk's data, this will save memory usage.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)