### PR TITLE
sync_diff_inspector: Table range should be FALSE when all the columns are equal

### DIFF
--- a/sync_diff_inspector/chunk/chunk.go
+++ b/sync_diff_inspector/chunk/chunk.go
@@ -260,7 +260,7 @@ func (c *Range) ToString(collation string) (string, []interface{}) {
 		sameArgs = append(sameArgs, bound.Lower)
 	}
 
-	if i == len(c.Bounds) {
+	if i == len(c.Bounds) && i > 0 {
 		// All the columns are equal in bounds, should return FALSE!
 		return "FALSE", nil
 	}

--- a/sync_diff_inspector/chunk/chunk.go
+++ b/sync_diff_inspector/chunk/chunk.go
@@ -260,6 +260,11 @@ func (c *Range) ToString(collation string) (string, []interface{}) {
 		sameArgs = append(sameArgs, bound.Lower)
 	}
 
+	if i == len(c.Bounds) {
+		// All the columns are equal in bounds, should return FALSE!
+		return "FALSE", nil
+	}
+
 	for ; i < len(c.Bounds); i++ {
 		bound := c.Bounds[i]
 		lowerSymbol := gt

--- a/sync_diff_inspector/chunk/chunk_test.go
+++ b/sync_diff_inspector/chunk/chunk_test.go
@@ -386,6 +386,40 @@ func TestChunkToString(t *testing.T) {
 	}
 	require.Equal(t, chunk.String(), `{"index":null,"type":0,"bounds":[{"column":"a","lower":"1","upper":"1","has-lower":false,"has-upper":false},{"column":"b","lower":"3","upper":"4","has-lower":false,"has-upper":false},{"column":"c","lower":"5","upper":"6","has-lower":false,"has-upper":false}],"is-first":false,"is-last":false,"where":"","args":null}`)
 	require.Equal(t, chunk.ToMeta(), "range in sequence: Full")
+
+	// all equal
+	chunk = &Range{
+		Bounds: []*Bound{
+			{
+				Column:   "a",
+				Lower:    "1",
+				Upper:    "1",
+				HasLower: true,
+				HasUpper: true,
+			}, {
+				Column:   "b",
+				Lower:    "3",
+				Upper:    "3",
+				HasLower: true,
+				HasUpper: true,
+			}, {
+				Column:   "c",
+				Lower:    "6",
+				Upper:    "6",
+				HasLower: true,
+				HasUpper: true,
+			},
+		},
+	}
+	conditions, args = chunk.ToString("")
+	require.Equal(t, conditions, "FALSE")
+	expectArgs = []string{}
+	for i, arg := range args {
+		require.Equal(t, arg, expectArgs[i])
+	}
+	require.Equal(t, chunk.String(), `{"index":null,"type":0,"bounds":[{"column":"a","lower":"1","upper":"1","has-lower":true,"has-upper":true},{"column":"b","lower":"3","upper":"3","has-lower":true,"has-upper":true},{"column":"c","lower":"6","upper":"6","has-lower":true,"has-upper":true}],"is-first":false,"is-last":false,"where":"","args":null}`)
+	require.Equal(t, chunk.ToMeta(), "range in sequence: (1,3,6) < (a,b,c) <= (1,3,6)")
+
 }
 
 func TestChunkInit(t *testing.T) {

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -545,7 +545,8 @@ func (df *Diff) binSearch(ctx context.Context, targetSource source.Source, table
 		zap.Int64("count1", count1),
 		zap.Int64("count2", count2))
 
-	if !isEqual1 && !isEqual2 {
+	// If there is a count zero, we think the range is very small.
+	if (!isEqual1 && !isEqual2) || (count1 == 0 || count2 == 0) {
 		return tableRange, nil
 	} else if !isEqual1 {
 		c, err := df.binSearch(ctx, targetSource, tableRange1, count1, tableDiff, indexColumns)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #615

### What is changed and how it works?

1. return where clause `FALSE` for chunk range when all the columns are equal
2. When there is a count zero, stop `binSearch`. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test 
 
The table `sbtest0426_2.sbtest1` will trigger the issue.
 ```
$ ./sync_diff_inspector --config config2.toml -L debug
A total of 1 tables need to be compared

Comparing the table structure of ``sbtest0426_2`.`sbtest1`` ... equivalent
Comparing the table data of ``sbtest0426_2`.`sbtest1`` ... failure
_____________________________________________________________________________
Progress [============================================================>] 100% 0/0
The data of `sbtest0426_2`.`sbtest1` is not equal

The rest of tables are all equal.
The patch file has been generated in 
        'output3/fix-on-pitr3/'
You can view the comparision details through './output3/sync_diff.log'
```
