### PR TITLE
tidb-binlog/: fix make check

### DIFF
--- a/tidb-binlog/pump_client/bench_test.go
+++ b/tidb-binlog/pump_client/bench_test.go
@@ -57,7 +57,8 @@ func writeFakeBinlog(b *testing.B, pumpClient *PumpsClient, threadCount int, num
 				}
 				err := pumpClient.WriteBinlog(pBinlog)
 				if err != nil {
-					b.Fatal(err)
+					b.Error(err)
+					return
 				}
 
 				cBinlog := &pb.Binlog{
@@ -67,7 +68,8 @@ func writeFakeBinlog(b *testing.B, pumpClient *PumpsClient, threadCount int, num
 				}
 				err = pumpClient.WriteBinlog(cBinlog)
 				if err != nil {
-					b.Fatal(err)
+					b.Error(err)
+					return
 				}
 			}
 			wg.Done()
@@ -81,7 +83,8 @@ func createMockPumpsClientAndServer(b *testing.B) (*PumpsClient, *mockPumpServer
 	addr := "127.0.0.1:15049"
 	pumpServer, err := createMockPumpServer(addr, "tcp", false)
 	if err != nil {
-		b.Fatal(err)
+		b.Error(err)
+		return nil, nil
 	}
 
 	opt := grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
@@ -90,10 +93,12 @@ func createMockPumpsClientAndServer(b *testing.B) (*PumpsClient, *mockPumpServer
 
 	clientCon, err := grpc.Dial(addr, opt, grpc.WithInsecure())
 	if err != nil {
-		b.Fatal(err)
+		b.Error(err)
+		return nil, nil
 	}
 	if clientCon == nil {
-		b.Fatal("grpc client is nil")
+		b.Error("grpc client is nil")
+		return nil, nil
 	}
 	pumpClient := mockPumpsClient(pb.NewPumpClient(clientCon), false)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make check failed when making on arm.
```

[2021-03-20T01:06:54.452Z] + make build

[2021-03-20T01:06:54.452Z] cp go.mod1 go.mod

[2021-03-20T01:06:54.452Z] cp go.sum1 go.sum

[2021-03-20T01:06:54.452Z] GO111MODULE=on go version

[2021-03-20T01:06:54.452Z] go version go1.16.2 linux/arm64

[2021-03-20T01:06:54.452Z] gofmt (simplify)

[2021-03-20T01:06:54.452Z] #go get github.com/golang/lint/golint

[2021-03-20T01:06:54.452Z] vet

[2021-03-20T01:07:04.541Z] # github.com/pingcap/tidb-tools/tidb-binlog/pump_client

[2021-03-20T01:07:04.541Z] tidb-binlog/pump_client/bench_test.go:60:6: call to (*B).Fatal from a non-test goroutine

[2021-03-20T01:07:04.541Z] tidb-binlog/pump_client/bench_test.go:70:6: call to (*B).Fatal from a non-test goroutine

[2021-03-20T01:07:36.564Z] make: *** [check] Error 2

script returned exit code 2
```

### What is changed and how it works?
Change `b.Fatal` to `b.Error` like this. https://github.com/minio/minio/pull/6682

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
