### PR TITLE
sync_diff_inspector: Unified time zone

### DIFF
--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -733,7 +733,7 @@ func (df *Diff) writeSQLs(ctx context.Context) {
 				chunkRange := dml.node.ChunkRange
 				fixSQLFile.WriteString(fmt.Sprintf("-- table: %s.%s\n-- %s\n", tableDiff.Schema, tableDiff.Table, chunkRange.ToMeta()))
 				if tableDiff.NeedUnifiedTimeZone {
-					fixSQLFile.WriteString(fmt.Sprintf("set @@session.time_zone = \"%s\";", source.UnifiedTimeZone))
+					fixSQLFile.WriteString(fmt.Sprintf("set @@session.time_zone = \"%s\";\n", source.UnifiedTimeZone))
 				}
 				for _, sql := range dml.sqls {
 					_, err = fixSQLFile.WriteString(fmt.Sprintf("%s\n", sql))

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -732,6 +732,9 @@ func (df *Diff) writeSQLs(ctx context.Context) {
 				// write chunk meta
 				chunkRange := dml.node.ChunkRange
 				fixSQLFile.WriteString(fmt.Sprintf("-- table: %s.%s\n-- %s\n", tableDiff.Schema, tableDiff.Table, chunkRange.ToMeta()))
+				if tableDiff.NeedUnifiedTimeZone {
+					fixSQLFile.WriteString(fmt.Sprintf("set @@session.time_zone = \"%s\";", source.UnifiedTimeZone))
+				}
 				for _, sql := range dml.sqls {
 					_, err = fixSQLFile.WriteString(fmt.Sprintf("%s\n", sql))
 					if err != nil {

--- a/sync_diff_inspector/source/common/table_diff.go
+++ b/sync_diff_inspector/source/common/table_diff.go
@@ -56,17 +56,11 @@ type TableDiff struct {
 	// select range, for example: "age > 10 AND age < 20"
 	Range string `json:"range"`
 
-	// set false if want to comapre the data directly
-	UseChecksum bool `json:"-"`
-
-	// set true if just want compare data by checksum, will skip select data when checksum is not equal
-	OnlyUseChecksum bool `json:"-"`
-
-	// ignore check table's struct
-	IgnoreStructCheck bool `json:"-"`
-
 	// ignore check table's data
 	IgnoreDataCheck bool `json:"-"`
+
+	// the table has column timestamp, which need to reset time_zone.
+	NeedUnifiedTimeZone bool `json:"-"`
 
 	Collation string `json:"collation"`
 

--- a/sync_diff_inspector/source/mysql_shard.go
+++ b/sync_diff_inspector/source/mysql_shard.go
@@ -229,7 +229,7 @@ func (s *MySQLSources) GetSourceStructInfo(ctx context.Context, tableIndex int) 
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		sourceTableInfo = utils.ResetColumns(sourceTableInfo, tableDiff.IgnoreColumns)
+		sourceTableInfo, _ = utils.ResetColumns(sourceTableInfo, tableDiff.IgnoreColumns)
 		sourceTableInfos[i] = sourceTableInfo
 	}
 	return sourceTableInfos, nil

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -184,20 +184,17 @@ func buildSourceFromCfg(ctx context.Context, tableDiffs []*common.TableDiff, che
 }
 
 func initDBConn(ctx context.Context, cfg *config.Config) error {
+	// Unified time zone
+	vars := map[string]string{
+		"time_zone": "+0:00",
+	}
 	// we had 3 producers and `cfg.CheckThreadCount` consumer to use db connections.
 	// so the connection count need to be cfg.CheckThreadCount + 3.
-	targetConn, err := common.CreateDB(ctx, cfg.Task.TargetInstance.ToDBConfig(), nil, cfg.CheckThreadCount+3)
+	targetConn, err := common.CreateDB(ctx, cfg.Task.TargetInstance.ToDBConfig(), vars, cfg.CheckThreadCount+3)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	targetTZOffset, err := dbutil.GetTimeZoneOffset(ctx, targetConn)
-	if err != nil {
-		return errors.Annotatef(err, "fetch target db %s time zone offset failed", cfg.Task.TargetInstance.ToDBConfig().String())
-	}
-	vars := map[string]string{
-		"time_zone": dbutil.FormatTimeZoneOffset(targetTZOffset),
-	}
 	cfg.Task.TargetInstance.Conn = targetConn
 
 	for _, source := range cfg.Task.SourceInstances {

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -41,6 +41,8 @@ const (
 	Replace
 )
 
+const UnifiedTimeZone string = "+0:00"
+
 type ChecksumInfo struct {
 	Checksum int64
 	Count    int64
@@ -115,16 +117,18 @@ func NewSources(ctx context.Context, cfg *config.Config) (downstream Source, ups
 	tableDiffs := make([]*common.TableDiff, 0, len(tablesToBeCheck))
 	for _, tables := range tablesToBeCheck {
 		for _, tableConfig := range tables {
+			new_Info, needUnifiedTimeZone := utils.ResetColumns(tableConfig.TargetTableInfo, tableConfig.IgnoreColumns)
 			tableDiffs = append(tableDiffs, &common.TableDiff{
 				Schema: tableConfig.Schema,
 				Table:  tableConfig.Table,
-				Info:   utils.ResetColumns(tableConfig.TargetTableInfo, tableConfig.IgnoreColumns),
+				Info:   new_Info,
 				// TODO: field `IgnoreColumns` can be deleted.
-				IgnoreColumns: tableConfig.IgnoreColumns,
-				Fields:        tableConfig.Fields,
-				Range:         tableConfig.Range,
-				Collation:     tableConfig.Collation,
-				ChunkSize:     tableConfig.ChunkSize,
+				IgnoreColumns:       tableConfig.IgnoreColumns,
+				Fields:              tableConfig.Fields,
+				Range:               tableConfig.Range,
+				NeedUnifiedTimeZone: needUnifiedTimeZone,
+				Collation:           tableConfig.Collation,
+				ChunkSize:           tableConfig.ChunkSize,
 			})
 
 			// When the router set case-sensitive false,
@@ -186,7 +190,7 @@ func buildSourceFromCfg(ctx context.Context, tableDiffs []*common.TableDiff, che
 func initDBConn(ctx context.Context, cfg *config.Config) error {
 	// Unified time zone
 	vars := map[string]string{
-		"time_zone": "+0:00",
+		"time_zone": UnifiedTimeZone,
 	}
 	// we had 3 producers and `cfg.CheckThreadCount` consumer to use db connections.
 	// so the connection count need to be cfg.CheckThreadCount + 3.

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -117,11 +117,11 @@ func NewSources(ctx context.Context, cfg *config.Config) (downstream Source, ups
 	tableDiffs := make([]*common.TableDiff, 0, len(tablesToBeCheck))
 	for _, tables := range tablesToBeCheck {
 		for _, tableConfig := range tables {
-			new_Info, needUnifiedTimeZone := utils.ResetColumns(tableConfig.TargetTableInfo, tableConfig.IgnoreColumns)
+			newInfo, needUnifiedTimeZone := utils.ResetColumns(tableConfig.TargetTableInfo, tableConfig.IgnoreColumns)
 			tableDiffs = append(tableDiffs, &common.TableDiff{
 				Schema: tableConfig.Schema,
 				Table:  tableConfig.Table,
-				Info:   new_Info,
+				Info:   newInfo,
 				// TODO: field `IgnoreColumns` can be deleted.
 				IgnoreColumns:       tableConfig.IgnoreColumns,
 				Fields:              tableConfig.Fields,

--- a/sync_diff_inspector/source/tidb.go
+++ b/sync_diff_inspector/source/tidb.go
@@ -145,7 +145,7 @@ func (s *TiDBSource) GetSourceStructInfo(ctx context.Context, tableIndex int) ([
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	tableInfos[0] = utils.ResetColumns(tableInfos[0], tableDiff.IgnoreColumns)
+	tableInfos[0], _ = utils.ResetColumns(tableInfos[0], tableDiff.IgnoreColumns)
 	return tableInfos, nil
 }
 

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -626,7 +626,7 @@ func TestBucketSpliter(t *testing.T) {
 
 	// Test Checkpoint
 	stopJ := 3
-	createFakeResultForBucketSplit(mock, testCases[0].aRandomValues[:stopJ], testCases[0].bRandomValues[:stopJ])
+	createFakeResultForBucketSplit(mock, testCases[0].aRandomValues, testCases[0].bRandomValues)
 	tableDiff.ChunkSize = testCases[0].chunkSize
 	iter, err := NewBucketIterator(ctx, "", tableDiff, db)
 	require.NoError(t, err)
@@ -635,6 +635,13 @@ func TestBucketSpliter(t *testing.T) {
 	for ; j < stopJ; j++ {
 		chunk, err = iter.Next()
 		require.NoError(t, err)
+	}
+	for {
+		c, err := iter.Next()
+		require.NoError(t, err)
+		if c == nil {
+			break
+		}
 	}
 	bounds1 := chunk.Bounds
 

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -301,13 +301,15 @@ func TestRandomSpliter(t *testing.T) {
 		tableInfo, err := dbutil.GetTableInfoBySQL(testCase.createTableSQL, parser.New())
 		require.NoError(t, err)
 
+		info, needUnifiedTimeStamp := utils.ResetColumns(tableInfo, testCase.IgnoreColumns)
 		tableDiff := &common.TableDiff{
-			Schema:        "test",
-			Table:         "test",
-			Info:          utils.ResetColumns(tableInfo, testCase.IgnoreColumns),
-			IgnoreColumns: testCase.IgnoreColumns,
-			Fields:        testCase.fields,
-			ChunkSize:     5,
+			Schema:              "test",
+			Table:               "test",
+			Info:                info,
+			IgnoreColumns:       testCase.IgnoreColumns,
+			NeedUnifiedTimeZone: needUnifiedTimeStamp,
+			Fields:              testCase.fields,
+			ChunkSize:           5,
 		}
 
 		createFakeResultForRandomSplit(mock, testCase.count, testCase.randomValues)

--- a/sync_diff_inspector/utils/utils_test.go
+++ b/sync_diff_inspector/utils/utils_test.go
@@ -213,7 +213,7 @@ func TestBasicTableUtilOperation(t *testing.T) {
 	require.True(t, equal)
 
 	// Test ignore columns
-	createTableSQL = "create table `test`.`test`(`a` int, `c` float, `b` varchar(10), `d` datetime, primary key(`a`, `b`), key(`c`, `d`))"
+	createTableSQL = "create table `test`.`test`(`a` int, `c` float, `b` varchar(10), `d` datetime, `e` timestamp, primary key(`a`, `b`), key(`c`, `d`))"
 	tableInfo, err = dbutil.GetTableInfoBySQL(createTableSQL, parser.New())
 	require.NoError(t, err)
 
@@ -221,7 +221,8 @@ func TestBasicTableUtilOperation(t *testing.T) {
 	require.Equal(t, len(tableInfo.Columns), 4)
 	require.Equal(t, tableInfo.Indices[0].Columns[1].Name.O, "b")
 	require.Equal(t, tableInfo.Indices[0].Columns[1].Offset, 2)
-	info := ResetColumns(tableInfo, []string{"c"})
+	info, hasTimeStampType := ResetColumns(tableInfo, []string{"c"})
+	require.True(t, hasTimeStampType)
 	require.Equal(t, len(info.Indices), 1)
 	require.Equal(t, len(info.Columns), 3)
 	require.Equal(t, tableInfo.Indices[0].Columns[1].Name.O, "b")
@@ -322,22 +323,23 @@ func TestResetColumns(t *testing.T) {
 	createTableSQL1 := "CREATE TABLE `test`.`atest` (`a` int, `b` int, `c` int, `d` int, primary key(`a`))"
 	tableInfo1, err := dbutil.GetTableInfoBySQL(createTableSQL1, parser.New())
 	require.NoError(t, err)
-	tbInfo := ResetColumns(tableInfo1, []string{"a"})
+	tbInfo, hasTimeStampType := ResetColumns(tableInfo1, []string{"a"})
 	require.Equal(t, len(tbInfo.Columns), 3)
 	require.Equal(t, len(tbInfo.Indices), 0)
 	require.Equal(t, tbInfo.Columns[2].Offset, 2)
+	require.False(t, hasTimeStampType)
 
 	createTableSQL2 := "CREATE TABLE `test`.`atest` (`a` int, `b` int, `c` int, `d` int, primary key(`a`), index idx(`b`, `c`))"
 	tableInfo2, err := dbutil.GetTableInfoBySQL(createTableSQL2, parser.New())
 	require.NoError(t, err)
-	tbInfo = ResetColumns(tableInfo2, []string{"a", "b"})
+	tbInfo, _ = ResetColumns(tableInfo2, []string{"a", "b"})
 	require.Equal(t, len(tbInfo.Columns), 2)
 	require.Equal(t, len(tbInfo.Indices), 0)
 
 	createTableSQL3 := "CREATE TABLE `test`.`atest` (`a` int, `b` int, `c` int, `d` int, primary key(`a`), index idx(`b`, `c`))"
 	tableInfo3, err := dbutil.GetTableInfoBySQL(createTableSQL3, parser.New())
 	require.NoError(t, err)
-	tbInfo = ResetColumns(tableInfo3, []string{"b", "c"})
+	tbInfo, _ = ResetColumns(tableInfo3, []string{"b", "c"})
 	require.Equal(t, len(tbInfo.Columns), 2)
 	require.Equal(t, len(tbInfo.Indices), 1)
 }

--- a/sync_diff_inspector/utils/utils_test.go
+++ b/sync_diff_inspector/utils/utils_test.go
@@ -218,13 +218,13 @@ func TestBasicTableUtilOperation(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, len(tableInfo.Indices), 2)
-	require.Equal(t, len(tableInfo.Columns), 4)
+	require.Equal(t, len(tableInfo.Columns), 5)
 	require.Equal(t, tableInfo.Indices[0].Columns[1].Name.O, "b")
 	require.Equal(t, tableInfo.Indices[0].Columns[1].Offset, 2)
 	info, hasTimeStampType := ResetColumns(tableInfo, []string{"c"})
 	require.True(t, hasTimeStampType)
 	require.Equal(t, len(info.Indices), 1)
-	require.Equal(t, len(info.Columns), 3)
+	require.Equal(t, len(info.Columns), 4)
 	require.Equal(t, tableInfo.Indices[0].Columns[1].Name.O, "b")
 	require.Equal(t, tableInfo.Indices[0].Columns[1].Offset, 1)
 }

--- a/tests/sync_diff_inspector/time_zone/run.sh
+++ b/tests/sync_diff_inspector/time_zone/run.sh
@@ -4,8 +4,11 @@ set -e
 
 cd "$(dirname "$0")"
 OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
+FIX_DIR=/tmp/tidb_tools_test/sync_diff_inspector/fixsql
 rm -rf $OUT_DIR
+rm -rf $FIX_DIR
 mkdir -p $OUT_DIR
+mkdir -p $FIX_DIR
 
 mysql -uroot -h 127.0.0.1 -P 4000 -e "SET @@GLOBAL.SQL_MODE='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';"
 sleep 3
@@ -36,6 +39,7 @@ echo "set different rows"
 mysql -uroot -h 127.0.0.1 -P 4001 -e "SET @@session.time_zone = '-06:00'; insert into tz_test.diff values (4, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/time_zone_diff.output
 check_contains "check failed" $OUT_DIR/sync_diff.log
+mv $OUT_DIR/fix-on-tidb/ $FIX_DIR/
 rm -rf $OUT_DIR/*
 
 echo "fix the rows"

--- a/tests/sync_diff_inspector/time_zone/run.sh
+++ b/tests/sync_diff_inspector/time_zone/run.sh
@@ -14,6 +14,7 @@ for port in 4000 4001; do
   mysql -uroot -h 127.0.0.1 -P $port -e "create database if not exists tz_test"
   mysql -uroot -h 127.0.0.1 -P $port -e "create table tz_test.diff(id int, dt datetime, ts timestamp);"
   mysql -uroot -h 127.0.0.1 -P $port -e "insert into tz_test.diff values (1, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
+  mysql -uroot -h 127.0.0.1 -P $port -e "set @@session.time_zone = \"-7:00\"; insert into tz_test.diff values (2, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
 done
 
 echo "check with the same time_zone, check result should be pass"

--- a/tests/sync_diff_inspector/time_zone/run.sh
+++ b/tests/sync_diff_inspector/time_zone/run.sh
@@ -38,7 +38,7 @@ rm -rf $OUT_DIR/*
 echo "set different rows, check result should be failed"
 mysql -uroot -h 127.0.0.1 -P 4001 -e "SET @@session.time_zone = '-06:00'; insert into tz_test.diff values (4, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "SET @@session.time_zone = '-05:00'; insert into tz_test.diff values (3, '2020-05-17 10:12:13', '2020-05-17 10:12:13');"
-sync_diff_inspector --config=./config.toml > $OUT_DIR/time_zone_diff.output
+sync_diff_inspector --config=./config.toml > $OUT_DIR/time_zone_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
 mv $OUT_DIR/fix-on-tidb/ $FIX_DIR/
 rm -rf $OUT_DIR/*

--- a/tests/sync_diff_inspector/time_zone/run.sh
+++ b/tests/sync_diff_inspector/time_zone/run.sh
@@ -14,7 +14,7 @@ for port in 4000 4001; do
   mysql -uroot -h 127.0.0.1 -P $port -e "create database if not exists tz_test"
   mysql -uroot -h 127.0.0.1 -P $port -e "create table tz_test.diff(id int, dt datetime, ts timestamp);"
   mysql -uroot -h 127.0.0.1 -P $port -e "insert into tz_test.diff values (1, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
-  mysql -uroot -h 127.0.0.1 -P $port -e "set @@session.time_zone = \"-7:00\"; insert into tz_test.diff values (2, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
+  mysql -uroot -h 127.0.0.1 -P $port -e "set @@session.time_zone = \"-07:00\"; insert into tz_test.diff values (2, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
 done
 
 echo "check with the same time_zone, check result should be pass"
@@ -31,6 +31,20 @@ echo "check with different time_zone, check result should be pass again"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/time_zone_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 rm -rf $OUT_DIR/*
+
+echo "set different rows"
+mysql -uroot -h 127.0.0.1 -P 4001 -e "SET @@session.time_zone = '-06:00'; insert into tz_test.diff values (4, '2020-05-17 09:12:13', '2020-05-17 09:12:13');"
+sync_diff_inspector --config=./config.toml > $OUT_DIR/time_zone_diff.output
+check_contains "check failed" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*
+
+echo "fix the rows"
+cat $FIX_DIR/fix-on-tidb/*.sql | mysql -uroot -h127.0.0.1 -P 4000
+sync_diff_inspector --config=./config.toml > $OUT_DIR/time_zone_diff.output
+check_contains "check pass!!!" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*
+mysql -uroot -h 127.0.0.1 -P 4000 -e "SET @@session.time_zone = '-06:00'; select ts from tz_test.diff where id = 4;" > $OUT_DIR/tmp_sql_timezone
+check_contains "2020-05-17 09:12:13" $OUT_DIR/tmp_sql_timezone
 
 # reset time_zone
 mysql -uroot -h 127.0.0.1 -P 4000 -e "SET @@global.time_zone = 'SYSTEM'";


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

downstream don't initialize the specific time zone when the connection is created.

### What is changed and how it works?

use the same time_zone parameter when the upstream/downstream's connection is created.
