### PR TITLE
Diff2: delete useless variable `bucket-id`

### DIFF
--- a/sync_diff_inspector/checkpoints/checkpoints.go
+++ b/sync_diff_inspector/checkpoints/checkpoints.go
@@ -67,9 +67,7 @@ type Node struct {
 	State string `json:"state"` // indicate the state ("success" or "failed") of the chunk
 
 	ChunkRange *chunk.Range `json:"chunk-range"`
-	// for bucket checkpoint
-	BucketID int   `json:"bucket-id"`
-	IndexID  int64 `json:"index-id"`
+	IndexID    int64        `json:"index-id"`
 }
 
 func (n *Node) GetID() *chunk.ChunkID { return n.ChunkRange.Index }

--- a/sync_diff_inspector/checkpoints/checkpoints_test.go
+++ b/sync_diff_inspector/checkpoints/checkpoints_test.go
@@ -66,8 +66,7 @@ func (cp *testCheckpointSuit) TestSaveChunk(c *C) {
 					},
 				},
 
-				BucketID: i,
-				State:    SuccessState,
+				State: SuccessState,
 			}
 			if rand.Intn(4) == 0 {
 				time.Sleep(time.Duration(rand.Intn(3)) * time.Second)

--- a/sync_diff_inspector/chunk/chunk.go
+++ b/sync_diff_inspector/chunk/chunk.go
@@ -152,7 +152,6 @@ type Range struct {
 	Args  []interface{} `json:"args"`
 
 	columnOffset map[string]int
-	BucketID     int `json:"bucket-id"`
 }
 
 func (r *Range) IsFirstChunkForBucket() bool {
@@ -378,7 +377,6 @@ func (c *Range) Clone() *Range {
 		newChunk.columnOffset[i] = v
 	}
 	newChunk.Index = c.Index.Copy()
-	newChunk.BucketID = c.BucketID
 	newChunk.IsFirst = c.IsFirst
 	newChunk.IsLast = c.IsLast
 	return newChunk
@@ -400,7 +398,6 @@ func InitChunks(chunks []*Range, t ChunkType, firstBucketID, lastBucketID int, i
 		conditions, args := chunk.ToString(collation)
 		chunk.Where = fmt.Sprintf("((%s) AND %s)", conditions, limits)
 		chunk.Args = args
-		chunk.BucketID = lastBucketID
 		chunk.Index = &ChunkID{
 			BucketIndexLeft:  firstBucketID,
 			BucketIndexRight: lastBucketID,
@@ -416,7 +413,6 @@ func InitChunk(chunk *Range, t ChunkType, firstBucketID, lastBucketID int, colla
 	conditions, args := chunk.ToString(collation)
 	chunk.Where = fmt.Sprintf("((%s) AND %s)", conditions, limits)
 	chunk.Args = args
-	chunk.BucketID = lastBucketID
 	chunk.Index = &ChunkID{
 		BucketIndexLeft:  firstBucketID,
 		BucketIndexRight: lastBucketID,

--- a/sync_diff_inspector/chunk/chunk_test.go
+++ b/sync_diff_inspector/chunk/chunk_test.go
@@ -130,7 +130,7 @@ func (cp *testChunkSuite) TestChunkToString(c *C) {
 		c.Assert(arg, Equals, expectArgs[i])
 	}
 
-	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":true,\"has-upper\":true},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":true,\"has-upper\":true},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":true,\"has-upper\":true}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null,\"bucket-id\":0}")
+	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":true,\"has-upper\":true},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":true,\"has-upper\":true},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":true,\"has-upper\":true}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null}")
 	c.Assert(chunk.ToMeta(), DeepEquals, "range in sequence: (1,3,5) < (a,b,c) <= (2,4,6)")
 
 	// upper
@@ -165,7 +165,7 @@ func (cp *testChunkSuite) TestChunkToString(c *C) {
 		c.Assert(arg, Equals, expectArgs[i])
 	}
 
-	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":false,\"has-upper\":true},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":false,\"has-upper\":true},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":false,\"has-upper\":true}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null,\"bucket-id\":0}")
+	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":false,\"has-upper\":true},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":false,\"has-upper\":true},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":false,\"has-upper\":true}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null}")
 	c.Assert(chunk.ToMeta(), DeepEquals, "range in sequence: (a,b,c) <= (2,4,6)")
 
 	// lower
@@ -207,7 +207,7 @@ func (cp *testChunkSuite) TestChunkToString(c *C) {
 		c.Assert(arg, Equals, expectArgs[i])
 	}
 
-	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":true,\"has-upper\":false},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":true,\"has-upper\":false},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":true,\"has-upper\":false}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null,\"bucket-id\":0}")
+	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":true,\"has-upper\":false},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":true,\"has-upper\":false},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":true,\"has-upper\":false}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null}")
 	c.Assert(chunk.ToMeta(), DeepEquals, "range in sequence: (1,3,5) < (a,b,c)")
 
 	// none
@@ -241,7 +241,7 @@ func (cp *testChunkSuite) TestChunkToString(c *C) {
 		c.Assert(arg, Equals, expectArgs[i])
 	}
 
-	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":false,\"has-upper\":false},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":false,\"has-upper\":false},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":false,\"has-upper\":false}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null,\"bucket-id\":0}")
+	c.Assert(chunk.String(), DeepEquals, "{\"index\":null,\"type\":0,\"bounds\":[{\"column\":\"a\",\"lower\":\"1\",\"upper\":\"2\",\"has-lower\":false,\"has-upper\":false},{\"column\":\"b\",\"lower\":\"3\",\"upper\":\"4\",\"has-lower\":false,\"has-upper\":false},{\"column\":\"c\",\"lower\":\"5\",\"upper\":\"6\",\"has-lower\":false,\"has-upper\":false}],\"is-first\":false,\"is-last\":false,\"where\":\"\",\"args\":null}")
 
 	c.Assert(chunk.ToMeta(), DeepEquals, "range in sequence: Full")
 }
@@ -298,12 +298,10 @@ func (*testChunkSuite) TestChunkInit(c *C) {
 	InitChunks(chunks, Others, 1, 1, 0, "[123]", "[sdfds fsd fd gd]", 1)
 	c.Assert(chunks[0].Where, Equals, "((((`a` COLLATE '[123]' > ?) OR (`a` = ? AND `b` COLLATE '[123]' > ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE '[123]' > ?)) AND ((`a` COLLATE '[123]' < ?) OR (`a` = ? AND `b` COLLATE '[123]' < ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE '[123]' <= ?))) AND [sdfds fsd fd gd])")
 	c.Assert(chunks[0].Args, DeepEquals, []interface{}{"1", "1", "3", "1", "3", "5", "2", "2", "4", "2", "4", "6"})
-	c.Assert(chunks[0].BucketID, Equals, 1)
 	c.Assert(chunks[0].Type, Equals, Others)
 	InitChunk(chunks[1], Others, 2, 2, "[456]", "[dsfsdf]")
 	c.Assert(chunks[1].Where, Equals, "((((`a` COLLATE '[456]' > ?) OR (`a` = ? AND `b` COLLATE '[456]' > ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE '[456]' > ?)) AND ((`a` COLLATE '[456]' < ?) OR (`a` = ? AND `b` COLLATE '[456]' < ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE '[456]' <= ?))) AND [dsfsdf])")
 	c.Assert(chunks[1].Args, DeepEquals, []interface{}{"2", "2", "4", "2", "4", "6", "3", "3", "5", "3", "5", "7"})
-	c.Assert(chunks[1].BucketID, Equals, 2)
 	c.Assert(chunks[1].Type, Equals, Others)
 }
 
@@ -335,7 +333,6 @@ func (*testChunkSuite) TestChunkCopyAndUpdate(c *C) {
 	c.Assert(chunk3.Where, Equals, "((((`a` COLLATE '[324]' > ?) OR (`a` = ? AND `b` COLLATE '[324]' > ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE '[324]' > ?)) AND ((`a` COLLATE '[324]' < ?) OR (`a` = ? AND `b` COLLATE '[324]' < ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE '[324]' <= ?))) AND [543])")
 	c.Log(chunk3.Args)
 	c.Assert(chunk3.Args, DeepEquals, []interface{}{"2", "2", "4", "2", "4", "10", "3", "3", "9", "3", "9", "7"})
-	c.Assert(chunk3.BucketID, Equals, 2)
 	c.Assert(chunk3.Type, Equals, Others)
 }
 

--- a/sync_diff_inspector/splitter/bucket.go
+++ b/sync_diff_inspector/splitter/bucket.go
@@ -215,18 +215,18 @@ func (s *BucketIterator) produceChunks(ctx context.Context, startRange *RangeInf
 			return
 		}
 		// init values for the next bucket
-		firstBucket = c.BucketID + 1
+		firstBucket = c.Index.BucketIndexRight + 1
 		// Note: Since this chunk is not the last one,
 		//       its bucketID is less than len(s.buckets)
-		if c.BucketID >= len(s.buckets) {
+		if c.Index.BucketIndexRight >= len(s.buckets) {
 			select {
 			case <-ctx.Done():
 			case s.errCh <- errors.New("Wrong Bucket: Bucket index of the checkpoint node is larger than buckets' size"):
 			}
 			return
 		}
-		latestCount = s.buckets[c.BucketID].Count
-		nextUpperValues, err := dbutil.AnalyzeValuesFromBuckets(s.buckets[c.BucketID].UpperBound, s.indexColumns)
+		latestCount = s.buckets[c.Index.BucketIndexRight].Count
+		nextUpperValues, err := dbutil.AnalyzeValuesFromBuckets(s.buckets[c.Index.BucketIndexRight].UpperBound, s.indexColumns)
 		if err != nil {
 			select {
 			case <-ctx.Done():

--- a/sync_diff_inspector/splitter/splitter.go
+++ b/sync_diff_inspector/splitter/splitter.go
@@ -75,7 +75,6 @@ func (r *RangeInfo) Update(column, lower, upper string, updateLower, updateUpper
 func (r *RangeInfo) ToNode() *checkpoints.Node {
 	return &checkpoints.Node{
 		ChunkRange: r.ChunkRange,
-		BucketID:   r.ChunkRange.BucketID,
 		IndexID:    r.IndexID,
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

bucket-id is no longer needed

### What is changed and how it works?

delete this field.
