### PR TITLE
schemacmp: set flen and decimal to singleton to avoid dm data mismatch

### DIFF
--- a/pkg/schemacmp/table_test.go
+++ b/pkg/schemacmp/table_test.go
@@ -240,8 +240,11 @@ func (s *tableSchema) TestJoinSchemas(c *C) {
 			name: "DM_055",
 			a:    "CREATE TABLE tb1 (a INT, b VARCHAR(10))",
 			b:    "CREATE TABLE tb2 (a BIGINT, b VARCHAR(10))",
-			cmp:  -1,
-			join: "CREATE TABLE tb2 (a BIGINT, b VARCHAR(10))",
+			// FIXME: introduced in https://github.com/pingcap/tidb-tools/pull/415, revert this after DM support add different Flen columns
+			// cmp:  -1,
+			// join: "CREATE TABLE tb2 (a BIGINT, b VARCHAR(10))",
+			cmpErr:  `.*"a".*distinct singletons.*`,
+			joinErr: `.*"a".*distinct singletons.*`,
 		},
 		{
 			name:   "DM_057",
@@ -387,8 +390,11 @@ func (s *tableSchema) TestJoinSchemas(c *C) {
 			name: "test case 2020-04-28-blob",
 			a:    "CREATE TABLE tb1 (a BLOB, b VARCHAR(10))",
 			b:    "CREATE TABLE tb2 (a LONGBLOB, b VARCHAR(10))",
-			cmp:  -1,
-			join: "CREATE TABLE tb2 (a LONGBLOB, b VARCHAR(10))",
+			// FIXME: introduced in https://github.com/pingcap/tidb-tools/pull/415, revert this after DM support add different Flen columns
+			// cmp:  -1,
+			// join: "CREATE TABLE tb2 (a LONGBLOB, b VARCHAR(10))",
+			cmpErr:  `.*"a".*distinct singletons.*`,
+			joinErr: `.*"a".*distinct singletons.*`,
 		},
 	}
 

--- a/pkg/schemacmp/type.go
+++ b/pkg/schemacmp/type.go
@@ -58,13 +58,17 @@ func decodeAntiKeys(encoded byte) uint {
 // encodeTypeTpAsLattice
 func encodeFieldTypeToLattice(ft *types.FieldType) Tuple {
 	var flen, dec Lattice
-	if ft.Tp == mysql.TypeNewDecimal {
-		flen = Singleton(ft.Flen)
-		dec = Singleton(ft.Decimal)
-	} else {
-		flen = Int(ft.Flen)
-		dec = Int(ft.Decimal)
-	}
+	// FIXME: set flen & dec to Singleton. When dm add column with different flen, dm can't transfer
+	//  the sql to modify the column to a larger flen. Change this back to Int after DM support this.
+	// if ft.Tp == mysql.TypeNewDecimal {
+	// 	flen = Singleton(ft.Flen)
+	// 	dec = Singleton(ft.Decimal)
+	// } else {
+	//	flen = Int(ft.Flen)
+	//	dec = Int(ft.Decimal)
+	// }
+	flen = Singleton(ft.Flen)
+	dec = Singleton(ft.Decimal)
 
 	var defVal Lattice
 	if mysql.HasAutoIncrementFlag(ft.Flag) || !mysql.HasNoDefaultValueFlag(ft.Flag) {

--- a/pkg/schemacmp/type_test.go
+++ b/pkg/schemacmp/type_test.go
@@ -43,7 +43,7 @@ var (
 	typeIntNotNull = &types.FieldType{
 		Tp:      mysql.TypeLong,
 		Flag:    mysql.NoDefaultValueFlag | mysql.NotNullFlag,
-		Flen:    10,
+		Flen:    11,
 		Decimal: 0,
 		Charset: binary,
 		Collate: binary,
@@ -364,16 +364,22 @@ func (*typeSchema) TestTypeCompareJoin(c *C) {
 		joinError     string
 	}{
 		{
-			a:             typeInt,
-			b:             typeInt22,
-			compareResult: -1,
-			join:          typeInt22,
+			a: typeInt,
+			b: typeInt22,
+			// FIXME: introduced in https://github.com/pingcap/tidb-tools/pull/415, revert this after DM support add different Flen columns
+			// compareResult: -1,
+			// join:          typeInt22,
+			compareError: `at tuple index \d+: distinct singletons.*`,
+			joinError:    `at tuple index \d+: distinct singletons.*`,
 		},
 		{
-			a:             typeInt1,
-			b:             typeInt,
-			compareResult: -1,
-			join:          typeInt,
+			a: typeInt1,
+			b: typeInt,
+			// FIXME: introduced in https://github.com/pingcap/tidb-tools/pull/415, revert this after DM support add different Flen columns
+			// compareResult: -1,
+			// join:          typeInt,
+			compareError: `at tuple index \d+: distinct singletons.*`,
+			joinError:    `at tuple index \d+: distinct singletons.*`,
 		},
 		{
 			a:             typeInt,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
set flen & dec to Singleton.

### What is changed and how it works?
When dm add a column with different flen, dm can't transfer the sql to modify the column to a larger flen. Change this back to Int after DM support this.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


