### PR TITLE
sync_diff_inspector: fix the snapshot using the DateTime string

### DIFF
--- a/sync_diff_inspector/config.go
+++ b/sync_diff_inspector/config.go
@@ -17,6 +17,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
+	"strconv"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
@@ -291,10 +292,16 @@ func (c *Config) checkConfig() bool {
 		if !c.SourceDBCfg[i].Valid() {
 			return false
 		}
+		if c.SourceDBCfg[i].Snapshot != "" {
+			c.SourceDBCfg[i].Snapshot = strconv.Quote(c.SourceDBCfg[i].Snapshot)
+		}
 	}
 
 	if c.TargetDBCfg.InstanceID == "" {
 		c.TargetDBCfg.InstanceID = "target"
+	}
+	if c.TargetDBCfg.Snapshot != "" {
+		c.TargetDBCfg.Snapshot = strconv.Quote(c.TargetDBCfg.Snapshot)
 	}
 	if _, ok := sourceInstanceMap[c.TargetDBCfg.InstanceID]; ok {
 		log.Error("target has same instance id in source", zap.String("instance id", c.TargetDBCfg.InstanceID))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Tiny fix for the Snapshot using the DateTime string like "2020-01-01 20:20:20"
![image](https://user-images.githubusercontent.com/20888467/87069807-6e2c8000-c24a-11ea-9cf6-35a1648e2c84.png)


### What is changed and how it works?
Enclose **tidb_snapshot** in Double quotes `""` for adding it in the dbDSN

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 

Related changes

 - Need to cherry-pick to the release branch