### PR TITLE
diff: keep priority for "range" filter

### DIFF
--- a/pkg/diff/chunk.go
+++ b/pkg/diff/chunk.go
@@ -249,7 +249,7 @@ func splitRangeByRandom(db *sql.DB, chunk *ChunkRange, count int, schema string,
 	}
 
 	chunkLimits, args := chunk.toString(collation)
-	limitRange := fmt.Sprintf("%s AND %s", chunkLimits, limits)
+	limitRange := fmt.Sprintf("(%s) AND %s", chunkLimits, limits)
 
 	randomValues := make([][]string, len(columns))
 	for i, column := range columns {
@@ -462,7 +462,7 @@ func SplitChunks(ctx context.Context, table *TableInstance, splitFields, limits 
 	for i, chunk := range chunks {
 		conditions, args := chunk.toString(collation)
 		chunk.ID = i
-		chunk.Where = fmt.Sprintf("(%s AND %s)", conditions, limits)
+		chunk.Where = fmt.Sprintf("((%s) AND %s)", conditions, limits)
 		chunk.Args = args
 		chunk.State = notCheckedState
 	}

--- a/pkg/diff/chunk_test.go
+++ b/pkg/diff/chunk_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb-tools/pkg/dbutil"
 	"github.com/pingcap/tidb-tools/pkg/importer"
+	"github.com/pingcap/tidb-tools/pkg/utils"
 )
 
 var _ = Suite(&testChunkSuite{})
@@ -189,4 +190,72 @@ func (*testChunkSuite) TestChunkToString(c *C) {
 	for i, arg := range args {
 		c.Assert(arg, Equals, expectArgs[i])
 	}
+}
+
+func (*testChunkSuite) TestRangeLimit(c *C) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	conn, err := createConn()
+	c.Assert(err, IsNil)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `test`")
+	c.Assert(err, IsNil)
+
+	_, err = conn.ExecContext(ctx, "DROP TABLE IF EXISTS `test`.`test_range`")
+	c.Assert(err, IsNil)
+
+	createTableSQL := `CREATE TABLE test.test_range (
+		a int NOT NULL,
+		b datetime DEFAULT NULL,
+		c time DEFAULT NULL,
+		d varchar(10) COLLATE latin1_bin DEFAULT NULL,
+		e int(10) DEFAULT NULL,
+		h year(4) DEFAULT NULL,
+		PRIMARY KEY (a))`
+
+	// will generate 0-9 at column `a`
+	dataCount := 10
+	cfg := &importer.Config{
+		TableSQL:    createTableSQL,
+		WorkerCount: 5,
+		JobCount:    dataCount,
+		Batch:       100,
+		DBCfg:       dbutil.GetDBConfigFromEnv("test"),
+	}
+
+	// generate data for test.test_chunk
+	importer.DoProcess(cfg)
+	defer conn.ExecContext(ctx, "DROP TABLE IF EXISTS `test`.`test_range`")
+
+	// only work on tidb, so don't assert err here
+	_, _ = conn.ExecContext(ctx, "ANALYZE TABLE `test`.`test_range`")
+
+	tableInfo, err := dbutil.GetTableInfo(ctx, conn, "test", "test_range")
+	c.Assert(err, IsNil)
+
+	tableInstance := &TableInstance{
+		Conn:   conn,
+		Schema: "test",
+		Table:  "test_range",
+		info:   tableInfo,
+	}
+
+	c.Assert(createCheckpointTable(ctx, conn), IsNil)
+	chunks, err := SplitChunks(ctx, tableInstance, "a,d", "a > 7", 1, "", false, conn)
+	c.Assert(err, IsNil)
+	defer conn.ExecContext(ctx, "DROP DATABASE sync_diff_inspector")
+	// a > 7 and chunkSize = 1 should return 2 chunk
+	c.Assert(chunks, HasLen, 2)
+	count := 0
+
+	for _, chunk := range chunks {
+		rows, _, err := getChunkRows(ctx, conn, "test", "test_range", tableInfo, chunk.Where, utils.StringsToInterfaces(chunk.Args), "")
+		c.Assert(err, IsNil)
+		for rows.Next() {
+			count++
+		}
+	}
+	c.Assert(count, Equals, 2)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tidb-tools/issues/413

### What is changed and how it works?
before this PR, if user specified `range = "id >= 4001 and id < 6001"` the WHERE clause may be `WHERE ((`id` < ?) OR (`id` = ? AND `name` <= ?) AND id >= 4001 and id < 6001)`, we could see that first `(`id` < ?)` will shortcut rest of WHERE

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes

 - Need to be included in the release note
   修复了 sync-diff-inspector 配置中`range`可能不生效的问题