### PR TITLE
sync-diff-inspector: fix index fields not taking effect

### DIFF
--- a/sync_diff_inspector/splitter/bucket.go
+++ b/sync_diff_inspector/splitter/bucket.go
@@ -54,7 +54,7 @@ func NewBucketIterator(ctx context.Context, progressID string, table *common.Tab
 }
 
 func NewBucketIteratorWithCheckpoint(ctx context.Context, progressID string, table *common.TableDiff, dbConn *sql.DB, startRange *RangeInfo, checkThreadCount int) (*BucketIterator, error) {
-	if utils.IsRangeTrivial(table.Range) {
+	if !utils.IsRangeTrivial(table.Range) {
 		return nil, errors.Errorf(
 			"BucketIterator does not support user configured Range. Range: %s",
 			table.Range)

--- a/sync_diff_inspector/splitter/bucket.go
+++ b/sync_diff_inspector/splitter/bucket.go
@@ -54,7 +54,7 @@ func NewBucketIterator(ctx context.Context, progressID string, table *common.Tab
 }
 
 func NewBucketIteratorWithCheckpoint(ctx context.Context, progressID string, table *common.TableDiff, dbConn *sql.DB, startRange *RangeInfo, checkThreadCount int) (*BucketIterator, error) {
-	if table.Range != "" {
+	if table.Range != "" && table.Range != "TRUE" {
 		return nil, errors.Errorf(
 			"BucketIterator does not support user configured Range. Range: %s",
 			table.Range)

--- a/sync_diff_inspector/splitter/bucket.go
+++ b/sync_diff_inspector/splitter/bucket.go
@@ -55,7 +55,9 @@ func NewBucketIterator(ctx context.Context, progressID string, table *common.Tab
 
 func NewBucketIteratorWithCheckpoint(ctx context.Context, progressID string, table *common.TableDiff, dbConn *sql.DB, startRange *RangeInfo, checkThreadCount int) (*BucketIterator, error) {
 	if table.Range != "" {
-		return nil, errors.New("BucketIterator does not support user configured Range")
+		return nil, errors.Errorf(
+			"BucketIterator does not support user configured Range. Range: %s",
+			table.Range)
 	}
 
 	bctx, cancel := context.WithCancel(ctx)

--- a/sync_diff_inspector/splitter/bucket.go
+++ b/sync_diff_inspector/splitter/bucket.go
@@ -54,7 +54,7 @@ func NewBucketIterator(ctx context.Context, progressID string, table *common.Tab
 }
 
 func NewBucketIteratorWithCheckpoint(ctx context.Context, progressID string, table *common.TableDiff, dbConn *sql.DB, startRange *RangeInfo, checkThreadCount int) (*BucketIterator, error) {
-	if table.Range != "" && table.Range != "TRUE" {
+	if utils.IsRangeTrivial(table.Range) {
 		return nil, errors.Errorf(
 			"BucketIterator does not support user configured Range. Range: %s",
 			table.Range)

--- a/sync_diff_inspector/splitter/bucket.go
+++ b/sync_diff_inspector/splitter/bucket.go
@@ -54,6 +54,10 @@ func NewBucketIterator(ctx context.Context, progressID string, table *common.Tab
 }
 
 func NewBucketIteratorWithCheckpoint(ctx context.Context, progressID string, table *common.TableDiff, dbConn *sql.DB, startRange *RangeInfo, checkThreadCount int) (*BucketIterator, error) {
+	if table.Range != "" {
+		return nil, errors.New("BucketIterator does not support user configured Range")
+	}
+
 	bctx, cancel := context.WithCancel(ctx)
 	bs := &BucketIterator{
 		table:     table,

--- a/sync_diff_inspector/splitter/index_fields.go
+++ b/sync_diff_inspector/splitter/index_fields.go
@@ -1,0 +1,111 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitter
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-tools/sync_diff_inspector/utils"
+	"github.com/pingcap/tidb/parser/model"
+	"go.uber.org/zap"
+)
+
+// indexFields wraps the column info for the user config "index-fields".
+type indexFields struct {
+	cols      []*model.ColumnInfo
+	tableInfo *model.TableInfo
+	empty     bool
+}
+
+func indexFieldsFromConfigString(strFields string, tableInfo *model.TableInfo) (*indexFields, error) {
+	if len(strFields) == 0 {
+		// Empty option
+		return &indexFields{empty: true}, nil
+	}
+
+	if tableInfo == nil {
+		log.Panic("parsing index fields with empty tableInfo",
+			zap.String("index-fields", strFields))
+	}
+
+	splitFieldArr := strings.Split(strFields, ",")
+	for i := range splitFieldArr {
+		splitFieldArr[i] = strings.TrimSpace(splitFieldArr[i])
+	}
+
+	fields, err := GetSplitFields(tableInfo, splitFieldArr)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Sort the columns to help with comparison.
+	sortColsInPlace(fields)
+
+	return &indexFields{
+		cols:      fields,
+		tableInfo: tableInfo,
+	}, nil
+}
+
+func (f *indexFields) MatchesIndex(index *model.IndexInfo) bool {
+	if f.empty {
+		// Default config matches all.
+		return true
+	}
+
+	// Sanity checks.
+	if index == nil {
+		log.Panic("matching with empty index")
+	}
+	if len(f.cols) == 0 {
+		log.Panic("unexpected cols with length 0")
+	}
+
+	if len(index.Columns) != len(f.cols) {
+		// We need an exact match.
+		// Lengths not matching eliminates the possibility.
+		return false
+	}
+
+	indexCols := utils.GetColumnsFromIndex(index, f.tableInfo)
+	// Sort for comparison
+	sortColsInPlace(indexCols)
+
+	for i := 0; i < len(indexCols); i++ {
+		if f.cols[i].ID != indexCols[i].ID {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (f *indexFields) Cols() []*model.ColumnInfo {
+	return f.cols
+}
+
+// IsEmpty returns true if the struct represents an empty
+// user-configured "index-fields" option.
+func (f *indexFields) IsEmpty() bool {
+	return f.empty
+}
+
+func sortColsInPlace(cols []*model.ColumnInfo) {
+	sort.SliceStable(cols, func(i, j int) bool {
+		return cols[i].ID < cols[j].ID
+	})
+}

--- a/sync_diff_inspector/splitter/index_fields_test.go
+++ b/sync_diff_inspector/splitter/index_fields_test.go
@@ -1,0 +1,106 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitter
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb-tools/pkg/dbutil"
+	"github.com/pingcap/tidb/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexFieldsSimple(t *testing.T) {
+	t.Parallel()
+
+	createTableSQL1 := "CREATE TABLE `sbtest1` " +
+		"(`id` int(11) NOT NULL AUTO_INCREMENT, " +
+		" `k` int(11) NOT NULL DEFAULT '0', " +
+		"`c` char(120) NOT NULL DEFAULT '', " +
+		"PRIMARY KEY (`id`), KEY `k_1` (`k`))"
+
+	tableInfo, err := dbutil.GetTableInfoBySQL(createTableSQL1, parser.New())
+	require.NoError(t, err)
+
+	fields, err := indexFieldsFromConfigString("k", tableInfo)
+	require.NoError(t, err)
+	require.False(t, fields.IsEmpty())
+	require.Len(t, fields.Cols(), 1)
+
+	for _, index := range tableInfo.Indices {
+		switch index.Name.String() {
+		case "PRIMARY":
+			require.False(t, fields.MatchesIndex(index))
+		case "k_1":
+			require.True(t, fields.MatchesIndex(index))
+		default:
+			require.FailNow(t, "unreachable")
+		}
+	}
+}
+
+func TestIndexFieldsComposite(t *testing.T) {
+	t.Parallel()
+
+	createTableSQL1 := "CREATE TABLE `sbtest1` " +
+		"(`id` int(11) NOT NULL AUTO_INCREMENT, " +
+		" `k` int(11) NOT NULL DEFAULT '0', " +
+		"`c` char(120) NOT NULL DEFAULT '', " +
+		"PRIMARY KEY (`id`, `k`)," +
+		"KEY `k_1` (`k`)," +
+		"UNIQUE INDEX `c_1` (`c`))"
+
+	tableInfo, err := dbutil.GetTableInfoBySQL(createTableSQL1, parser.New())
+	require.NoError(t, err)
+
+	fields, err := indexFieldsFromConfigString("id, k", tableInfo)
+	require.NoError(t, err)
+	require.False(t, fields.IsEmpty())
+	require.Len(t, fields.Cols(), 2)
+
+	for _, index := range tableInfo.Indices {
+		switch index.Name.String() {
+		case "PRIMARY":
+			require.True(t, fields.MatchesIndex(index))
+		case "k_1":
+			require.False(t, fields.MatchesIndex(index))
+		case "c_1":
+			require.False(t, fields.MatchesIndex(index))
+		default:
+			require.FailNow(t, "unreachable")
+		}
+	}
+}
+
+func TestIndexFieldsEmpty(t *testing.T) {
+	t.Parallel()
+
+	createTableSQL1 := "CREATE TABLE `sbtest1` " +
+		"(`id` int(11) NOT NULL AUTO_INCREMENT, " +
+		" `k` int(11) NOT NULL DEFAULT '0', " +
+		"`c` char(120) NOT NULL DEFAULT '', " +
+		"PRIMARY KEY (`id`), KEY `k_1` (`k`))"
+
+	tableInfo, err := dbutil.GetTableInfoBySQL(createTableSQL1, parser.New())
+	require.NoError(t, err)
+
+	fields, err := indexFieldsFromConfigString("", tableInfo)
+	require.NoError(t, err)
+	require.True(t, fields.IsEmpty())
+
+	for _, index := range tableInfo.Indices {
+		// Expected to match all.
+		require.True(t, fields.MatchesIndex(index))
+	}
+}

--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -905,3 +905,11 @@ func GetChunkIDFromSQLFileName(fileIDStr string) (int, int, int, int, error) {
 	}
 	return tableIndex, bucketIndexLeft, bucketIndexRight, chunkIndex, nil
 }
+
+// IsRangeTrivial checks if a user configured Range is empty or `TRUE`.
+func IsRangeTrivial(rangeCond string) bool {
+	if rangeCond == "" {
+		return true
+	}
+	return strings.ToLower(rangeCond) == "true"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #623 

### What is changed and how it works?
- Added `index-fields` index selection for `BucketIterator`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test

Related changes

 - Need to cherry-pick to the release branch
