### PR TITLE
update go mod to fix compatibility issue

### DIFF
--- a/go.mod1
+++ b/go.mod1
@@ -12,9 +12,9 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce
 	github.com/pingcap/kvproto v0.0.0-20200706115936-1e0910aabe6c
 	github.com/pingcap/log v0.0.0-20200511115504-543df19646ad
-	github.com/pingcap/parser v0.0.0-20200729064743-5fe0b0fdf629
+	github.com/pingcap/parser v0.0.0-20200730092557-34a468e9b774
 	github.com/pingcap/pd/v4 v4.0.0-rc.2.0.20200714122454-1a64f969cb3c
-	github.com/pingcap/tidb v1.1.0-beta.0.20200729093508-ccfc9b2ad0dc
+	github.com/pingcap/tidb v1.1.0-beta.0.20200731004449-a63fa79d90c5
 	github.com/pingcap/tipb v0.0.0-20200618092958-4fad48b4c8c3
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738

--- a/go.sum1
+++ b/go.sum1
@@ -521,8 +521,8 @@ github.com/pingcap/parser v0.0.0-20200518090819-ec1e13b948b1/go.mod h1:vQdbJqobJ
 github.com/pingcap/parser v0.0.0-20200522094936-3b720a0512a6/go.mod h1:vQdbJqobJAgFyiRNNtXahpMoGWwPEuWciVEK5A20NS0=
 github.com/pingcap/parser v0.0.0-20200609110328-c65941b9fbb3/go.mod h1:vQdbJqobJAgFyiRNNtXahpMoGWwPEuWciVEK5A20NS0=
 github.com/pingcap/parser v0.0.0-20200623082809-b74301ac298b/go.mod h1:vQdbJqobJAgFyiRNNtXahpMoGWwPEuWciVEK5A20NS0=
-github.com/pingcap/parser v0.0.0-20200729064743-5fe0b0fdf629 h1:pBEzY0/NKPS5lZ2uo80KF+5M5al5j9GsYWrQBvDxmvY=
-github.com/pingcap/parser v0.0.0-20200729064743-5fe0b0fdf629/go.mod h1:vQdbJqobJAgFyiRNNtXahpMoGWwPEuWciVEK5A20NS0=
+github.com/pingcap/parser v0.0.0-20200730092557-34a468e9b774 h1:ch3VED+NQdsARfJUmNciIynhVbOot3be1pQcmftIrI4=
+github.com/pingcap/parser v0.0.0-20200730092557-34a468e9b774/go.mod h1:vQdbJqobJAgFyiRNNtXahpMoGWwPEuWciVEK5A20NS0=
 github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2 h1:JTzYYukREvxVSKW/ncrzNjFitd8snoQ/Xz32pw8i+s8=
 github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2/go.mod h1:s+utZtXDznOiL24VK0qGmtoHjjXNsscJx3m1n8cC56s=
 github.com/pingcap/pd/v4 v4.0.0-rc.2.0.20200520083007-2c251bd8f181/go.mod h1:q4HTx/bA8aKBa4S7L+SQKHvjRPXCRV0tA0yRw0qkZSA=
@@ -543,8 +543,8 @@ github.com/pingcap/tidb v1.1.0-beta.0.20200603101356-552e7709de0d/go.mod h1:wgu4
 github.com/pingcap/tidb v1.1.0-beta.0.20200604055950-efc1c154d098/go.mod h1:UMxsNE326wyfgFJCx6aerPRLj1/tGPYDBKS9T9NOHI8=
 github.com/pingcap/tidb v1.1.0-beta.0.20200610060912-f12cdc42010f/go.mod h1:jyXOvS9k0PTxYHju2OgySOe9FtydA52TiQ5bXAaKyQE=
 github.com/pingcap/tidb v1.1.0-beta.0.20200721005019-f5c6e59f0daf/go.mod h1:dYCOFXJsoqBumpxAyBqCG3WZriIY7JgeBZHgvfARDa8=
-github.com/pingcap/tidb v1.1.0-beta.0.20200729093508-ccfc9b2ad0dc h1:4XXsRSvMHRSDPX82+kJtP1JQM8rbvoSyVR9uWnWRo70=
-github.com/pingcap/tidb v1.1.0-beta.0.20200729093508-ccfc9b2ad0dc/go.mod h1:ONitS06YYLrPWZgRRmo2tAGzRup3OSr5WRMkqN8D9IY=
+github.com/pingcap/tidb v1.1.0-beta.0.20200731004449-a63fa79d90c5 h1:9I/TzJreppQ/QB/XsgDRidpGVj3Q+FYRYPI/PjXW7MM=
+github.com/pingcap/tidb v1.1.0-beta.0.20200731004449-a63fa79d90c5/go.mod h1:tGL4bibikUVvAbzS9rdcqBg2AIVRttZYmGCl0+wAUQk=
 github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200421113014-507d2bb3a15e+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200514040632-f76b3e428e19+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/parser/pull/947 changes some const value of online DDL state, and https://github.com/pingcap/parser/pull/952  reverts it. So we keep parser and tidb dependencies up to date

### What is changed and how it works?

update go mod

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
