### PR TITLE
diff: increase connection limit according to number of shard tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ endef
 
 build: prepare version check importer sync_diff_inspector ddl_checker finish
 
+
+failpoint-enable: retool_setup
+	$(FAILPOINT_ENABLE)
+
+failpoint-disable: retool_setup
+	$(FAILPOINT_DISABLE)
+
 retool_setup:
 	@echo "setup retool"
 	go get github.com/twitchtv/retool

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -621,9 +621,6 @@ func (t *TableDiff) compareRows(ctx context.Context, chunk *ChunkRange) (bool, e
 
 				}
 				// still don't have data, means the rows is read to the end, so delete the source
-				if err := sourceRows[i].Close(); err != nil {
-					return nil, err
-				}
 				needDeleteSource = append(needDeleteSource, i)
 			}
 		}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -567,13 +567,12 @@ func (t *TableDiff) compareRows(ctx context.Context, chunk *ChunkRange) (bool, e
 	defer targetRows.Close()
 
 	for i, sourceTable := range t.SourceTables {
-		rows, _, err2 := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, chunk.Where, args, t.Collation)
-		if err2 != nil {
-			return false, errors.Trace(err2)
+		rows, _, err := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, chunk.Where, args, t.Collation)
+		if err != nil {
+			return false, errors.Trace(err)
 		}
-		if err2 = rows.Close(); err2 != nil {
-			return false, errors.Trace(err2)
-		}
+
+		defer rows.Close()
 
 		sourceRows[i] = rows
 		sourceHaveData[i] = false

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -567,11 +567,13 @@ func (t *TableDiff) compareRows(ctx context.Context, chunk *ChunkRange) (bool, e
 	defer targetRows.Close()
 
 	for i, sourceTable := range t.SourceTables {
-		rows, _, err := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, chunk.Where, args, t.Collation)
-		if err != nil {
-			return false, errors.Trace(err)
+		rows, _, err2 := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, chunk.Where, args, t.Collation)
+		if err2 != nil {
+			return false, errors.Trace(err2)
 		}
-		defer rows.Close()
+		if err2 = rows.Close(); err2 != nil {
+			return false, errors.Trace(err2)
+		}
 
 		sourceRows[i] = rows
 		sourceHaveData[i] = false

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -567,12 +567,13 @@ func (t *TableDiff) compareRows(ctx context.Context, chunk *ChunkRange) (bool, e
 	defer targetRows.Close()
 
 	for i, sourceTable := range t.SourceTables {
-		rows, _, err := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, chunk.Where, args, t.Collation)
-		if err != nil {
-			return false, errors.Trace(err)
+		rows, _, err2 := getChunkRows(ctx, sourceTable.Conn, sourceTable.Schema, sourceTable.Table, sourceTable.info, chunk.Where, args, t.Collation)
+		if err2 != nil {
+			return false, errors.Trace(err2)
 		}
-
-		defer rows.Close()
+		if err2 = rows.Close(); err2 != nil {
+			return false, errors.Trace(err2)
+		}
 
 		sourceRows[i] = rows
 		sourceHaveData[i] = false

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -404,6 +404,37 @@ func (df *Diff) AdjustTableConfig(cfg *Config) (err error) {
 		df.tables[table.Schema][table.Table].Collation = table.Collation
 	}
 
+	// we need to increase max open connections for upstream, because one chunk needs accessing N shard tables in one
+	// upstream, and there are `CheckThreadCount` processing chunks. At most we need N*`CheckThreadCount` connections
+	// for an upstream
+	// instanceID -> max number of upstream shard tables every target table
+	maxNumShardTablesOneRun := map[string]int{}
+	for _, targetTables := range df.tables {
+		for _, sourceCfg := range targetTables {
+			upstreamCount := map[string]int{}
+			for _, sourceTables := range sourceCfg.SourceTables {
+				upstreamCount[sourceTables.InstanceID]++
+			}
+			for id, count := range upstreamCount {
+				if count > maxNumShardTablesOneRun[id] {
+					maxNumShardTablesOneRun[id] = count
+				}
+			}
+		}
+	}
+
+	for instanceId, count := range maxNumShardTablesOneRun {
+		db := df.sourceDBs[instanceId].Conn
+		if db == nil {
+			return errors.Errorf("didn't found sourceDB for instance %s", instanceId)
+		}
+		log.Info("will increase connection configurations for DB of instance",
+			zap.String("instance id", instanceId),
+			zap.Int("connection limit", count*df.checkThreadCount))
+		db.SetMaxOpenConns(count * df.checkThreadCount)
+		db.SetMaxIdleConns(count * df.checkThreadCount)
+	}
+
 	return nil
 }
 

--- a/tests/sync_diff_inspector/shard/config.toml
+++ b/tests/sync_diff_inspector/shard/config.toml
@@ -9,7 +9,8 @@ log-level = "debug"
 chunk-size = 1000
 
 # how many goroutines are created to check data
-check-thread-count = 4
+# before #412, sync-diff-inspector will SetMaxOpenConns to 1, so processing 2 shard tables in upstream will block
+check-thread-count = 1
 
 # sampling check percent, for example 10 means only check 10% data
 sample-percent = 100


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #411

### What is changed and how it works?
one chunk need accessing every shard tables in one upstream,  and there are `CheckThreadCount` simultaneously processing chunks. Adjust connection limit to fix the worst case which needs `CheckThreadCount` * number of shard tables connections.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (an integration test of DM could pass)

Code changes

Side effects

Related changes

 - Need to be included in the release note