### PR TITLE
*: Clear redundant log methods

### DIFF
--- a/pkg/ddl-checker/executable_checker.go
+++ b/pkg/ddl-checker/executable_checker.go
@@ -36,7 +36,7 @@ type ExecutableChecker struct {
 
 // NewExecutableChecker creates a new ExecutableChecker
 func NewExecutableChecker() (*ExecutableChecker, error) {
-	logutil.InitZapLogger(&logutil.LogConfig{
+	logutil.InitLogger(&logutil.LogConfig{
 		Config: log.Config{
 			Level: "error",
 		},

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -613,8 +613,3 @@ func copyPumps(pumps map[string]*PumpStatus) []*PumpStatus {
 
 	return ps
 }
-
-// InitLogger initializes logger.
-func InitLogger(cfg *logutil.LogConfig) error {
-	return logutil.InitZapLogger(cfg)
-}

--- a/tidb-binlog/pump_client/client.go
+++ b/tidb-binlog/pump_client/client.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb-tools/pkg/etcd"
 	"github.com/pingcap/tidb-tools/pkg/utils"
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
-	"github.com/pingcap/tidb/util/logutil"
 	pb "github.com/pingcap/tipb/go-binlog"
 	pd "github.com/tikv/pd/client"
 	"go.etcd.io/etcd/mvcc/mvccpb"


### PR DESCRIPTION
### What problem does this PR solve?

Based on https://github.com/pingcap/tidb/pull/25381

close https://github.com/pingcap/tidb-tools/issues/445

Clear redundant log methods.

### What is changed and how it works?

* Remove redundant `InitLogger` with is the same as `logutil. InitLogger` in tidb.
* Replace `InitZapLogger` with `InitLogger`
