### PR TITLE
test: remove outdated `tidb-instance-id` in config

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -440,7 +440,7 @@ func GetBucketsInfo(ctx context.Context, db *sql.DB, schema, table string, table
 
 	for rows.Next() {
 		var dbName, tableName, partitionName, columnName, lowerBound, upperBound sql.NullString
-		var isIndex, bucketID, count, repeats sql.NullInt64
+		var isIndex, bucketID, count, repeats, ndv sql.NullInt64
 
 		// add partiton_name in new version
 		switch len(cols) {
@@ -448,6 +448,8 @@ func GetBucketsInfo(ctx context.Context, db *sql.DB, schema, table string, table
 			err = rows.Scan(&dbName, &tableName, &columnName, &isIndex, &bucketID, &count, &repeats, &lowerBound, &upperBound)
 		case 10:
 			err = rows.Scan(&dbName, &tableName, &partitionName, &columnName, &isIndex, &bucketID, &count, &repeats, &lowerBound, &upperBound)
+		case 11:
+			err = rows.Scan(&dbName, &tableName, &partitionName, &columnName, &isIndex, &bucketID, &count, &repeats, &lowerBound, &upperBound, &ndv)
 		default:
 			return nil, errors.New("Unknown struct for buckets info")
 		}

--- a/tests/sync_diff_inspector/ignore_column/config.toml
+++ b/tests/sync_diff_inspector/ignore_column/config.toml
@@ -24,9 +24,6 @@ use-checkpoint = false
 # the name of the file which saves sqls used to fix different data.
 fix-sql-file = "/tmp/tidb_tools_test/sync_diff_inspector/fix.sql"
 
-# use this tidb's statistics information to split chunk
-tidb-instance-id = "target-1"
-
 # tables need to check.
 [[check-tables]]
 # schema name in target database.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

after https://github.com/pingcap/tidb-tools/pull/409, not-used config items will cause errors. And `tidb-instance-id` is removed in https://github.com/pingcap/tidb-tools/pull/249 but left in an intergration test config file.

### What is changed and how it works?

remove it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects


Related changes
