### PR TITLE
schemacmp: skip empty charset and collate in table.String()

### DIFF
--- a/pkg/schemacmp/table.go
+++ b/pkg/schemacmp/table.go
@@ -330,11 +330,15 @@ func restoreTableInfoFromUnwrapped(ctx *format.RestoreCtx, table []interface{}, 
 		restoreIndexInfoFromUnwrapped(ctx, index, indexName)
 	}
 
-	ctx.WritePlain(") ")
-	ctx.WriteKeyWord("CHARSET ")
-	ctx.WriteKeyWord(table[tableInfoTupleIndexCharset].(string))
-	ctx.WriteKeyWord(" COLLATE ")
-	ctx.WriteKeyWord(table[tableInfoTupleIndexCollate].(string))
+	ctx.WritePlain(")")
+	if charset := table[tableInfoTupleIndexCharset].(string); charset != "" {
+		ctx.WriteKeyWord(" CHARSET ")
+		ctx.WriteKeyWord(charset)
+	}
+	if collate := table[tableInfoTupleIndexCollate].(string); collate != "" {
+		ctx.WriteKeyWord(" COLLATE ")
+		ctx.WriteKeyWord(collate)
+	}
 	if bits := table[tableInfoTupleIndexShardRowIDBits].(uint64); bits > 0 {
 		ctx.WriteKeyWord(" SHARD_ROW_ID_BITS ")
 		ctx.WritePlainf("%d", bits)

--- a/pkg/schemacmp/table_test.go
+++ b/pkg/schemacmp/table_test.go
@@ -530,6 +530,8 @@ func (s *tableSchema) TestTableString(c *C) {
 			sql := strings.ToLower(schemacmp.Encode(ti).String())
 			c.Assert(strings.Contains(sql, "charset"), Equals, charset != "")
 			c.Assert(strings.Contains(sql, "collate"), Equals, collate != "")
+			_, err := s.toTableInfo(sql)
+			c.Assert(err, IsNil)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When table's charset or collate is empty, table.String() still writes charset or collate keyword, such as `CREATE TABLE tbl (id INT) CHARSET  COLLATE`, which is not a valid sql syntax.

### What is changed and how it works?i

Skip charset or collate keyword when it is empty.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes


Side effects


Related changes

