### PR TITLE
abstract sql.DB to interface 

### DIFF
--- a/pkg/check/table_structure.go
+++ b/pkg/check/table_structure.go
@@ -148,8 +148,8 @@ func (c *TablesChecker) Name() string {
 	return "table structure compatibility check"
 }
 
-func (c *TablesChecker) checkCreateSQL(statement string) []*incompatibilityOption {
-	parser2, err := dbutil.GetParserForDB(c.db)
+func (c *TablesChecker) checkCreateSQL(ctx context.Context, statement string) []*incompatibilityOption {
+	parser2, err := dbutil.GetParserForDB(ctx, c.db)
 	if err != nil {
 		return []*incompatibilityOption{
 			{
@@ -310,7 +310,7 @@ func (c *ShardingTablesChecker) Check(ctx context.Context) *Result {
 			return r
 		}
 
-		parser2, err := dbutil.GetParserForDB(db)
+		parser2, err := dbutil.GetParserForDB(ctx, db)
 		if err != nil {
 			markCheckError(r, err)
 			r.Extra = fmt.Sprintf("fail to get parser for instance %s on sharding %s", instance, c.name)

--- a/pkg/check/table_structure.go
+++ b/pkg/check/table_structure.go
@@ -107,7 +107,7 @@ func (c *TablesChecker) Check(ctx context.Context) *Result {
 				return r
 			}
 
-			opts := c.checkCreateSQL(statement)
+			opts := c.checkCreateSQL(ctx, statement)
 			if len(opts) > 0 {
 				options[tableName] = opts
 				statements[tableName] = statement

--- a/pkg/dbutil/index.go
+++ b/pkg/dbutil/index.go
@@ -2,7 +2,6 @@ package dbutil
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sort"
 	"strconv"
@@ -22,7 +21,7 @@ type IndexInfo struct {
 }
 
 // ShowIndex returns result of executing `show index`
-func ShowIndex(ctx context.Context, db *sql.DB, schemaName string, table string) ([]*IndexInfo, error) {
+func ShowIndex(ctx context.Context, db QueryExecutor, schemaName string, table string) ([]*IndexInfo, error) {
 	/*
 		show index example result:
 		mysql> show index from test;
@@ -73,7 +72,7 @@ func ShowIndex(ctx context.Context, db *sql.DB, schemaName string, table string)
 // * primary key
 // * unique key
 // * normal index which has max cardinality
-func FindSuitableColumnWithIndex(ctx context.Context, db *sql.DB, schemaName string, tableInfo *model.TableInfo) (*model.ColumnInfo, error) {
+func FindSuitableColumnWithIndex(ctx context.Context, db QueryExecutor, schemaName string, tableInfo *model.TableInfo) (*model.ColumnInfo, error) {
 	// find primary key
 	for _, index := range tableInfo.Indices {
 		if index.Primary {

--- a/pkg/dbutil/interface.go
+++ b/pkg/dbutil/interface.go
@@ -11,11 +11,17 @@ var (
 	_ DBExecutor = &sql.Conn{}
 )
 
+// QueryExecutor is a interface for execute Query from a database.
+//
+// in generate the implement should be *sql.DB or *sql.Conn
 type QueryExecutor interface {
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
+// DBExecutor is a interface for execute read and write statements from a database.
+//
+// in generate the implement should be *sql.DB or *sql.Conn
 type DBExecutor interface {
 	QueryExecutor
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)

--- a/pkg/dbutil/interface.go
+++ b/pkg/dbutil/interface.go
@@ -1,0 +1,23 @@
+package dbutil
+
+import (
+	"context"
+	"database/sql"
+)
+
+// check compatibility
+var (
+	_ DBExecutor = &sql.DB{}
+	_ DBExecutor = &sql.Conn{}
+)
+
+type QueryExecutor interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}
+
+type DBExecutor interface {
+	QueryExecutor
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}

--- a/pkg/dbutil/table.go
+++ b/pkg/dbutil/table.go
@@ -15,7 +15,6 @@ package dbutil
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 
@@ -29,13 +28,13 @@ import (
 )
 
 // GetTableInfo returns table information.
-func GetTableInfo(ctx context.Context, db *sql.DB, schemaName string, tableName string) (*model.TableInfo, error) {
+func GetTableInfo(ctx context.Context, db QueryExecutor, schemaName string, tableName string) (*model.TableInfo, error) {
 	createTableSQL, err := GetCreateTableSQL(ctx, db, schemaName, tableName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	parser2, err := GetParserForDB(db)
+	parser2, err := GetParserForDB(ctx, db)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/dbutil/variable.go
+++ b/pkg/dbutil/variable.go
@@ -2,7 +2,6 @@ package dbutil
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,27 +13,27 @@ import (
 )
 
 // ShowVersion queries variable 'version' and returns its value.
-func ShowVersion(ctx context.Context, db *sql.DB) (value string, err error) {
+func ShowVersion(ctx context.Context, db QueryExecutor) (value string, err error) {
 	return ShowMySQLVariable(ctx, db, "version")
 }
 
 // ShowLogBin queries variable 'log_bin' and returns its value.
-func ShowLogBin(ctx context.Context, db *sql.DB) (value string, err error) {
+func ShowLogBin(ctx context.Context, db QueryExecutor) (value string, err error) {
 	return ShowMySQLVariable(ctx, db, "log_bin")
 }
 
 // ShowBinlogFormat queries variable 'binlog_format' and returns its value.
-func ShowBinlogFormat(ctx context.Context, db *sql.DB) (value string, err error) {
+func ShowBinlogFormat(ctx context.Context, db QueryExecutor) (value string, err error) {
 	return ShowMySQLVariable(ctx, db, "binlog_format")
 }
 
 // ShowBinlogRowImage queries variable 'binlog_row_image' and returns its values.
-func ShowBinlogRowImage(ctx context.Context, db *sql.DB) (value string, err error) {
+func ShowBinlogRowImage(ctx context.Context, db QueryExecutor) (value string, err error) {
 	return ShowMySQLVariable(ctx, db, "binlog_row_image")
 }
 
 // ShowServerID queries variable 'server_id' and returns its value.
-func ShowServerID(ctx context.Context, db *sql.DB) (serverID uint64, err error) {
+func ShowServerID(ctx context.Context, db QueryExecutor) (serverID uint64, err error) {
 	value, err := ShowMySQLVariable(ctx, db, "server_id")
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -45,7 +44,7 @@ func ShowServerID(ctx context.Context, db *sql.DB) (serverID uint64, err error) 
 }
 
 // ShowMySQLVariable queries MySQL variable and returns its value.
-func ShowMySQLVariable(ctx context.Context, db *sql.DB, variable string) (value string, err error) {
+func ShowMySQLVariable(ctx context.Context, db QueryExecutor, variable string) (value string, err error) {
 	query := fmt.Sprintf("SHOW GLOBAL VARIABLES LIKE '%s';", variable)
 	err = db.QueryRowContext(ctx, query).Scan(&variable, &value)
 	if err != nil {
@@ -56,7 +55,7 @@ func ShowMySQLVariable(ctx context.Context, db *sql.DB, variable string) (value 
 
 // ShowGrants queries privileges for a mysql user.
 // For mysql 8.0, if user has granted roles, ShowGrants also extract privilege from roles.
-func ShowGrants(ctx context.Context, db *sql.DB, user, host string) ([]string, error) {
+func ShowGrants(ctx context.Context, db QueryExecutor, user, host string) ([]string, error) {
 	if host == "" {
 		host = "%"
 	}


### PR DESCRIPTION
…

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
add a interface to allow call some util function with both *sql.DB and *sql.Conn.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
   - add context.Context parameter to some functions 
 - Has interface methods change
 - Has persistent data change

Side effects

 - Breaking backward compatibility

Related changes
