### PR TITLE
filter: add another Apply function for filter to return the original value

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -267,7 +267,7 @@ func (f *Filter) Apply(stbs []*Table) []*Table {
 		if !f.caseSensitive {
 			newTb = &Table{
 				Schema: strings.ToLower(newTb.Schema),
-				Name: strings.ToLower(newTb.Name),
+				Name:   strings.ToLower(newTb.Name),
 			}
 		}
 

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -227,7 +227,8 @@ func (f *Filter) initTableRule(dbStr, tableStr string, isAllowList bool) error {
 	return nil
 }
 
-// ApplyOn applies filter rules on tables
+// deprecated
+// ApplyOn applies filter rules on tables and convert schema/table name to lower case if not caseSensitive
 // rules like
 // https://dev.mysql.com/doc/refman/8.0/en/replication-rules-table-options.html
 // https://dev.mysql.com/doc/refman/8.0/en/replication-rules-db-options.html
@@ -249,6 +250,31 @@ func (f *Filter) ApplyOn(stbs []*Table) []*Table {
 		}
 	}
 
+	return tbs
+}
+
+// ApplyOn applies filter rules on tables
+// rules like
+// https://dev.mysql.com/doc/refman/8.0/en/replication-rules-table-options.html
+// https://dev.mysql.com/doc/refman/8.0/en/replication-rules-db-options.html
+func (f *Filter) Apply(stbs []*Table) []*Table {
+	if f == nil || f.rules == nil {
+		return stbs
+	}
+	tbs := make([]*Table, 0)
+	for _, tb := range stbs {
+		newTb := tb
+		if !f.caseSensitive {
+			newTb = &Table{
+				Schema: strings.ToLower(newTb.Schema),
+				Name: strings.ToLower(newTb.Name),
+			}
+		}
+
+		if f.Match(newTb) {
+			tbs = append(tbs, tb)
+		}
+	}
 	return tbs
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Add a new `Filter.Apply` method to avoid change the original schema/table name to lower case in case-insensitive mode
- deprecate the `Filter.ApplyOn` method, caller should not depend on the side effect

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

Related changes