### PR TITLE
sync-diff: fix panic in meetError

### DIFF
--- a/sync_diff_inspector/report/report.go
+++ b/sync_diff_inspector/report/report.go
@@ -240,7 +240,10 @@ func (r *Report) Print(w io.Writer) error {
 		summary.WriteString("Error in comparison process:\n")
 		for schema, tableMap := range r.TableResults {
 			for table, result := range tableMap {
-				summary.WriteString(fmt.Sprintf("%s error occured in %s\n", result.MeetError.Error(), dbutil.TableName(schema, table)))
+				// not every table failed in this time.
+				if result.MeetError != nil {
+					summary.WriteString(fmt.Sprintf("%s error occured in %s\n", result.MeetError.Error(), dbutil.TableName(schema, table)))
+				}
 			}
 		}
 		summary.WriteString(fmt.Sprintf("You can view the comparision details through '%s/%s'\n", r.task.OutputDir, config.LogFileName))

--- a/sync_diff_inspector/report/report.go
+++ b/sync_diff_inspector/report/report.go
@@ -240,7 +240,7 @@ func (r *Report) Print(w io.Writer) error {
 		summary.WriteString("Error in comparison process:\n")
 		for schema, tableMap := range r.TableResults {
 			for table, result := range tableMap {
-				// not every table failed in this time.
+				// not all tables failed.
 				if result.MeetError != nil {
 					summary.WriteString(fmt.Sprintf("%s error occured in %s\n", result.MeetError.Error(), dbutil.TableName(schema, table)))
 				}

--- a/sync_diff_inspector/report/report_test.go
+++ b/sync_diff_inspector/report/report_test.go
@@ -254,6 +254,7 @@ func TestPrint(t *testing.T) {
 
 	// Error
 	report.SetTableMeetError("test", "tbl1", errors.New("123"))
+	report.SetTableStructCheckResult("test", "tbl1", false, false)
 	buf = new(bytes.Buffer)
 	report.Print(buf)
 	require.Equal(t, buf.String(), "Error in comparison process:\n"+

--- a/sync_diff_inspector/report/report_test.go
+++ b/sync_diff_inspector/report/report_test.go
@@ -209,6 +209,12 @@ func TestPrint(t *testing.T) {
 			Info:      tableInfo,
 			Collation: "[123]",
 		},
+		{
+			Schema:    "test",
+			Table:     "tbl1",
+			Info:      tableInfo,
+			Collation: "[123]",
+		},
 	}
 	configs := []*ReportConfig{
 		{
@@ -247,12 +253,11 @@ func TestPrint(t *testing.T) {
 		"You can view the comparision details through 'output_dir/sync_diff.log'\n")
 
 	// Error
-	report.SetTableMeetError("test", "tbl", errors.New("123"))
-	report.SetTableStructCheckResult("test", "tbl", false, false)
+	report.SetTableMeetError("test", "tbl1", errors.New("123"))
 	buf = new(bytes.Buffer)
 	report.Print(buf)
 	require.Equal(t, buf.String(), "Error in comparison process:\n"+
-		"123 error occured in `test`.`tbl`\n"+
+		"123 error occured in `test`.`tbl1`\n"+
 		"You can view the comparision details through 'output_dir/sync_diff.log'\n")
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

When synd-diff enter Error state. not every tables has the error. so we should filter the table doesn't have the error and only write errors into summary.
### What is changed and how it works?
1.  filter the table doesn't have the error and only write errors into summary.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test



