### PR TITLE
sync_diff: fix chunkSize is 0 when table is empty

### DIFF
--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -102,7 +102,9 @@ func NewRandomIteratorWithCheckpoint(ctx context.Context, progressID string, tab
 				// no index
 				// will use table scan
 				// so we use one chunk
-				chunkSize = cnt
+				// plus 1 to avoid chunkSize is 0
+				// while chunkCnt = (2cnt)/(cnt+1) <= 1
+				chunkSize = cnt + 1
 			}
 		}
 		log.Info("get chunk size for table", zap.Int64("chunk size", chunkSize),

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -898,7 +898,7 @@ func TestChunkSize(t *testing.T) {
 	createFakeResultForRandomSplit(mock, 1000, nil)
 	randomIter, err = NewRandomIterator(ctx, "", tableDiff_noindex, db)
 	require.NoError(t, err)
-	require.Equal(t, randomIter.chunkSize, int64(1000))
+	require.Equal(t, randomIter.chunkSize, int64(1001))
 
 	// test limit splitter chunksize
 	createFakeResultForCount(mock, 1000)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #585 

### What is changed and how it works?

avoid chunkSize is 0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```
[root@copy-of-vm-ee-centos76-v1 bin]# ./sync_diff_inspector --config configa.toml 
A total of 1 tables need to be compared

Comparing the table structure of ``test`.`emp`` ... equivalent
Comparing the table data of ``test`.`emp`` ... equivalent
_____________________________________________________________________________
Progress [============================================================>] 100% 0/0
A total of 1 table have been compared and all are equal.
You can view the comparision details through './output_empty/sync_diff.log'
```
