### PR TITLE
Sync go:build lines

### DIFF
--- a/pkg/utils/cpu_posix.go
+++ b/pkg/utils/cpu_posix.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//go:build linux || darwin || freebsd || unix
 // +build linux darwin freebsd unix
 
 package utils

--- a/pkg/utils/cpu_windows.go
+++ b/pkg/utils/cpu_windows.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//go:build windows
 // +build windows
 
 package utils


### PR DESCRIPTION
### What problem does this PR solve?

Using `go fmt` with Go 1.17 or newer resulted in file changes due to "out of sync" `//go:build` lines. This is because a change in Go 1.17 that is described on https://go.dev/doc/go1.17#gofmt

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code


