### PR TITLE
sync-diff: fix the problem that sync diff data is null

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -235,12 +235,14 @@ func GetRandomValues(ctx context.Context, db *sql.DB, schemaName, table, column 
 
 	randomValue := make([]string, 0, num)
 	for rows.Next() {
-		var value string
+		var value sql.NullString
 		err = rows.Scan(&value)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		randomValue = append(randomValue, value)
+		if value.Valid {
+			randomValue = append(randomValue, value.String)
+		}
 	}
 
 	return randomValue, errors.Trace(rows.Err())

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -937,6 +937,16 @@ func compareData(map1, map2 map[string]*dbutil.ColumnData, orderKeyCols []*model
 			}
 			break
 
+		} else if data1.IsNull || data2.IsNull {
+			if data1.IsNull && data2.IsNull {
+				continue
+			}
+			if data1.IsNull {
+				cmp = -1
+			} else if data2.IsNull {
+				cmp = 1
+			}
+			break
 		} else {
 			num1, err1 := strconv.ParseFloat(string(data1.Data), 64)
 			num2, err2 := strconv.ParseFloat(string(data2.Data), 64)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When some return data from mysql is null sync-diff will fail.

### What is changed and how it works?
sync-diff: fix the problem that sync diff data is null

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch