### PR TITLE
sync-diff-inspector: change bit_xor to sum

### DIFF
--- a/sync_diff_inspector/source/common/table_diff.go
+++ b/sync_diff_inspector/source/common/table_diff.go
@@ -62,6 +62,9 @@ type TableDiff struct {
 	// the table has column timestamp, which need to reset time_zone.
 	NeedUnifiedTimeZone bool `json:"-"`
 
+	// the table has unique column, so it's ok to use bit_xor function.
+	HasUniqueColumn bool `json:"-"`
+
 	Collation string `json:"collation"`
 
 	ChunkSize int64 `json:"chunk-size"`

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -123,16 +123,16 @@ func NewSources(ctx context.Context, cfg *config.Config) (downstream Source, ups
 
 	tableDiffs := make([]*common.TableDiff, 0, len(tablesToBeCheck))
 	for _, tableConfig := range tablesToBeCheck {
-		newInfo, needUnifiedTimeZone := utils.ResetColumns(tableConfig.TargetTableInfo, tableConfig.IgnoreColumns)
+		newInfo, needUnifiedTimeZone, hasUniqueColumn := utils.ResetColumns(tableConfig.TargetTableInfo, tableConfig.IgnoreColumns)
 		tableDiffs = append(tableDiffs, &common.TableDiff{
-			Schema: tableConfig.Schema,
-			Table:  tableConfig.Table,
-			Info:   newInfo,
-			// TODO: field `IgnoreColumns` can be deleted.
+			Schema:              tableConfig.Schema,
+			Table:               tableConfig.Table,
+			Info:                newInfo,
 			IgnoreColumns:       tableConfig.IgnoreColumns,
 			Fields:              strings.Join(tableConfig.Fields, ","),
 			Range:               tableConfig.Range,
 			NeedUnifiedTimeZone: needUnifiedTimeZone,
+			HasUniqueColumn:     hasUniqueColumn,
 			Collation:           tableConfig.Collation,
 			ChunkSize:           tableConfig.ChunkSize,
 		})

--- a/sync_diff_inspector/source/tidb.go
+++ b/sync_diff_inspector/source/tidb.go
@@ -123,7 +123,7 @@ func (s *TiDBSource) GetCountAndCrc32(ctx context.Context, tableRange *splitter.
 	chunk := tableRange.GetChunk()
 
 	matchSource := getMatchSource(s.sourceTableMap, table)
-	count, checksum, err := utils.GetCountAndCRC32Checksum(ctx, s.dbConn, matchSource.OriginSchema, matchSource.OriginTable, table.Info, chunk.Where, chunk.Args)
+	count, checksum, err := utils.GetCountAndCRC32Checksum(ctx, s.dbConn, matchSource.OriginSchema, matchSource.OriginTable, table.Info, table.HasUniqueColumn, chunk.Where, chunk.Args)
 
 	cost := time.Since(beginTime)
 	return &ChecksumInfo{
@@ -147,7 +147,7 @@ func (s *TiDBSource) GetSourceStructInfo(ctx context.Context, tableIndex int) ([
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	tableInfos[0], _ = utils.ResetColumns(tableInfos[0], tableDiff.IgnoreColumns)
+	tableInfos[0], _, _ = utils.ResetColumns(tableInfos[0], tableDiff.IgnoreColumns)
 	return tableInfos, nil
 }
 

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -322,13 +322,14 @@ func TestRandomSpliter(t *testing.T) {
 		tableInfo, err := dbutil.GetTableInfoBySQL(testCase.createTableSQL, parser.New())
 		require.NoError(t, err)
 
-		info, needUnifiedTimeStamp := utils.ResetColumns(tableInfo, testCase.IgnoreColumns)
+		info, needUnifiedTimeStamp, hasUniqueColumn := utils.ResetColumns(tableInfo, testCase.IgnoreColumns)
 		tableDiff := &common.TableDiff{
 			Schema:              "test",
 			Table:               "test",
 			Info:                info,
 			IgnoreColumns:       testCase.IgnoreColumns,
 			NeedUnifiedTimeZone: needUnifiedTimeStamp,
+			HasUniqueColumn:     hasUniqueColumn,
 			Fields:              testCase.fields,
 			ChunkSize:           5,
 		}

--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -710,7 +710,7 @@ func GetTableSize(ctx context.Context, db *sql.DB, schemaName, tableName string)
 func GetCountAndCRC32Checksum(ctx context.Context, db *sql.DB, schemaName, tableName string, tbInfo *model.TableInfo, limitRange string, args []interface{}) (int64, int64, error) {
 	/*
 		calculate CRC32 checksum and count example:
-		mysql> select count(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', id, name, age, CONCAT(ISNULL(id), ISNULL(name), ISNULL(age))))AS UNSIGNED)) as CHECKSUM from test.test where id > 0;
+		mysql> select count(*) as CNT, SUM(CAST(CRC32(CONCAT_WS(',', id, name, age, CONCAT(ISNULL(id), ISNULL(name), ISNULL(age))))AS UNSIGNED)) as CHECKSUM from test.test where id > 0;
 		+--------+------------+
 		|  CNT   |  CHECKSUM  |
 		+--------+------------+
@@ -733,7 +733,7 @@ func GetCountAndCRC32Checksum(ctx context.Context, db *sql.DB, schemaName, table
 		columnIsNull = append(columnIsNull, fmt.Sprintf("ISNULL(%s)", name))
 	}
 
-	query := fmt.Sprintf("SELECT COUNT(*) as CNT, BIT_XOR(CAST(CRC32(CONCAT_WS(',', %s, CONCAT(%s)))AS UNSIGNED)) as CHECKSUM FROM %s WHERE %s;",
+	query := fmt.Sprintf("SELECT COUNT(*) as CNT, SUM(CAST(CRC32(CONCAT_WS(',', %s, CONCAT(%s)))AS UNSIGNED)) as CHECKSUM FROM %s WHERE %s;",
 		strings.Join(columnNames, ", "), strings.Join(columnIsNull, ", "), dbutil.TableName(schemaName, tableName), limitRange)
 	log.Debug("count and checksum", zap.String("sql", query), zap.Reflect("args", args))
 

--- a/sync_diff_inspector/utils/utils_test.go
+++ b/sync_diff_inspector/utils/utils_test.go
@@ -254,16 +254,16 @@ func TestGetCountAndCRC32Checksum(t *testing.T) {
 	tableInfo, err := dbutil.GetTableInfoBySQL(createTableSQL, parser.New())
 	require.NoError(t, err)
 
-	mock.ExpectQuery("SELECT COUNT(*) as CNT, BIT_XOR.*FROM `test_schema`\\.`test_table` WHERE \\[23 45\\].*").WithArgs("123", "234").WillReturnRows(sqlmock.NewRows([]string{"CNT", "CHECKSUM"}).AddRow(123, 456))
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) as CNT, BIT_XOR.*FROM `test_schema`\\.`test_table` WHERE \\[23 45\\].*").WithArgs("123", "234").WillReturnRows(sqlmock.NewRows([]string{"CNT", "CHECKSUM"}).AddRow(123, 456))
 
 	count, checksum, err := GetCountAndCRC32Checksum(ctx, conn, "test_schema", "test_table", tableInfo, true, "[23 45]", []interface{}{"123", "234"})
 	require.NoError(t, err)
 	require.Equal(t, count, int64(123))
 	require.Equal(t, checksum, int64(456))
 
-	mock.ExpectQuery("SELECT COUNT(*) as CNT, SUM.*FROM `test_schema`\\.`test_table` WHERE \\[23 45\\].*").WithArgs("123", "234").WillReturnRows(sqlmock.NewRows([]string{"CNT", "CHECKSUM"}).AddRow(456, 123))
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) as CNT, SUM.*FROM `test_schema`\\.`test_table` WHERE \\[23 45\\].*").WithArgs("123", "234").WillReturnRows(sqlmock.NewRows([]string{"CNT", "CHECKSUM"}).AddRow(456, 123))
 
-	count, checksum, err = GetCountAndCRC32Checksum(ctx, conn, "test_schema", "test_table", tableInfo, true, "[23 45]", []interface{}{"123", "234"})
+	count, checksum, err = GetCountAndCRC32Checksum(ctx, conn, "test_schema", "test_table", tableInfo, false, "[23 45]", []interface{}{"123", "234"})
 	require.NoError(t, err)
 	require.Equal(t, count, int64(456))
 	require.Equal(t, checksum, int64(123))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #634 

### What is changed and how it works?
use `SUM` instead of `BIT_XOR`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

