### PR TITLE
解决分库分表时,延迟关闭rows导致循环多次堵塞的问题

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -571,7 +571,7 @@ func (t *TableDiff) compareRows(ctx context.Context, chunk *ChunkRange) (bool, e
 		if err != nil {
 			return false, errors.Trace(err)
 		}
-		defer rows.Close()
+		rows.Close()
 
 		sourceRows[i] = rows
 		sourceHaveData[i] = false


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
当配置分库分表时,每当t.SourceTables有多个,for循环里执行到第二次及以上时,会卡在rows, err := db.QueryContext(ctx, query, args...)这里没有执行下去.

### What is changed and how it works?
取消延迟关闭rows,改为每次拿到结果就关闭

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note