### PR TITLE
diff: fix send on closed channel panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ define run_unit_test
 	@echo "running unit test for packages:" $(1)
 	$(FAILPOINT_ENABLE)
 	@export log_level=error; \
-	$(GOTEST) -cover $(PACKAGES) \
+	$(GOTEST) -cover $(1) \
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	$(FAILPOINT_DISABLE)
 endef

--- a/go.mod1
+++ b/go.mod1
@@ -19,6 +19,7 @@ require (
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
+	github.com/pingcap/failpoint v0.0.0-20200210140405-f8f9fb234798
 	github.com/pingcap/kvproto v0.0.0-20200409034505-a5af800ca2ef
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
 	github.com/pingcap/parser v0.0.0-20200410065024-81f3db8e6095

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -412,7 +412,6 @@ func (t *TableDiff) checkChunksDataEqual(ctx context.Context, filterByRand bool,
 
 func (t *TableDiff) checkChunkDataEqual(ctx context.Context, filterByRand bool, chunk *ChunkRange) (equal bool, err error) {
 	failpoint.Inject("CancelCheckChunkDataEqual", func(val failpoint.Value) {
-		log.Info("check chunk data equal failed", zap.String("failpoint", "CancelCheckChunkDataEqual"))
 		chunkID := val.(int)
 		if chunkID != chunk.ID {
 			return

--- a/tools.json
+++ b/tools.json
@@ -1,0 +1,9 @@
+{
+  "Tools": [
+    {
+      "Repository": "github.com/pingcap/failpoint/failpoint-ctl",
+      "Commit": "e7b1061e6e81d44326c449cf518992e0e2d47e98"
+    }
+  ],
+  "RetoolVersion": "1.3.7"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix issue https://github.com/pingcap/tidb-tools/issues/375

when cancel the context, the `CheckTableData` will return directly with channel `checkResultCh ` closed, but some `checkChunksDataEqual` goroutines are still running, they may send results to the closed channel.

### What is changed and how it works?

fix it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test