### PR TITLE
sync_diff_inspector: make exclude table support regex

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -9,8 +9,8 @@ import (
 )
 
 // SliceToMap converts slice to map
-func SliceToMap(slice []string) map[string]interface{} {
-	sMap := make(map[string]interface{})
+func SliceToMap(slice []string) map[string]struct{} {
+	sMap := make(map[string]struct{})
 	for _, str := range slice {
 		sMap[str] = struct{}{}
 	}

--- a/sync_diff_inspector/config.toml
+++ b/sync_diff_inspector/config.toml
@@ -61,6 +61,10 @@ fix-sql-file = "fix.sql"
     # tables that should be exclude when checked
     exclude-tables = ["a_table", "should_not_compare"]
 
+    # support regular expression, must start with '~'.
+    # for example, this config will check tables with prefix 'test'.
+    # tables = ["~^should_not_compare.*"]
+
 # schema and table in table-config must be contained in check-tables.
 # a example for comparing table with same schema and table name.
 [[table-config]]

--- a/sync_diff_inspector/config.toml
+++ b/sync_diff_inspector/config.toml
@@ -17,7 +17,7 @@ check-thread-count = 4
 sample-percent = 100
 
 # calculate the data's checksum, and compare data by checksum.
-# set false if want to comapre the data directly
+# set false if want to compare the data directly
 use-checksum = true
 
 # set true if just want compare data by checksum, will skip select data when checksum is not equal.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When we try to exclude some tables, we need to write them one by one which is inconvenient.

### What is changed and how it works?
make `check-tables.exclude_table` support regex

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```toml
[[check-tables]]
schema = "chauncy"
tables = ["~.*"]
exclude-tables = ["~t[2-3]"]
```
Run with this config and t2, t3 are not equal. diff can pass.

Related changes

 - Need to update the documentation
