### PR TITLE
sync-diff-inspector: optimize CountAndChecksum

### DIFF
--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -645,8 +645,7 @@ func GetTableSize(ctx context.Context, db *sql.DB, schemaName, tableName string)
 func GetCountAndCRC32Checksum(ctx context.Context, db *sql.DB, schemaName, tableName string, tbInfo *model.TableInfo, limitRange string, args []interface{}) (int64, int64, error) {
 	/*
 		calculate CRC32 checksum and count example:
-		mysql> select count(t.checksum), BIT_XOR(t.checksum) from
-		(select CAST(CRC32(CONCAT_WS(',', id, name, age, CONCAT(ISNULL(id), ISNULL(name), ISNULL(age))))AS UNSIGNED) as checksum from test.test where id > 0) as t;
+		mysql> select count(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', id, name, age, CONCAT(ISNULL(id), ISNULL(name), ISNULL(age))))AS UNSIGNED)) as CHECKSUM from test.test where id > 0) as t;
 		+--------+------------+
 		| count  | checksum   |
 		+--------+------------+
@@ -669,7 +668,7 @@ func GetCountAndCRC32Checksum(ctx context.Context, db *sql.DB, schemaName, table
 		columnIsNull = append(columnIsNull, fmt.Sprintf("ISNULL(%s)", name))
 	}
 
-	query := fmt.Sprintf("SELECT COUNT(t.crc32) as CNT, BIT_XOR(t.crc32) as CHECKSUM from (SELECT CAST(CRC32(CONCAT_WS(',', %s, CONCAT(%s)))AS UNSIGNED) AS crc32 FROM %s WHERE %s) as t;",
+	query := fmt.Sprintf("SELECT COUNT(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', %s, CONCAT(%s)))AS UNSIGNED)) as CHECKSUM FROM %s WHERE %s;",
 		strings.Join(columnNames, ", "), strings.Join(columnIsNull, ", "), dbutil.TableName(schemaName, tableName), limitRange)
 	log.Debug("count and checksum", zap.String("sql", query), zap.Reflect("args", args))
 

--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -645,7 +645,7 @@ func GetTableSize(ctx context.Context, db *sql.DB, schemaName, tableName string)
 func GetCountAndCRC32Checksum(ctx context.Context, db *sql.DB, schemaName, tableName string, tbInfo *model.TableInfo, limitRange string, args []interface{}) (int64, int64, error) {
 	/*
 		calculate CRC32 checksum and count example:
-		mysql> select count(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', id, name, age, CONCAT(ISNULL(id), ISNULL(name), ISNULL(age))))AS UNSIGNED)) as CHECKSUM from test.test where id > 0) as t;
+		mysql> select count(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', id, name, age, CONCAT(ISNULL(id), ISNULL(name), ISNULL(age))))AS UNSIGNED)) as CHECKSUM from test.test where id > 0;
 		+--------+------------+
 		|  CNT   |  CHECKSUM  |
 		+--------+------------+

--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -647,7 +647,7 @@ func GetCountAndCRC32Checksum(ctx context.Context, db *sql.DB, schemaName, table
 		calculate CRC32 checksum and count example:
 		mysql> select count(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', id, name, age, CONCAT(ISNULL(id), ISNULL(name), ISNULL(age))))AS UNSIGNED)) as CHECKSUM from test.test where id > 0) as t;
 		+--------+------------+
-		| count  | checksum   |
+		|  CNT   |  CHECKSUM  |
 		+--------+------------+
 		| 100000 | 1128664311 |
 		+--------+------------+


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In mysql the CountAndChecksum SQL is not optimized.

new sync-diff-inspector:
```
mysql> SELECT COUNT(t.crc32) as CNT, BIT_XOR(t.crc32) as CHECKSUM from (SELECT CAST(CRC32(CONCAT_WS(',', `id`, `a`, `b`, `c`, `d`, CONCAT(ISNULL(`id`), ISNULL(`a`), ISNULL(`b`), ISNULL(`c`), ISNULL(`d`))))AS UNSIGNED) AS crc32 FROM `test_1000w`.`test1` WHERE (((`id` > 6515360) OR (`id` = 6515360 AND `a` > 52044895) OR (`id` = 6515360 AND `a` = 52044895 AND `b` > 3804091)) AND (TRUE))) as t;
+---------+------------+
| CNT     | CHECKSUM   |
+---------+------------+
| 3484640 | 4006106634 |
+---------+------------+
1 row in set (15.24 sec)
```

old ysnc-diff-inspector:
```
SELECT BIT_XOR(CAST(CRC32(CONCAT_WS(',', `id`, `a`, `b`, `c`, `d`, CONCAT(ISNULL(`id`), ISNULL(`a`), ISNULL(`b`), ISNULL(`c`), ISNULL(`d`)))) AS UNSIGNED)) AS checksum FROM `test_1000w`.`test1` WHERE (((`id` > 6515360) OR (`id` = 6515360 AND `a` > 52044895) OR (`id` = 6515360 AND `a` = 52044895 AND `b` > 3804091)) AND (TRUE));
+------------+
| checksum   |
+------------+
| 4006106634 |
+------------+
1 row in set (8.68 sec)
```


### What is changed and how it works?

use optimized SQL (without cache):
```
mysql> SELECT count(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', `id`, `a`, `b`, `c`, `d`, CONCAT(ISNULL(`id`), ISNULL(`a`), ISNULL(`b`), ISNULL(`c`), ISNULL(`d`)))) AS UNSIGNED)) AS checksum FROM `test_1000w`.`test1` WHERE (((`id` > 6515360) OR (`id` = 6515360 AND `a` > 52044895) OR (`id` = 6515360 AND `a` = 52044895 AND `b` > 3804091)) AND (TRUE));
+---------+------------+
| CNT     | checksum   |
+---------+------------+
| 3484640 | 4006106634 |
+---------+------------+
1 row in set (8.73 sec)
```
