### PR TITLE
schemacmp: keep column flag consistent with MySQL

### DIFF
--- a/pkg/schemacmp/table_test.go
+++ b/pkg/schemacmp/table_test.go
@@ -400,6 +400,48 @@ func (s *tableSchema) TestJoinSchemas(c *C) {
 			cmp:  -1,
 			join: "CREATE TABLE tb2 (a LONGBLOB, b VARCHAR(10))",
 		},
+		{
+			name: "join equal single primary key",
+			a:    "CREATE TABLE t(a INT, b INT, PRIMARY KEY(a))",
+			b:    "CREATE TABLE t(a INT, b INT, PRIMARY KEY(a))",
+			cmp:  0,
+			join: "CREATE TABLE t(a INT, b INT, PRIMARY KEY(a))",
+		},
+		{
+			name: "join equal composite primary key",
+			a:    "CREATE TABLE t(a INT, b INT, c INT, PRIMARY KEY(a, b))",
+			b:    "CREATE TABLE t(a INT, b INT, c INT, PRIMARY KEY(a, b))",
+			cmp:  0,
+			join: "CREATE TABLE t(a INT, b INT, c INT, PRIMARY KEY(a, b))",
+		},
+		{
+			name: "join equal single index",
+			a:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, INDEX idx_b(b))",
+			b:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, INDEX idx_b(b))",
+			cmp:  0,
+			join: "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, INDEX idx_b(b))",
+		},
+		{
+			name: "join equal unique index",
+			a:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, UNIQUE KEY uni_b(b))",
+			b:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, UNIQUE KEY uni_b(b))",
+			cmp:  0,
+			join: "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, UNIQUE KEY uni_b(b))",
+		},
+		{
+			name: "join equal composite index",
+			a:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, INDEX idx_bc(b, c))",
+			b:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, INDEX idx_bc(b, c))",
+			cmp:  0,
+			join: "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, INDEX idx_bc(b, c))",
+		},
+		{
+			name: "join equal composite unique index",
+			a:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, UNIQUE INDEX idx_bc(b, c))",
+			b:    "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, UNIQUE INDEX idx_bc(b, c))",
+			cmp:  0,
+			join: "CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT, UNIQUE INDEX idx_bc(b, c))",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

From TiDB [ddl_api](https://github.com/pingcap/tidb/blob/080ed4ee7b5b492fcc17bdc881100f3478aa7118/ddl/ddl_api.go#L292), if a index has multiple columns, only the first column can be applied the MultipleKeyFlag. However, schemacmp.Join applies flag to all the index columns. It causes some strange behavior. For example,
```golang
a := toTableInfo("create table t(a int primary key, b int, c int, d int, e int, f int, unique key uni_bc(b,c), unique key uni_d(d), index idx_ef(e,f))")
b := toTableInfo("create table t(a int primary key, b int, c int, d int, e int, f int, unique key uni_bc(b,c), unique key uni_d(d), index idx_ef(e,f))")
aa := schemacmp.Encode(a)
bb := schemacmp.Encode(b)
joined, _ := aa.Join(bb)
cmp, err := aa.Compare(joined)
assert(cmp == 0 && err == nil) // failed
```
This pr tries to  keep column flag consistent with TiDB & MySQL after joined, so that the joined table of two same table is equal to the original table.

### What is changed and how it works?

Keep column flag consistent with MySQL after joined.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes

Side effects

Related changes
