### PR TITLE
Diff2: add global channel for chunks_iter to generate chunks smoothly

### DIFF
--- a/sync_diff_inspector/source/chunks_iter.go
+++ b/sync_diff_inspector/source/chunks_iter.go
@@ -56,11 +56,12 @@ func (t *ChunksIterator) produceChunks(ctx context.Context, startRange *splitter
 	defer close(t.chunksCh)
 	pool := utils.NewWorkerPool(3, "chunks producer")
 	t.nextTableIndex = 0
+
 	if startRange != nil {
+		curIndex := startRange.GetTableIndex()
+		curTable := t.TableDiffs[curIndex]
+		t.nextTableIndex = curIndex + 1
 		pool.Apply(func() {
-			curIndex := startRange.GetTableIndex()
-			curTable := t.TableDiffs[curIndex]
-			t.nextTableIndex = curIndex + 1
 			chunkIter, err := t.tableAnalyzer.AnalyzeSplitter(ctx, curTable, startRange)
 			if err != nil {
 				t.errCh <- errors.Trace(err)

--- a/sync_diff_inspector/source/chunks_iter.go
+++ b/sync_diff_inspector/source/chunks_iter.go
@@ -45,7 +45,7 @@ func NewChunksIterator(ctx context.Context, analyzer TableAnalyzer, tableDiffs [
 		tableAnalyzer: analyzer,
 		TableDiffs:    tableDiffs,
 		chunksCh:      make(chan *splitter.RangeInfo, 64),
-		errCh:         make(chan error, 1),
+		errCh:         make(chan error, len(tableDiffs)),
 		cancel:        cancel,
 	}
 	go iter.produceChunks(ctxx, startRange)

--- a/sync_diff_inspector/source/chunks_iter.go
+++ b/sync_diff_inspector/source/chunks_iter.go
@@ -15,7 +15,6 @@ package source
 
 import (
 	"context"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -23,7 +22,6 @@ import (
 	"github.com/pingcap/tidb-tools/sync_diff_inspector/chunk"
 	"github.com/pingcap/tidb-tools/sync_diff_inspector/source/common"
 	"github.com/pingcap/tidb-tools/sync_diff_inspector/splitter"
-	"go.uber.org/zap"
 )
 
 // ChunksIterator is used for single mysql/tidb source.
@@ -33,140 +31,118 @@ type ChunksIterator struct {
 
 	TableDiffs     []*common.TableDiff
 	nextTableIndex int
-	chunkIterCh    chan *splitter.ChunkIterator
+	chunksCh       chan *splitter.RangeInfo
 	errCh          chan error
 	limit          int
 
-	tableIter  splitter.ChunkIterator
-	progressID string
+	cancel context.CancelFunc
 }
 
-func (t *ChunksIterator) produceChunkIter(ctx context.Context) {
-	defer func() {
-		close(t.chunkIterCh)
-		close(t.errCh)
-	}()
-	for i := t.nextTableIndex; i < len(t.TableDiffs); i++ {
-		table := t.TableDiffs[i]
-		startTime := time.Now()
-		chunkIter, err := t.tableAnalyzer.AnalyzeSplitter(ctx, table, nil)
+func NewChunksIterator(ctx context.Context, analyzer TableAnalyzer, tableDiffs []*common.TableDiff, startRange *splitter.RangeInfo) (*ChunksIterator, error) {
+	ctxx, cancel := context.WithCancel(ctx)
+	iter := &ChunksIterator{
+		tableAnalyzer: analyzer,
+		TableDiffs:    tableDiffs,
+		chunksCh:      make(chan *splitter.RangeInfo, 32),
+		errCh:         make(chan error, 1),
+		cancel:        cancel,
+	}
+	go iter.produceChunks(ctxx, startRange)
+	return iter, nil
+}
+
+func (t *ChunksIterator) produceChunks(ctx context.Context, startRange *splitter.RangeInfo) {
+	defer close(t.chunksCh)
+
+	t.nextTableIndex = 0
+	if startRange != nil {
+		curIndex := startRange.GetTableIndex()
+		curTable := t.TableDiffs[curIndex]
+		t.nextTableIndex = curIndex + 1
+		chunkIter, err := t.tableAnalyzer.AnalyzeSplitter(ctx, curTable, startRange)
 		if err != nil {
-			t.errCh <- err
+			t.errCh <- errors.Trace(err)
 			return
 		}
-		log.Debug("initialize table", zap.Duration("time cost", time.Since(startTime)))
-		t.chunkIterCh <- &chunkIter
+		for {
+			c, err := chunkIter.Next()
+			if err != nil {
+				t.errCh <- errors.Trace(err)
+				return
+			}
+			if c == nil {
+				break
+			}
+			c.Index.TableIndex = curIndex
+			select {
+			case <-ctx.Done():
+				log.Info("Stop do produce chunks by context done")
+				return
+			case t.chunksCh <- &splitter.RangeInfo{
+				ChunkRange: c,
+				IndexID:    getCurTableIndexID(chunkIter),
+				ProgressID: startRange.ProgressID,
+			}:
+			}
+		}
+	}
+
+	for ; t.nextTableIndex < len(t.TableDiffs); t.nextTableIndex++ {
+		table := t.TableDiffs[t.nextTableIndex]
+		chunkIter, err := t.tableAnalyzer.AnalyzeSplitter(ctx, table, nil)
+		if err != nil {
+			t.errCh <- errors.Trace(err)
+			return
+		}
+		for {
+			c, err := chunkIter.Next()
+			if err != nil {
+				t.errCh <- errors.Trace(err)
+				return
+			}
+			if c == nil {
+				break
+			}
+			c.Index.TableIndex = t.nextTableIndex
+			select {
+			case <-ctx.Done():
+				log.Info("Stop do produce chunks by context done")
+				return
+			case t.chunksCh <- &splitter.RangeInfo{
+				ChunkRange: c,
+				IndexID:    getCurTableIndexID(chunkIter),
+				ProgressID: dbutil.TableName(table.Schema, table.Table),
+			}:
+			}
+		}
 	}
 }
 
 func (t *ChunksIterator) Next(ctx context.Context) (*splitter.RangeInfo, error) {
-	// TODO: creates different tables chunks in parallel
-	if t.tableIter == nil {
+	select {
+	case <-ctx.Done():
 		return nil, nil
-	}
-	c, err := t.tableIter.Next()
-	if err != nil {
+	case r, ok := <-t.chunksCh:
+		if !ok && r == nil {
+			return nil, nil
+		}
+		return r, nil
+	case err := <-t.errCh:
 		return nil, errors.Trace(err)
 	}
-	if c != nil {
-		curIndex := t.getCurTableIndex()
-		c.Index.TableIndex = curIndex
-		return &splitter.RangeInfo{
-			ChunkRange: c,
-			IndexID:    t.getCurTableIndexID(),
-			ProgressID: t.progressID,
-		}, nil
-	}
-	err = t.nextTable(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if t.tableIter == nil {
-		return nil, nil
-	}
-	c, err = t.tableIter.Next()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	curIndex := t.getCurTableIndex()
-	c.Index.TableIndex = curIndex
-	return &splitter.RangeInfo{
-		ChunkRange: c,
-		IndexID:    t.getCurTableIndexID(),
-		ProgressID: t.progressID,
-	}, nil
 }
 
 func (t *ChunksIterator) Close() {
-	if t.tableIter != nil {
-		t.tableIter.Close()
-	}
+	t.cancel()
 }
 
 func (t *ChunksIterator) getCurTableIndex() int {
 	return t.nextTableIndex - 1
 }
 
-func (t *ChunksIterator) getCurTableIndexID() int64 {
-	if bt, ok := t.tableIter.(*splitter.BucketIterator); ok {
+func getCurTableIndexID(tableIter splitter.ChunkIterator) int64 {
+	if bt, ok := tableIter.(*splitter.BucketIterator); ok {
 		return bt.GetIndexID()
 	}
 	return 0
-}
-
-func (t *ChunksIterator) initTable(ctx context.Context, startRange *splitter.RangeInfo) error {
-	if t.nextTableIndex >= len(t.TableDiffs) {
-		t.tableIter = nil
-		return nil
-	}
-	curTable := t.TableDiffs[t.nextTableIndex]
-	t.nextTableIndex++
-	t.progressID = dbutil.TableName(curTable.Schema, curTable.Table)
-
-	// reads table index from checkpoint at the beginning
-	if startRange != nil {
-		curIndex := startRange.GetTableIndex()
-		curTable = t.TableDiffs[curIndex]
-		t.nextTableIndex = curIndex + 1
-		t.progressID = startRange.ProgressID
-	}
-	chunkIter, err := t.tableAnalyzer.AnalyzeSplitter(ctx, curTable, startRange)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if t.tableIter != nil {
-		t.tableIter.Close()
-	}
-	t.tableIter = chunkIter
-	go t.produceChunkIter(ctx)
-	return nil
-}
-
-// if error is nil and t.iter is not nil,
-// then nextTable is done successfully.
-func (t *ChunksIterator) nextTable(ctx context.Context) error {
-	if t.nextTableIndex >= len(t.TableDiffs) {
-		t.tableIter = nil
-		return nil
-	}
-	curTable := t.TableDiffs[t.nextTableIndex]
-	t.nextTableIndex++
-	t.progressID = dbutil.TableName(curTable.Schema, curTable.Table)
-	if t.tableIter != nil {
-		t.tableIter.Close()
-	}
-	select {
-	case <-ctx.Done():
-		log.Info("Stop do produce chunkIter by context done")
-		return nil
-	case c, ok := <-t.chunkIterCh:
-		if !ok {
-			t.tableIter = nil
-			return nil
-		}
-		t.tableIter = *c
-		return nil
-	case err := <-t.errCh:
-		return errors.Trace(err)
-	}
 }

--- a/sync_diff_inspector/source/mysql_shard.go
+++ b/sync_diff_inspector/source/mysql_shard.go
@@ -80,16 +80,7 @@ func (s *MySQLSources) GetTableAnalyzer() TableAnalyzer {
 }
 
 func (s *MySQLSources) GetRangeIterator(ctx context.Context, r *splitter.RangeInfo, analyzer TableAnalyzer) (RangeIterator, error) {
-	dbIter := &ChunksIterator{
-		tableAnalyzer:  analyzer,
-		TableDiffs:     s.tableDiffs,
-		nextTableIndex: 0,
-		limit:          0,
-		chunkIterCh:    make(chan *splitter.ChunkIterator, 1),
-		errCh:          make(chan error, 1),
-	}
-	err := dbIter.initTable(ctx, r)
-	return dbIter, err
+	return NewChunksIterator(ctx, analyzer, s.tableDiffs, r)
 }
 
 func (s *MySQLSources) Close() {

--- a/sync_diff_inspector/source/source_test.go
+++ b/sync_diff_inspector/source/source_test.go
@@ -97,7 +97,6 @@ func (m *MockChunkIterator) Next() (*chunk.Range, error) {
 		return nil, nil
 	}
 	m.index.ChunkIndex = m.index.ChunkIndex + 1
-	fmt.Printf("m.index.ChunkIndex: %v\n", m.index)
 	return &chunk.Range{
 		Index: &chunk.ChunkID{
 			TableIndex:       m.index.TableIndex,
@@ -194,7 +193,6 @@ func (s *testSourceSuite) TestTiDBSource(c *C) {
 			c.Assert(equal(i, &chunk.ChunkID{TableIndex: len(tableCases), BucketIndexLeft: 0, BucketIndexRight: 0, ChunkIndex: 0, ChunkCnt: CHUNKS}), IsTrue)
 			break
 		}
-		c.Log(i, ch.ChunkRange.Index)
 		c.Assert(equal(ch.ChunkRange.Index, i), IsTrue)
 		next(i)
 	}

--- a/sync_diff_inspector/source/tidb.go
+++ b/sync_diff_inspector/source/tidb.go
@@ -107,16 +107,7 @@ func getMatchSource(sourceTableMap map[string]*common.TableSource, table *common
 }
 
 func (s *TiDBSource) GetRangeIterator(ctx context.Context, r *splitter.RangeInfo, analyzer TableAnalyzer) (RangeIterator, error) {
-	dbIter := &ChunksIterator{
-		tableAnalyzer:  analyzer,
-		TableDiffs:     s.tableDiffs,
-		nextTableIndex: 0,
-		chunkIterCh:    make(chan *splitter.ChunkIterator, 1),
-		errCh:          make(chan error, 1),
-		limit:          0,
-	}
-	err := dbIter.initTable(ctx, r)
-	return dbIter, err
+	return NewChunksIterator(ctx, analyzer, s.tableDiffs, r)
 }
 
 func (s *TiDBSource) Close() {

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -645,7 +645,6 @@ func (s *testSplitterSuite) TestBucketSpliter(c *C) {
 	createFakeResultForBucketSplit(mock, nil, nil)
 	createFakeResultForCount(mock, 64)
 	createFakeResultForRandom(mock, testCases[0].aRandomValues[stopJ:], testCases[0].bRandomValues[stopJ:])
-	mock.ExpectQuery("SELECT COUNT\\(DISTINCT `a.*").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("123"))
 	iter, err = NewBucketIteratorWithCheckpoint(ctx, "", tableDiff, db, rangeInfo, 1)
 	c.Assert(err, IsNil)
 	chunk, err = iter.Next()
@@ -675,7 +674,6 @@ func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandom
 	}
 	mock.ExpectQuery("SHOW STATS_BUCKETS").WillReturnRows(statsRows)
 
-	mock.ExpectQuery("SELECT COUNT\\(DISTINCT `a.*").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("123"))
 	createFakeResultForRandom(mock, aRandomValues, bRandomValues)
 }
 
@@ -745,7 +743,6 @@ func (s *testSplitterSuite) TestLimitSpliter(c *C) {
 	}
 
 	for i, testCase := range testCases {
-		mock.ExpectQuery("SELECT COUNT\\(DISTINCT `a.*").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("123"))
 		createFakeResultForLimitSplit(mock, testCase.limitAValues, testCase.limitBValues, true)
 
 		iter, err := NewLimitIterator(ctx, "", tableDiff, db)
@@ -768,7 +765,6 @@ func (s *testSplitterSuite) TestLimitSpliter(c *C) {
 
 	// Test Checkpoint
 	stopJ := 2
-	mock.ExpectQuery("SELECT COUNT\\(DISTINCT `a.*").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("123"))
 	createFakeResultForLimitSplit(mock, testCases[0].limitAValues[:stopJ], testCases[0].limitBValues[:stopJ], true)
 	iter, err := NewLimitIterator(ctx, "", tableDiff, db)
 	c.Assert(err, IsNil)
@@ -785,7 +781,6 @@ func (s *testSplitterSuite) TestLimitSpliter(c *C) {
 		IndexID:    iter.GetIndexID(),
 	}
 
-	mock.ExpectQuery("SELECT COUNT\\(DISTINCT `a.*").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("123"))
 	createFakeResultForLimitSplit(mock, testCases[0].limitAValues[stopJ:], testCases[0].limitBValues[stopJ:], true)
 	iter, err = NewLimitIteratorWithCheckpoint(ctx, "", tableDiff, db, rangeInfo)
 	c.Assert(err, IsNil)
@@ -853,7 +848,6 @@ func (s *testSplitterSuite) TestChunkSize(c *C) {
 	statsRows := sqlmock.NewRows([]string{"Db_name", "Table_name", "Column_name", "Is_index", "Bucket_id", "Count", "Repeats", "Lower_Bound", "Upper_Bound"})
 	statsRows.AddRow("test", "test", "PRIMARY", 1, 0, 1000000000, 1, "(1, 2)", "(2, 3)")
 	mock.ExpectQuery("SHOW STATS_BUCKETS").WillReturnRows(statsRows)
-	mock.ExpectQuery("SELECT COUNT\\(DISTINCT `a.*").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("123"))
 
 	bucketIter, err := NewBucketIterator(ctx, "", tableDiff, db)
 	c.Assert(err, IsNil)
@@ -896,7 +890,6 @@ func (s *testSplitterSuite) TestChunkSize(c *C) {
 	c.Assert(randomIter.chunkSize, Equals, int64(1000))
 
 	// test limit splitter chunksize
-	mock.ExpectQuery("SELECT COUNT\\(DISTINCT `a.*").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("123"))
 	createFakeResultForCount(mock, 1000)
 	mock.ExpectQuery("SELECT `a`,.*limit 50000.*").WillReturnRows(sqlmock.NewRows([]string{"a", "b"}))
 	_, err = NewLimitIterator(ctx, "", tableDiff, db)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note