### PR TITLE
sync-diff-inspector: skip validation for tables that exist only upstream or downstream and print skipped information in summary and progress

### DIFF
--- a/sync_diff_inspector/config/config.go
+++ b/sync_diff_inspector/config/config.go
@@ -374,6 +374,8 @@ type Config struct {
 	CheckStructOnly bool `toml:"check-struct-only" json:"check-struct-only"`
 	// experimental feature: only check table data without table struct
 	CheckDataOnly bool `toml:"check-data-only" json:"-"`
+	// skip validation for tables that don't exist upstream or downstream
+	SkipNonExistingTable bool `toml:"skip-non-existing-table" json:"-"`
 	// DMAddr is dm-master's address, the format should like "http://127.0.0.1:8261"
 	DMAddr string `toml:"dm-addr" json:"dm-addr"`
 	// DMTask string `toml:"dm-task" json:"dm-task"`
@@ -411,6 +413,7 @@ func NewConfig() *Config {
 	fs.IntVar(&cfg.CheckThreadCount, "check-thread-count", 4, "how many goroutines are created to check data")
 	fs.BoolVar(&cfg.ExportFixSQL, "export-fix-sql", true, "set true if want to compare rows or set to false will only compare checksum")
 	fs.BoolVar(&cfg.CheckStructOnly, "check-struct-only", false, "ignore check table's data")
+	fs.BoolVar(&cfg.SkipNonExistingTable, "skip-non-existing-table", false, "skip validation for tables that don't exist upstream or downstream")
 	fs.BoolVar(&cfg.CheckDataOnly, "check-data-only", false, "ignore check table's struct")
 
 	_ = fs.MarkHidden("check-data-only")

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -297,16 +297,13 @@ func (df *Diff) StructEqual(ctx context.Context) error {
 		tableIndex = df.startRange.ChunkRange.Index.TableIndex
 	}
 	for ; tableIndex < len(tables); tableIndex++ {
-		var isEqual, isSkip bool
-		isAllTableExist := tables[tableIndex].NeedSkippedTable
+		isEqual, isSkip, isAllTableExist := false, true, tables[tableIndex].NeedSkippedTable
 		if source.AllTableExist(tables[tableIndex]) {
 			var err error
 			isEqual, isSkip, err = df.compareStruct(ctx, tableIndex)
 			if err != nil {
 				return errors.Trace(err)
 			}
-		} else {
-			isEqual, isSkip = false, true
 		}
 		progress.RegisterTable(dbutil.TableName(tables[tableIndex].Schema, tables[tableIndex].Table), !isEqual, isSkip, isAllTableExist)
 		df.report.SetTableStructCheckResult(tables[tableIndex].Schema, tables[tableIndex].Table, isEqual, isSkip, isAllTableExist)

--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -298,7 +298,7 @@ func (df *Diff) StructEqual(ctx context.Context) error {
 	}
 	for ; tableIndex < len(tables); tableIndex++ {
 		isEqual, isSkip, isAllTableExist := false, true, tables[tableIndex].TableLack
-		if common.AllTableExist(tables[tableIndex].TableLack) {
+		if common.AllTableExist(isAllTableExist) {
 			var err error
 			isEqual, isSkip, err = df.compareStruct(ctx, tableIndex)
 			if err != nil {
@@ -422,8 +422,8 @@ func (df *Diff) consume(ctx context.Context, rangeInfo *splitter.RangeInfo) bool
 		dml.node.State = checkpoints.IgnoreState
 		// for tables that don't exist upstream or downstream
 		if !common.AllTableExist(tableDiff.TableLack) {
-			upCount := df.upstream.GetCountAndCrc32(ctx, rangeInfo).Count
-			downCount := df.downstream.GetCountAndCrc32(ctx, rangeInfo).Count
+			upCount := df.upstream.GetCountForLackTable(ctx, rangeInfo)
+			downCount := df.downstream.GetCountForLackTable(ctx, rangeInfo)
 			df.report.SetTableDataCheckResult(schema, table, false, int(upCount), int(downCount), upCount, downCount, id)
 			return false
 		}

--- a/sync_diff_inspector/progress/progress.go
+++ b/sync_diff_inspector/progress/progress.go
@@ -135,11 +135,12 @@ func (tpp *TableProgressPrinter) RegisterTable(name string, isFailed bool, isDon
 	var state table_state_t
 	if isFailed {
 		if isDone {
-			if isExist == common.UpstreamTableLackFlag {
+			switch isExist {
+			case common.UpstreamTableLackFlag:
 				state = TABLE_STATE_NOT_EXSIT_UPSTREAM | TABLE_STATE_REGISTER
-			} else if isExist == common.DownstreamTableLackFlag {
+			case common.DownstreamTableLackFlag:
 				state = TABLE_STATE_NOT_EXSIT_DOWNSTREAM | TABLE_STATE_REGISTER
-			} else {
+			default:
 				state = TABLE_STATE_RESULT_FAIL_STRUCTURE_DONE | TABLE_STATE_REGISTER
 			}
 		} else {

--- a/sync_diff_inspector/progress/progress.go
+++ b/sync_diff_inspector/progress/progress.go
@@ -135,9 +135,9 @@ func (tpp *TableProgressPrinter) RegisterTable(name string, isFailed bool, isDon
 	var state table_state_t
 	if isFailed {
 		if isDone {
-			if isExist == common.DownstreamTableLackFlag {
+			if isExist == common.UpstreamTableLackFlag {
 				state = TABLE_STATE_NOT_EXSIT_UPSTREAM | TABLE_STATE_REGISTER
-			} else if isExist == common.UpstreamTableLackFlag {
+			} else if isExist == common.DownstreamTableLackFlag {
 				state = TABLE_STATE_NOT_EXSIT_DOWNSTREAM | TABLE_STATE_REGISTER
 			} else {
 				state = TABLE_STATE_RESULT_FAIL_STRUCTURE_DONE | TABLE_STATE_REGISTER

--- a/sync_diff_inspector/progress/progress.go
+++ b/sync_diff_inspector/progress/progress.go
@@ -127,7 +127,7 @@ func (tpp *TableProgressPrinter) UpdateTotal(name string, total int, stopUpdate 
 	}
 }
 
-func (tpp *TableProgressPrinter) RegisterTable(name string, isFailed bool, isDone bool) {
+func (tpp *TableProgressPrinter) RegisterTable(name string, isFailed bool, isDone bool, isAllExist int) {
 	var state table_state_t
 	if isFailed {
 		if isDone {
@@ -410,9 +410,9 @@ func UpdateTotal(name string, total int, stopUpdate bool) {
 	}
 }
 
-func RegisterTable(name string, isFailed bool, isDone bool) {
+func RegisterTable(name string, isFailed bool, isDone bool, isAllExist int) {
 	if progress_ != nil {
-		progress_.RegisterTable(name, isFailed, isDone)
+		progress_.RegisterTable(name, isFailed, isDone, isAllExist)
 	}
 }
 

--- a/sync_diff_inspector/progress/progress_test.go
+++ b/sync_diff_inspector/progress/progress_test.go
@@ -24,12 +24,12 @@ import (
 
 func TestProgress(t *testing.T) {
 	p := NewTableProgressPrinter(4, 0)
-	p.RegisterTable("1", true, true)
+	p.RegisterTable("1", true, true, 0)
 	p.StartTable("1", 50, true)
-	p.RegisterTable("2", true, false)
+	p.RegisterTable("2", true, false, 0)
 	p.StartTable("2", 2, true)
 	p.Inc("2")
-	p.RegisterTable("3", false, false)
+	p.RegisterTable("3", false, false, 0)
 	p.StartTable("3", 1, false)
 	p.Inc("2")
 	p.Inc("3")
@@ -55,9 +55,9 @@ func TestProgress(t *testing.T) {
 
 func TestTableError(t *testing.T) {
 	p := NewTableProgressPrinter(4, 0)
-	p.RegisterTable("1", true, true)
+	p.RegisterTable("1", true, true, 0)
 	p.StartTable("1", 50, true)
-	p.RegisterTable("2", true, true)
+	p.RegisterTable("2", true, true, 0)
 	p.StartTable("2", 1, true)
 	p.Inc("2")
 	buffer := new(bytes.Buffer)
@@ -80,9 +80,9 @@ func TestTableError(t *testing.T) {
 
 func TestAllSuccess(t *testing.T) {
 	Init(2, 0)
-	RegisterTable("1", false, false)
+	RegisterTable("1", false, false, 0)
 	StartTable("1", 1, true)
-	RegisterTable("2", false, false)
+	RegisterTable("2", false, false, 0)
 	StartTable("2", 1, true)
 	Inc("1")
 	Inc("2")

--- a/sync_diff_inspector/progress/progress_test.go
+++ b/sync_diff_inspector/progress/progress_test.go
@@ -59,6 +59,9 @@ func TestTableError(t *testing.T) {
 	p.StartTable("1", 50, true)
 	p.RegisterTable("2", true, true, 0)
 	p.StartTable("2", 1, true)
+	p.RegisterTable("3", true, true, -1)
+	p.StartTable("3", 1, true)
+
 	p.Inc("2")
 	buffer := new(bytes.Buffer)
 	p.SetOutput(buffer)
@@ -73,6 +76,9 @@ func TestTableError(t *testing.T) {
 			"\x1b[2A\x1b[JComparing the table structure of `2` ... failure\n"+
 			"_____________________________________________________________________________\n"+
 			"Progress [==============================>------------------------------] 50% 0/0\n"+
+			"\x1b[2A\x1b[JComparing the table data of `3` ...skipped\n"+
+			"_____________________________________________________________________________\n"+
+			"Progress [=============================================>---------------] 75% 0/1\n"+
 			"\x1b[1A\x1b[J\nError in comparison process:\n[aaa]\n\n"+
 			"You can view the comparison details through './output_dir/sync_diff_inspector.log'\n",
 	)

--- a/sync_diff_inspector/progress/progress_test.go
+++ b/sync_diff_inspector/progress/progress_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestProgress(t *testing.T) {
 	p := NewTableProgressPrinter(4, 0)
-	p.RegisterTable("1", true, true, 0)
+	p.RegisterTable("1", true, true, 1)
 	p.StartTable("1", 50, true)
 	p.RegisterTable("2", true, false, 0)
 	p.StartTable("2", 2, true)
@@ -47,8 +47,8 @@ func TestProgress(t *testing.T) {
 	require.Equal(
 		t,
 		buffer.String(),
-		"\x1b[1A\x1b[J\nSummary:\n\nThe structure of `1` is not equal.\nThe structure of `2` is not equal.\nThe data of `4` is not equal.\n"+
-			"\nThe rest of the tables are all equal.\nThe patch file has been generated to './output_dir/patch.sql'\n"+
+		"\x1b[1A\x1b[J\nSummary:\n\nThe data of `1` does not exist in upstream database.\nThe structure of `2` is not equal.\nThe data of `4` is not equal.\n"+
+			"\nThe rest of the tables are all equal.\nA total of 4 tables have been compared, 1 tables finished, 2 tables failed, 1 tables skipped.\nThe patch file has been generated to './output_dir/patch.sql'\n"+
 			"You can view the comparison details through './output_dir/sync_diff_inspector.log'\n\n",
 	)
 }

--- a/sync_diff_inspector/report/report.go
+++ b/sync_diff_inspector/report/report.go
@@ -80,7 +80,7 @@ type Report struct {
 	Result       string                             `json:"-"`             // Result is pass or fail
 	PassNum      int32                              `json:"-"`             // The pass number of tables
 	FailedNum    int32                              `json:"-"`             // The failed number of tables
-	SkippedNum   int32                              `json:"-"`             // Theskippeded number of tables
+	SkippedNum   int32                              `json:"-"`             // The skipped number of tables
 	TableResults map[string]map[string]*TableResult `json:"table-results"` // TableResult saved the map of  `schema` => `table` => `tableResult`
 	StartTime    time.Time                          `json:"start-time"`
 	Duration     time.Duration                      `json:"time-duration"`

--- a/sync_diff_inspector/report/report.go
+++ b/sync_diff_inspector/report/report.go
@@ -56,16 +56,16 @@ type ReportConfig struct {
 
 // TableResult saves the check result for every table.
 type TableResult struct {
-	Schema       string                  `json:"schema"`
-	Table        string                  `json:"table"`
-	StructEqual  bool                    `json:"struct-equal"`
-	DataSkip     bool                    `json:"data-skip"`
-	DataEqual    bool                    `json:"data-equal"`
-	MeetError    error                   `json:"-"`
-	ChunkMap     map[string]*ChunkResult `json:"chunk-result"` // `ChunkMap` stores the `ChunkResult` of each chunk of the table
-	UpCount      int64                   `json:"up-count"`     // `UpCount` is the number of rows in the table from upstream
-	DownCount    int64                   `json:"down-count"`   // `DownCount` is the number of rows in the table from downstream
-	TableSkipped int                     `json:"table-skipped"`
+	Schema      string                  `json:"schema"`
+	Table       string                  `json:"table"`
+	StructEqual bool                    `json:"struct-equal"`
+	DataSkip    bool                    `json:"data-skip"`
+	DataEqual   bool                    `json:"data-equal"`
+	MeetError   error                   `json:"-"`
+	ChunkMap    map[string]*ChunkResult `json:"chunk-result"` // `ChunkMap` stores the `ChunkResult` of each chunk of the table
+	UpCount     int64                   `json:"up-count"`     // `UpCount` is the number of rows in the table from upstream
+	DownCount   int64                   `json:"down-count"`   // `DownCount` is the number of rows in the table from downstream
+	TableLack   int                     `json:"table-lack"`
 }
 
 // ChunkResult save the necessarily information to provide summary information
@@ -317,7 +317,7 @@ func (r *Report) SetTableStructCheckResult(schema, table string, equal bool, ski
 	tableResult := r.TableResults[schema][table]
 	tableResult.StructEqual = equal
 	tableResult.DataSkip = skip
-	tableResult.TableSkipped = exist
+	tableResult.TableLack = exist
 	if !equal && AllTableExist(tableResult) && r.Result != Error {
 		r.Result = Fail
 	}
@@ -418,22 +418,13 @@ func (r *Report) GetSnapshot(chunkID *chunk.ChunkID, schema, table string) (*Rep
 }
 
 func AllTableExist(result *TableResult) bool {
-	if result.TableSkipped == common.AllTableExistFlag {
-		return true
-	}
-	return false
+	return result.TableLack == common.AllTableExistFlag
 }
 
 func UpstreamTableLack(result *TableResult) bool {
-	if result.TableSkipped == common.UpstreamTableLackFlag {
-		return true
-	}
-	return false
+	return result.TableLack == common.UpstreamTableLackFlag
 }
 
 func DownstreamTableLack(result *TableResult) bool {
-	if result.TableSkipped == common.DownstreamTableLackFlag {
-		return true
-	}
-	return false
+	return result.TableLack == common.DownstreamTableLackFlag
 }

--- a/sync_diff_inspector/report/report_test.go
+++ b/sync_diff_inspector/report/report_test.go
@@ -110,7 +110,7 @@ func TestReport(t *testing.T) {
 	report.CalculateTotalSize(ctx, db)
 
 	// Test Table Report
-	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
+	report.SetTableStructCheckResult("test", "tbl", true, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("test", "tbl", true, 100, 200, 222, 222, &chunk.ChunkID{1, 1, 1, 1, 2})
 	report.SetTableMeetError("test", "tbl", errors.New("eeee"))
 
@@ -127,18 +127,18 @@ func TestReport(t *testing.T) {
 	require.Equal(t, new_report.getSortedTables(), [][]string{{"`atest`.`atbl`", "0", "0"}, {"`ctest`.`atbl`", "0", "0"}, {"`dtest`.`atbl`", "0", "0"}, {"`test`.`tbl`", "222", "222"}})
 	require.Equal(t, new_report.getDiffRows(), [][]string{})
 
-	new_report.SetTableStructCheckResult("atest", "atbl", true, false, 0)
+	new_report.SetTableStructCheckResult("atest", "atbl", true, false, common.AllTableExistFlag)
 	new_report.SetTableDataCheckResult("atest", "atbl", false, 111, 222, 333, 333, &chunk.ChunkID{1, 1, 1, 1, 2})
 	require.Equal(t, new_report.getSortedTables(), [][]string{{"`ctest`.`atbl`", "0", "0"}, {"`dtest`.`atbl`", "0", "0"}, {"`test`.`tbl`", "222", "222"}})
 	require.Equal(t, new_report.getDiffRows(), [][]string{{"`atest`.`atbl`", "succeed", "true", "+111/-222", "333", "333"}})
 
-	new_report.SetTableStructCheckResult("atest", "atbl", false, false, 0)
+	new_report.SetTableStructCheckResult("atest", "atbl", false, false, common.AllTableExistFlag)
 	require.Equal(t, new_report.getSortedTables(), [][]string{{"`ctest`.`atbl`", "0", "0"}, {"`dtest`.`atbl`", "0", "0"}, {"`test`.`tbl`", "222", "222"}})
 	require.Equal(t, new_report.getDiffRows(), [][]string{{"`atest`.`atbl`", "succeed", "false", "+111/-222", "333", "333"}})
 
-	new_report.SetTableStructCheckResult("ctest", "atbl", false, true, 0)
+	new_report.SetTableStructCheckResult("ctest", "atbl", false, true, common.AllTableExistFlag)
 
-	new_report.SetTableStructCheckResult("dtest", "atbl", false, true, -1)
+	new_report.SetTableStructCheckResult("dtest", "atbl", false, true, common.DownstreamTableLackFlag)
 
 	buf := new(bytes.Buffer)
 	new_report.Print(buf)
@@ -255,7 +255,7 @@ func TestPrint(t *testing.T) {
 
 	var buf *bytes.Buffer
 	// All Pass
-	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
+	report.SetTableStructCheckResult("test", "tbl", true, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("test", "tbl", true, 0, 0, 22, 22, &chunk.ChunkID{0, 0, 0, 0, 1})
 	buf = new(bytes.Buffer)
 	report.Print(buf)
@@ -264,7 +264,7 @@ func TestPrint(t *testing.T) {
 
 	// Error
 	report.SetTableMeetError("test", "tbl1", errors.New("123"))
-	report.SetTableStructCheckResult("test", "tbl1", false, false, 0)
+	report.SetTableStructCheckResult("test", "tbl1", false, false, common.AllTableExistFlag)
 	buf = new(bytes.Buffer)
 	report.Print(buf)
 	require.Equal(t, buf.String(), "Error in comparison process:\n"+
@@ -329,17 +329,17 @@ func TestGetSnapshot(t *testing.T) {
 	}
 	report.Init(tableDiffs, configsBytes[:2], configsBytes[2])
 
-	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
+	report.SetTableStructCheckResult("test", "tbl", true, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("test", "tbl", false, 100, 100, 200, 300, &chunk.ChunkID{0, 0, 0, 1, 10})
 	report.SetTableDataCheckResult("test", "tbl", true, 0, 0, 300, 300, &chunk.ChunkID{0, 0, 0, 3, 10})
 	report.SetTableDataCheckResult("test", "tbl", false, 200, 200, 400, 500, &chunk.ChunkID{0, 0, 0, 3, 10})
 
-	report.SetTableStructCheckResult("atest", "tbl", true, false, 0)
+	report.SetTableStructCheckResult("atest", "tbl", true, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("atest", "tbl", false, 100, 100, 500, 600, &chunk.ChunkID{0, 0, 0, 0, 10})
 	report.SetTableDataCheckResult("atest", "tbl", true, 0, 0, 600, 600, &chunk.ChunkID{0, 0, 0, 3, 10})
 	report.SetTableDataCheckResult("atest", "tbl", false, 200, 200, 700, 800, &chunk.ChunkID{0, 0, 0, 3, 10})
 
-	report.SetTableStructCheckResult("xtest", "tbl", true, false, 0)
+	report.SetTableStructCheckResult("xtest", "tbl", true, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("xtest", "tbl", false, 100, 100, 800, 900, &chunk.ChunkID{0, 0, 0, 0, 10})
 	report.SetTableDataCheckResult("xtest", "tbl", true, 0, 0, 900, 900, &chunk.ChunkID{0, 0, 0, 1, 10})
 	report.SetTableDataCheckResult("xtest", "tbl", false, 200, 200, 1000, 1100, &chunk.ChunkID{0, 0, 0, 3, 10})
@@ -463,19 +463,19 @@ func TestCommitSummary(t *testing.T) {
 	}
 	report.Init(tableDiffs, configsBytes[:2], configsBytes[2])
 
-	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
+	report.SetTableStructCheckResult("test", "tbl", true, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("test", "tbl", true, 100, 200, 400, 400, &chunk.ChunkID{0, 0, 0, 1, 10})
 
-	report.SetTableStructCheckResult("atest", "tbl", true, false, 0)
+	report.SetTableStructCheckResult("atest", "tbl", true, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("atest", "tbl", false, 100, 200, 500, 600, &chunk.ChunkID{0, 0, 0, 2, 10})
 
-	report.SetTableStructCheckResult("xtest", "tbl", false, false, 0)
+	report.SetTableStructCheckResult("xtest", "tbl", false, false, common.AllTableExistFlag)
 	report.SetTableDataCheckResult("xtest", "tbl", false, 100, 200, 600, 700, &chunk.ChunkID{0, 0, 0, 3, 10})
 
-	report.SetTableStructCheckResult("xtest", "tb1", false, true, 1)
+	report.SetTableStructCheckResult("xtest", "tb1", false, true, common.UpstreamTableLackFlag)
 	report.SetTableDataCheckResult("xtest", "tb1", false, 0, 200, 0, 200, &chunk.ChunkID{0, 0, 0, 4, 10})
 
-	report.SetTableStructCheckResult("xtest", "tb2", false, true, -1)
+	report.SetTableStructCheckResult("xtest", "tb2", false, true, common.DownstreamTableLackFlag)
 	report.SetTableDataCheckResult("xtest", "tb2", false, 100, 0, 100, 0, &chunk.ChunkID{0, 0, 0, 5, 10})
 
 	err = report.CommitSummary()

--- a/sync_diff_inspector/report/report_test.go
+++ b/sync_diff_inspector/report/report_test.go
@@ -104,7 +104,7 @@ func TestReport(t *testing.T) {
 	report.CalculateTotalSize(ctx, db)
 
 	// Test Table Report
-	report.SetTableStructCheckResult("test", "tbl", true, false)
+	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
 	report.SetTableDataCheckResult("test", "tbl", true, 100, 200, 222, 222, &chunk.ChunkID{1, 1, 1, 1, 2})
 	report.SetTableMeetError("test", "tbl", errors.New("eeee"))
 
@@ -121,16 +121,16 @@ func TestReport(t *testing.T) {
 	require.Equal(t, new_report.getSortedTables(), [][]string{{"`atest`.`atbl`", "0", "0"}, {"`ctest`.`atbl`", "0", "0"}, {"`test`.`tbl`", "222", "222"}})
 	require.Equal(t, new_report.getDiffRows(), [][]string{})
 
-	new_report.SetTableStructCheckResult("atest", "atbl", true, false)
+	new_report.SetTableStructCheckResult("atest", "atbl", true, false, 0)
 	new_report.SetTableDataCheckResult("atest", "atbl", false, 111, 222, 333, 333, &chunk.ChunkID{1, 1, 1, 1, 2})
 	require.Equal(t, new_report.getSortedTables(), [][]string{{"`ctest`.`atbl`", "0", "0"}, {"`test`.`tbl`", "222", "222"}})
-	require.Equal(t, new_report.getDiffRows(), [][]string{{"`atest`.`atbl`", "true", "+111/-222", "333", "333"}})
+	require.Equal(t, new_report.getDiffRows(), [][]string{{"`atest`.`atbl`", "succeed", "true", "+111/-222", "333", "333"}})
 
-	new_report.SetTableStructCheckResult("atest", "atbl", false, false)
+	new_report.SetTableStructCheckResult("atest", "atbl", false, false, 0)
 	require.Equal(t, new_report.getSortedTables(), [][]string{{"`ctest`.`atbl`", "0", "0"}, {"`test`.`tbl`", "222", "222"}})
-	require.Equal(t, new_report.getDiffRows(), [][]string{{"`atest`.`atbl`", "false", "+111/-222", "333", "333"}})
+	require.Equal(t, new_report.getDiffRows(), [][]string{{"`atest`.`atbl`", "succeed", "false", "+111/-222", "333", "333"}})
 
-	new_report.SetTableStructCheckResult("ctest", "atbl", false, true)
+	new_report.SetTableStructCheckResult("ctest", "atbl", false, true, 0)
 
 	buf := new(bytes.Buffer)
 	new_report.Print(buf)
@@ -245,7 +245,7 @@ func TestPrint(t *testing.T) {
 
 	var buf *bytes.Buffer
 	// All Pass
-	report.SetTableStructCheckResult("test", "tbl", true, false)
+	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
 	report.SetTableDataCheckResult("test", "tbl", true, 0, 0, 22, 22, &chunk.ChunkID{0, 0, 0, 0, 1})
 	buf = new(bytes.Buffer)
 	report.Print(buf)
@@ -254,7 +254,7 @@ func TestPrint(t *testing.T) {
 
 	// Error
 	report.SetTableMeetError("test", "tbl1", errors.New("123"))
-	report.SetTableStructCheckResult("test", "tbl1", false, false)
+	report.SetTableStructCheckResult("test", "tbl1", false, false, 0)
 	buf = new(bytes.Buffer)
 	report.Print(buf)
 	require.Equal(t, buf.String(), "Error in comparison process:\n"+
@@ -319,17 +319,17 @@ func TestGetSnapshot(t *testing.T) {
 	}
 	report.Init(tableDiffs, configsBytes[:2], configsBytes[2])
 
-	report.SetTableStructCheckResult("test", "tbl", true, false)
+	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
 	report.SetTableDataCheckResult("test", "tbl", false, 100, 100, 200, 300, &chunk.ChunkID{0, 0, 0, 1, 10})
 	report.SetTableDataCheckResult("test", "tbl", true, 0, 0, 300, 300, &chunk.ChunkID{0, 0, 0, 3, 10})
 	report.SetTableDataCheckResult("test", "tbl", false, 200, 200, 400, 500, &chunk.ChunkID{0, 0, 0, 3, 10})
 
-	report.SetTableStructCheckResult("atest", "tbl", true, false)
+	report.SetTableStructCheckResult("atest", "tbl", true, false, 0)
 	report.SetTableDataCheckResult("atest", "tbl", false, 100, 100, 500, 600, &chunk.ChunkID{0, 0, 0, 0, 10})
 	report.SetTableDataCheckResult("atest", "tbl", true, 0, 0, 600, 600, &chunk.ChunkID{0, 0, 0, 3, 10})
 	report.SetTableDataCheckResult("atest", "tbl", false, 200, 200, 700, 800, &chunk.ChunkID{0, 0, 0, 3, 10})
 
-	report.SetTableStructCheckResult("xtest", "tbl", true, false)
+	report.SetTableStructCheckResult("xtest", "tbl", true, false, 0)
 	report.SetTableDataCheckResult("xtest", "tbl", false, 100, 100, 800, 900, &chunk.ChunkID{0, 0, 0, 0, 10})
 	report.SetTableDataCheckResult("xtest", "tbl", true, 0, 0, 900, 900, &chunk.ChunkID{0, 0, 0, 1, 10})
 	report.SetTableDataCheckResult("xtest", "tbl", false, 200, 200, 1000, 1100, &chunk.ChunkID{0, 0, 0, 3, 10})
@@ -441,13 +441,13 @@ func TestCommitSummary(t *testing.T) {
 	}
 	report.Init(tableDiffs, configsBytes[:2], configsBytes[2])
 
-	report.SetTableStructCheckResult("test", "tbl", true, false)
+	report.SetTableStructCheckResult("test", "tbl", true, false, 0)
 	report.SetTableDataCheckResult("test", "tbl", true, 100, 200, 400, 400, &chunk.ChunkID{0, 0, 0, 1, 10})
 
-	report.SetTableStructCheckResult("atest", "tbl", true, false)
+	report.SetTableStructCheckResult("atest", "tbl", true, false, 0)
 	report.SetTableDataCheckResult("atest", "tbl", false, 100, 200, 500, 600, &chunk.ChunkID{0, 0, 0, 2, 10})
 
-	report.SetTableStructCheckResult("xtest", "tbl", false, false)
+	report.SetTableStructCheckResult("xtest", "tbl", false, false, 0)
 	report.SetTableDataCheckResult("xtest", "tbl", false, 100, 200, 600, 700, &chunk.ChunkID{0, 0, 0, 3, 10})
 
 	err = report.CommitSummary()
@@ -480,13 +480,13 @@ func TestCommitSummary(t *testing.T) {
 		"| `ytest`.`tbl` |       0 |         0 |\n"+
 		"+---------------+---------+-----------+\n\n\n"+
 		"The following tables contains inconsistent data\n\n"+
-		"+---------------+--------------------+----------------+---------+-----------+\n"+
-		"|     TABLE     | STRUCTURE EQUALITY | DATA DIFF ROWS | UPCOUNT | DOWNCOUNT |\n"+
-		"+---------------+--------------------+----------------+---------+-----------+\n")
+		"+---------------+---------+--------------------+----------------+---------+-----------+\n"+
+		"|     TABLE     | RESULT  | STRUCTURE EQUALITY | DATA DIFF ROWS | UPCOUNT | DOWNCOUNT |\n"+
+		"+---------------+---------+--------------------+----------------+---------+-----------+\n")
 	require.Contains(t, str,
-		"| `atest`.`tbl` | true               | +100/-200      |     500 |       600 |\n")
+		"| `atest`.`tbl` | succeed | true               | +100/-200      |     500 |       600 |\n")
 	require.Contains(t, str,
-		"| `xtest`.`tbl` | false              | +100/-200      |     600 |       700 |\n")
+		"| `xtest`.`tbl` | succeed | false              | +100/-200      |     600 |       700 |\n")
 
 	file.Close()
 	err = os.Remove(filename)

--- a/sync_diff_inspector/report/report_test.go
+++ b/sync_diff_inspector/report/report_test.go
@@ -139,7 +139,8 @@ func TestReport(t *testing.T) {
 	require.Contains(t, info, "The data of `atest`.`atbl` is not equal\n")
 	require.Contains(t, info, "The structure of `ctest`.`atbl` is not equal, and data-check is skipped\n")
 	require.Contains(t, info, "\n"+
-		"The rest of tables are all equal.\n"+
+		"The rest of tables are all equal.\n\n"+
+		"A total of 0 tables have been compared, 0 tables finished, 0 tables failed, 0 tables skipped.\n"+
 		"The patch file has been generated in \n\t'output_dir/123456/fix-on-tidb1/'\n"+
 		"You can view the comparision details through 'output_dir/sync_diff.log'\n")
 }

--- a/sync_diff_inspector/source/chunks_iter.go
+++ b/sync_diff_inspector/source/chunks_iter.go
@@ -103,7 +103,7 @@ func (t *ChunksIterator) produceChunks(ctx context.Context, startRange *splitter
 	for ; t.nextTableIndex < len(t.TableDiffs); t.nextTableIndex++ {
 		curTableIndex := t.nextTableIndex
 		// skip data-check, but still need to send a empty chunk to make checkpoint continuous
-		if t.TableDiffs[curTableIndex].IgnoreDataCheck || t.TableDiffs[curTableIndex].NeedSkippedTable != 0 {
+		if t.TableDiffs[curTableIndex].IgnoreDataCheck || !AllTableExist(t.TableDiffs[curTableIndex]) {
 			pool.Apply(func() {
 				table := t.TableDiffs[curTableIndex]
 				progressID := dbutil.TableName(table.Schema, table.Table)

--- a/sync_diff_inspector/source/chunks_iter.go
+++ b/sync_diff_inspector/source/chunks_iter.go
@@ -103,7 +103,7 @@ func (t *ChunksIterator) produceChunks(ctx context.Context, startRange *splitter
 	for ; t.nextTableIndex < len(t.TableDiffs); t.nextTableIndex++ {
 		curTableIndex := t.nextTableIndex
 		// skip data-check, but still need to send a empty chunk to make checkpoint continuous
-		if t.TableDiffs[curTableIndex].IgnoreDataCheck {
+		if t.TableDiffs[curTableIndex].IgnoreDataCheck || t.TableDiffs[curTableIndex].NeedSkippedTable != 0 {
 			pool.Apply(func() {
 				table := t.TableDiffs[curTableIndex]
 				progressID := dbutil.TableName(table.Schema, table.Table)

--- a/sync_diff_inspector/source/chunks_iter.go
+++ b/sync_diff_inspector/source/chunks_iter.go
@@ -103,7 +103,7 @@ func (t *ChunksIterator) produceChunks(ctx context.Context, startRange *splitter
 	for ; t.nextTableIndex < len(t.TableDiffs); t.nextTableIndex++ {
 		curTableIndex := t.nextTableIndex
 		// skip data-check, but still need to send a empty chunk to make checkpoint continuous
-		if t.TableDiffs[curTableIndex].IgnoreDataCheck || !AllTableExist(t.TableDiffs[curTableIndex]) {
+		if t.TableDiffs[curTableIndex].IgnoreDataCheck || !common.AllTableExist(t.TableDiffs[curTableIndex].TableLack) {
 			pool.Apply(func() {
 				table := t.TableDiffs[curTableIndex]
 				progressID := dbutil.TableName(table.Schema, table.Table)

--- a/sync_diff_inspector/source/common/table_diff.go
+++ b/sync_diff_inspector/source/common/table_diff.go
@@ -66,10 +66,10 @@ type TableDiff struct {
 
 	ChunkSize int64 `json:"chunk-size"`
 
-	// NeedSkippedTable = 1: the table only exists downstream,
-	// NeedSkippedTable = -1: the table only exists upstream,
-	// NeedSkippedTable = 0: the table exists both upstream and downstream.
-	NeedSkippedTable int `json:"-"`
+	// TableLack = 1: the table only exists downstream,
+	// TableLack = -1: the table only exists upstream,
+	// TableLack = 0: the table exists both upstream and downstream.
+	TableLack int `json:"-"`
 }
 
 const (
@@ -77,3 +77,7 @@ const (
 	DownstreamTableLackFlag = -1
 	UpstreamTableLackFlag   = 1
 )
+
+func AllTableExist(tableLack int) bool {
+	return tableLack == AllTableExistFlag
+}

--- a/sync_diff_inspector/source/common/table_diff.go
+++ b/sync_diff_inspector/source/common/table_diff.go
@@ -65,4 +65,9 @@ type TableDiff struct {
 	Collation string `json:"collation"`
 
 	ChunkSize int64 `json:"chunk-size"`
+
+	// NeedSkippedTable = 1: the table only exists downstream,
+	// NeedSkippedTable = -1: the table only exists upstream,
+	// NeedSkippedTable = 0: the table exists both upstream and downstream.
+	NeedSkippedTable int `json:"-"`
 }

--- a/sync_diff_inspector/source/common/table_diff.go
+++ b/sync_diff_inspector/source/common/table_diff.go
@@ -71,3 +71,9 @@ type TableDiff struct {
 	// NeedSkippedTable = 0: the table exists both upstream and downstream.
 	NeedSkippedTable int `json:"-"`
 }
+
+const (
+	AllTableExistFlag       = 0
+	UpstreamTableLackFlag   = -1
+	DownstreamTableLackFlag = 1
+)

--- a/sync_diff_inspector/source/common/table_diff.go
+++ b/sync_diff_inspector/source/common/table_diff.go
@@ -74,6 +74,6 @@ type TableDiff struct {
 
 const (
 	AllTableExistFlag       = 0
-	UpstreamTableLackFlag   = -1
-	DownstreamTableLackFlag = 1
+	DownstreamTableLackFlag = -1
+	UpstreamTableLackFlag   = 1
 )

--- a/sync_diff_inspector/source/mysql_shard.go
+++ b/sync_diff_inspector/source/mysql_shard.go
@@ -99,7 +99,7 @@ func (s *MySQLSources) GetCountAndCrc32(ctx context.Context, tableRange *splitte
 	chunk := tableRange.GetChunk()
 
 	// for tables that do not exist upstream or downstream
-	if table.NeedSkippedTable != 0 {
+	if !AllTableExist(table) {
 		return &ChecksumInfo{
 			Count: 0,
 		}
@@ -169,7 +169,7 @@ func (s *MySQLSources) GetRowsIterator(ctx context.Context, tableRange *splitter
 
 	table := s.tableDiffs[tableRange.GetTableIndex()]
 	// for tables that do not exist upstream or downstream
-	if table.NeedSkippedTable != 0 {
+	if !AllTableExist(table) {
 		return nil, nil
 	}
 	matchSources := getMatchedSourcesForTable(s.sourceTablesMap, table)
@@ -234,7 +234,7 @@ func (s *MySQLSources) GetSnapshot() string {
 func (s *MySQLSources) GetSourceStructInfo(ctx context.Context, tableIndex int) ([]*model.TableInfo, error) {
 	tableDiff := s.GetTables()[tableIndex]
 	// for tables that do not exist upstream or downstream
-	if tableDiff.NeedSkippedTable != 0 {
+	if !AllTableExist(tableDiff) {
 		return nil, nil
 	}
 	tableSources := getMatchedSourcesForTable(s.sourceTablesMap, tableDiff)

--- a/sync_diff_inspector/source/mysql_shard.go
+++ b/sync_diff_inspector/source/mysql_shard.go
@@ -296,7 +296,7 @@ func (ms *MultiSourceRowsIterator) Close() {
 	}
 }
 
-func NewMySQLSources(ctx context.Context, tableDiffs []*common.TableDiff, ds []*config.DataSource, threadCount int, f tableFilter.Filter) (Source, error) {
+func NewMySQLSources(ctx context.Context, tableDiffs []*common.TableDiff, ds []*config.DataSource, threadCount int, f tableFilter.Filter, skipNonExistingTable bool) (Source, error) {
 	sourceTablesMap := make(map[string][]*common.TableShardSource)
 	// we should get the real table name
 	// and real table row query from sourceDB.
@@ -369,7 +369,10 @@ func NewMySQLSources(ctx context.Context, tableDiffs []*common.TableDiff, ds []*
 
 	}
 
-	tableDiffs = checkTableMatched(tableDiffs, targetUniqueTableMap, sourceTablesAfterRoute)
+	tableDiffs, err := checkTableMatched(tableDiffs, targetUniqueTableMap, sourceTablesAfterRoute, skipNonExistingTable)
+	if err != nil {
+		return nil, errors.Annotatef(err, "please make sure the filter is correct.")
+	}
 
 	mss := &MySQLSources{
 		tableDiffs:      tableDiffs,

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -383,7 +383,7 @@ func checkTableMatched(tableDiffs []*common.TableDiff, targetMap map[string]stru
 			if !skipNonExistingTable {
 				return tableDiffs, errors.Errorf("the source has no table to be compared. target-table is `%s`", tableDiff)
 			}
-			index := getIndexByUniqueID(tableDiffs, tableDiff)
+			index := getIndexMapForTable(tableDiffs, tableDiff)[tableDiff]
 			if tableDiffs[index].NeedSkippedTable == 0 {
 				tableDiffs[index].NeedSkippedTable = 1
 				log.Info("the source has no table to be compared", zap.String("target-table", tableDiff))
@@ -411,12 +411,13 @@ func checkTableMatched(tableDiffs []*common.TableDiff, targetMap map[string]stru
 }
 
 // Get the index of table in tableDiffs by uniqueID:`schema`.`table`
-func getIndexByUniqueID(tableDiffs []*common.TableDiff, uniqueID string) int {
+func getIndexMapForTable(tableDiffs []*common.TableDiff, uniqueID string) map[string]int {
+	tableIndexMap := make(map[string]int)
 	for i := 0; i < len(tableDiffs); i++ {
 		tableUniqueID := utils.UniqueID(tableDiffs[i].Schema, tableDiffs[i].Table)
 		if tableUniqueID == uniqueID {
-			return i
+			tableIndexMap[uniqueID] = i
 		}
 	}
-	return 0
+	return tableIndexMap
 }

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -385,8 +385,8 @@ func checkTableMatched(tableDiffs []*common.TableDiff, targetMap map[string]stru
 				return tableDiffs, errors.Errorf("the source has no table to be compared. target-table is `%s`", tableDiff)
 			}
 			index := tableIndexMap[tableDiff]
-			if tableDiffs[index].NeedSkippedTable == 0 {
-				tableDiffs[index].NeedSkippedTable = common.UpstreamTableLackFlag
+			if tableDiffs[index].TableLack == 0 {
+				tableDiffs[index].TableLack = common.UpstreamTableLackFlag
 				log.Info("the source has no table to be compared", zap.String("target-table", tableDiff))
 			}
 		}
@@ -400,9 +400,9 @@ func checkTableMatched(tableDiffs []*common.TableDiff, targetMap map[string]stru
 			}
 			slice := strings.Split(strings.Replace(tableDiff, "`", "", -1), ".")
 			tableDiffs = append(tableDiffs, &common.TableDiff{
-				Schema:           slice[0],
-				Table:            slice[1],
-				NeedSkippedTable: common.DownstreamTableLackFlag,
+				Schema:    slice[0],
+				Table:     slice[1],
+				TableLack: common.DownstreamTableLackFlag,
 			})
 			log.Info("the target has no table to be compared", zap.String("source-table", tableDiff))
 		}
@@ -418,8 +418,4 @@ func getIndexMapForTable(tableDiffs []*common.TableDiff) map[string]int {
 		tableIndexMap[tableUniqueID] = i
 	}
 	return tableIndexMap
-}
-
-func AllTableExist(tableDiffs *common.TableDiff) bool {
-	return tableDiffs.NeedSkippedTable == common.AllTableExistFlag
 }

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -85,6 +85,9 @@ type Source interface {
 	// GetCountAndCrc32 gets the crc32 result and the count from given range.
 	GetCountAndCrc32(context.Context, *splitter.RangeInfo) *ChecksumInfo
 
+	// GetCountForLackTable gets the count for tables that don't exist upstream or downstream.
+	GetCountForLackTable(context.Context, *splitter.RangeInfo) int64
+
 	// GetRowsIterator gets the row data iterator from given range.
 	GetRowsIterator(context.Context, *splitter.RangeInfo) (RowDataIterator, error)
 

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -385,7 +385,7 @@ func checkTableMatched(tableDiffs []*common.TableDiff, targetMap map[string]stru
 			}
 			index := getIndexMapForTable(tableDiffs, tableDiff)[tableDiff]
 			if tableDiffs[index].NeedSkippedTable == 0 {
-				tableDiffs[index].NeedSkippedTable = 1
+				tableDiffs[index].NeedSkippedTable = common.UpstreamTableLackFlag
 				log.Info("the source has no table to be compared", zap.String("target-table", tableDiff))
 			}
 		}
@@ -401,7 +401,7 @@ func checkTableMatched(tableDiffs []*common.TableDiff, targetMap map[string]stru
 			tableDiffs = append(tableDiffs, &common.TableDiff{
 				Schema:           slice[0],
 				Table:            slice[1],
-				NeedSkippedTable: -1,
+				NeedSkippedTable: common.DownstreamTableLackFlag,
 			})
 			log.Info("the target has no table to be compared", zap.String("source-table", tableDiff))
 		}
@@ -420,4 +420,11 @@ func getIndexMapForTable(tableDiffs []*common.TableDiff, uniqueID string) map[st
 		}
 	}
 	return tableIndexMap
+}
+
+func AllTableExist(tableDiffs *common.TableDiff) bool {
+	if tableDiffs.NeedSkippedTable == common.AllTableExistFlag {
+		return true
+	}
+	return false
 }

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -188,10 +188,6 @@ func NewSources(ctx context.Context, cfg *config.Config) (downstream Source, ups
 		}
 	}
 
-	if len(tableDiffs) == 0 {
-		return nil, nil, errors.Errorf("no table need to be compared")
-	}
-
 	// Sort TableDiff is important!
 	// because we compare table one by one.
 	sort.Slice(tableDiffs, func(i, j int) bool {
@@ -210,6 +206,9 @@ func NewSources(ctx context.Context, cfg *config.Config) (downstream Source, ups
 	upstream, err = buildSourceFromCfg(ctx, tableDiffs, mysqlConnCount, bucketSpliterPool, cfg.SkipNonExistingTable, cfg.Task.TargetCheckTables, cfg.Task.SourceInstances...)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "from upstream")
+	}
+	if len(upstream.GetTables()) == 0 {
+		return nil, nil, errors.Errorf("no table need to be compared")
 	}
 	downstream, err = buildSourceFromCfg(ctx, upstream.GetTables(), mysqlConnCount, bucketSpliterPool, cfg.SkipNonExistingTable, cfg.Task.TargetCheckTables, cfg.Task.TargetInstance)
 	if err != nil {

--- a/sync_diff_inspector/source/source.go
+++ b/sync_diff_inspector/source/source.go
@@ -421,8 +421,5 @@ func getIndexMapForTable(tableDiffs []*common.TableDiff) map[string]int {
 }
 
 func AllTableExist(tableDiffs *common.TableDiff) bool {
-	if tableDiffs.NeedSkippedTable == common.AllTableExistFlag {
-		return true
-	}
-	return false
+	return tableDiffs.NeedSkippedTable == common.AllTableExistFlag
 }

--- a/sync_diff_inspector/source/source_test.go
+++ b/sync_diff_inspector/source/source_test.go
@@ -942,7 +942,7 @@ func TestCheckTableMatched(t *testing.T) {
 
 	tables, err = checkTableMatched(tableDiffs, tmap, smap, true)
 	require.NoError(t, err)
-	require.Equal(t, 0, tables[0].NeedSkippedTable)
-	require.Equal(t, 1, tables[1].NeedSkippedTable)
-	require.Equal(t, -1, tables[2].NeedSkippedTable)
+	require.Equal(t, 0, tables[0].TableLack)
+	require.Equal(t, 1, tables[1].TableLack)
+	require.Equal(t, -1, tables[2].TableLack)
 }

--- a/sync_diff_inspector/source/tidb.go
+++ b/sync_diff_inspector/source/tidb.go
@@ -124,6 +124,7 @@ func (s *TiDBSource) GetCountAndCrc32(ctx context.Context, tableRange *splitter.
 	beginTime := time.Now()
 	table := s.tableDiffs[tableRange.GetTableIndex()]
 	chunk := tableRange.GetChunk()
+
 	matchSource := getMatchSource(s.sourceTableMap, table)
 	count, checksum, err := utils.GetCountAndCRC32Checksum(ctx, s.dbConn, matchSource.OriginSchema, matchSource.OriginTable, table.Info, chunk.Where, chunk.Args)
 

--- a/sync_diff_inspector/source/tidb.go
+++ b/sync_diff_inspector/source/tidb.go
@@ -194,7 +194,7 @@ func (s *TiDBSource) GetSnapshot() string {
 	return s.snapshot
 }
 
-func getSourceTableMap(ctx context.Context, tableDiffs []*common.TableDiff, ds *config.DataSource, f tableFilter.Filter) (map[string]*common.TableSource, error) {
+func NewTiDBSource(ctx context.Context, tableDiffs []*common.TableDiff, ds *config.DataSource, bucketSpliterPool *utils.WorkerPool, f tableFilter.Filter) (Source, error) {
 	sourceTableMap := make(map[string]*common.TableSource)
 	log.Info("find router for tidb source")
 	// we should get the real table name
@@ -253,17 +253,8 @@ func getSourceTableMap(ctx context.Context, tableDiffs []*common.TableDiff, ds *
 		}
 	}
 
-	if err = checkTableMatched(targetUniqueTableMap, sourceTablesAfterRoute); err != nil {
-		return nil, errors.Annotatef(err, "please make sure the filter is correct.")
-	}
-	return sourceTableMap, nil
-}
+	tableDiffs = checkTableMatched(tableDiffs, targetUniqueTableMap, sourceTablesAfterRoute)
 
-func NewTiDBSource(ctx context.Context, tableDiffs []*common.TableDiff, ds *config.DataSource, bucketSpliterPool *utils.WorkerPool, f tableFilter.Filter) (Source, error) {
-	sourceTableMap, err := getSourceTableMap(ctx, tableDiffs, ds, f)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	ts := &TiDBSource{
 		tableDiffs:        tableDiffs,
 		sourceTableMap:    sourceTableMap,

--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -909,7 +909,7 @@ func ResetColumns(tableInfo *model.TableInfo, columns []string) (*model.TableInf
 	return tableInfo, hasTimeStampType
 }
 
-// UniqueID returns `schema:table`
+// UniqueID returns `schema`.`table`
 func UniqueID(schema string, table string) string {
 	// QuoteSchema quotes a full table name
 	return fmt.Sprintf("`%s`.`%s`", EscapeName(schema), EscapeName(table))

--- a/tests/sync_diff_inspector/table_skip/config_base.toml
+++ b/tests/sync_diff_inspector/table_skip/config_base.toml
@@ -46,4 +46,4 @@ skip-non-existing-table = true
     target-instance = "tidb"
 
     # tables need to check.
-    target-check-tables = ["diff_test.t*"]
+    target-check-tables = ["skip_test.t*"]

--- a/tests/sync_diff_inspector/table_skip/config_base.toml
+++ b/tests/sync_diff_inspector/table_skip/config_base.toml
@@ -1,0 +1,46 @@
+# Diff Configuration.
+
+######################### Global config #########################
+
+# how many goroutines are created to check data
+check-thread-count = 4
+
+# set false if just want compare data by checksum, will skip select data when checksum is not equal.
+# set true if want compare all different rows, will slow down the total compare time.
+export-fix-sql = true
+
+# ignore check table's data
+check-struct-only = false
+
+######################### Databases config #########################
+[data-sources]
+[data-sources.mysql1]
+    host = "127.0.0.1"#MYSQL_HOST
+    port = 3306#MYSQL_PORT
+    user = "root"
+    password = "123456"
+    # remove comment if use tidb's snapshot data
+    # snapshot = "2016-10-08 16:45:26"
+
+[data-sources.tidb]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    # remove comment if use tidb's snapshot data
+    # snapshot = "2016-10-08 16:45:26"
+
+######################### Task config #########################
+[task]
+    # 1 fix sql: fix-target-TIDB1.sql
+    # 2 log: sync-diff.log
+    # 3 summary: summary.txt
+    # 4 checkpoint: a dir
+    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+
+    source-instances = ["mysql1"]
+
+    target-instance = "tidb"
+
+    # tables need to check.
+    target-check-tables = ["diff_test.t*"]

--- a/tests/sync_diff_inspector/table_skip/config_base.toml
+++ b/tests/sync_diff_inspector/table_skip/config_base.toml
@@ -12,6 +12,9 @@ export-fix-sql = true
 # ignore check table's data
 check-struct-only = false
 
+# skip validation for tables that don't exist upstream or downstream
+skip-non-existing-table = true
+
 ######################### Databases config #########################
 [data-sources]
 [data-sources.mysql1]

--- a/tests/sync_diff_inspector/table_skip/config_base.toml
+++ b/tests/sync_diff_inspector/table_skip/config_base.toml
@@ -18,7 +18,7 @@ check-struct-only = false
     host = "127.0.0.1"#MYSQL_HOST
     port = 3306#MYSQL_PORT
     user = "root"
-    password = "123456"
+    password = ""
     # remove comment if use tidb's snapshot data
     # snapshot = "2016-10-08 16:45:26"
 

--- a/tests/sync_diff_inspector/table_skip/config_router.toml
+++ b/tests/sync_diff_inspector/table_skip/config_router.toml
@@ -28,7 +28,7 @@ skip-non-existing-table = true
     user = "root"
     password = ""
 
-    route-rules = ["rule2","rule3"]
+    route-rules = ["rule2"]
 
 [data-sources.tidb0]
     host = "127.0.0.1"
@@ -38,22 +38,17 @@ skip-non-existing-table = true
 
 ########################### Routes ###########################
 [routes.rule1]
-schema-pattern = "diff_test"        # Matches the schema name of the data source. Supports the wildcards "*" and "?"
+schema-pattern = "skip_test"        # Matches the schema name of the data source. Supports the wildcards "*" and "?"
 table-pattern = "t[1-2]"  # Matches the table name of the data source. Supports the wildcards "*" and "?"
-target-schema = "diff_test"         # The name of the schema in the target database
+target-schema = "skip_test"         # The name of the schema in the target database
 target-table = "t5"       # The name of the target table
 
 [routes.rule2]
-schema-pattern = "diff_test"
+schema-pattern = "skip_test"
 table-pattern = "t0"
-target-schema = "diff_test"
+target-schema = "skip_test"
 target-table = "t5"
 
-[routes.rule3]
-schema-pattern = "diff_test"
-table-pattern = "t4"
-target-schema = "diff_test"
-target-table = "t4"
 ######################### Task config #########################
 [task]
     output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
@@ -63,4 +58,4 @@ target-table = "t4"
     target-instance = "tidb0"
 
     # The tables of downstream databases to be compared. Each table needs to contain the schema name and the table name, separated by '.'
-    target-check-tables = ["diff_test.t5","diff_test.t4"]
+    target-check-tables = ["skip_test.t5"]

--- a/tests/sync_diff_inspector/table_skip/config_router.toml
+++ b/tests/sync_diff_inspector/table_skip/config_router.toml
@@ -1,0 +1,66 @@
+# Diff Configuration.
+
+######################### Global config #########################
+
+# The number of goroutines created to check data. The number of connections between upstream and downstream databases are slightly greater than this value
+check-thread-count = 4
+
+# If enabled, SQL statements is exported to fix inconsistent tables
+export-fix-sql = true
+
+# Only compares the table structure instead of the data
+check-struct-only = false
+
+# skip validation for tables that don't exist upstream or downstream
+skip-non-existing-table = true
+######################### Datasource config #########################
+[data-sources.mysql1]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""
+
+    route-rules = ["rule1"]
+
+[data-sources.mysql2]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""
+
+    route-rules = ["rule2","rule3"]
+
+[data-sources.tidb0]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+
+########################### Routes ###########################
+[routes.rule1]
+schema-pattern = "diff_test"        # Matches the schema name of the data source. Supports the wildcards "*" and "?"
+table-pattern = "t[1-2]"  # Matches the table name of the data source. Supports the wildcards "*" and "?"
+target-schema = "diff_test"         # The name of the schema in the target database
+target-table = "t5"       # The name of the target table
+
+[routes.rule2]
+schema-pattern = "diff_test"
+table-pattern = "t0"
+target-schema = "diff_test"
+target-table = "t5"
+
+[routes.rule3]
+schema-pattern = "diff_test"
+table-pattern = "t4"
+target-schema = "diff_test"
+target-table = "t4"
+######################### Task config #########################
+[task]
+    output-dir = "./output"
+
+    source-instances = ["mysql1", "mysql2"]
+
+    target-instance = "tidb0"
+
+    # The tables of downstream databases to be compared. Each table needs to contain the schema name and the table name, separated by '.'
+    target-check-tables = ["diff_test.t5","diff_test.t4"]

--- a/tests/sync_diff_inspector/table_skip/config_router.toml
+++ b/tests/sync_diff_inspector/table_skip/config_router.toml
@@ -56,7 +56,7 @@ target-schema = "diff_test"
 target-table = "t4"
 ######################### Task config #########################
 [task]
-    output-dir = "./output"
+    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1", "mysql2"]
 

--- a/tests/sync_diff_inspector/table_skip/data.sql
+++ b/tests/sync_diff_inspector/table_skip/data.sql
@@ -1,0 +1,6 @@
+drop database if exit diff_test;
+create database diff_test;
+create table diff_test.t0 (a int, b int, primary key(a));
+create table diff_test.t1 (a int, b int, primary key(a));
+insert into diff_test.t0 values (1,1)
+insert into diff_test.t1 values (1,1)

--- a/tests/sync_diff_inspector/table_skip/data.sql
+++ b/tests/sync_diff_inspector/table_skip/data.sql
@@ -1,4 +1,4 @@
-create database diff_test if not exists diff_test;
+create database if not exists diff_test;
 create table diff_test.t0 (a int, b int, primary key(a));
 create table diff_test.t1 (a int, b int, primary key(a));
 insert into diff_test.t0 values (1,1);

--- a/tests/sync_diff_inspector/table_skip/data.sql
+++ b/tests/sync_diff_inspector/table_skip/data.sql
@@ -1,5 +1,5 @@
-create database if not exists diff_test;
-create table diff_test.t0 (a int, b int, primary key(a));
-create table diff_test.t1 (a int, b int, primary key(a));
-insert into diff_test.t0 values (1,1);
-insert into diff_test.t1 values (2,2);
+create database if not exists skip_test;
+create table skip_test.t0 (a int, b int, primary key(a));
+create table skip_test.t1 (a int, b int, primary key(a));
+insert into skip_test.t0 values (1,1);
+insert into skip_test.t1 values (2,2);

--- a/tests/sync_diff_inspector/table_skip/data.sql
+++ b/tests/sync_diff_inspector/table_skip/data.sql
@@ -1,4 +1,4 @@
-drop database if exit diff_test;
+drop database if exists diff_test;
 create database diff_test;
 create table diff_test.t0 (a int, b int, primary key(a));
 create table diff_test.t1 (a int, b int, primary key(a));

--- a/tests/sync_diff_inspector/table_skip/data.sql
+++ b/tests/sync_diff_inspector/table_skip/data.sql
@@ -3,4 +3,4 @@ create database diff_test;
 create table diff_test.t0 (a int, b int, primary key(a));
 create table diff_test.t1 (a int, b int, primary key(a));
 insert into diff_test.t0 values (1,1);
-insert into diff_test.t1 values (1,1);
+insert into diff_test.t1 values (2,2);

--- a/tests/sync_diff_inspector/table_skip/data.sql
+++ b/tests/sync_diff_inspector/table_skip/data.sql
@@ -2,5 +2,5 @@ drop database if exit diff_test;
 create database diff_test;
 create table diff_test.t0 (a int, b int, primary key(a));
 create table diff_test.t1 (a int, b int, primary key(a));
-insert into diff_test.t0 values (1,1)
-insert into diff_test.t1 values (1,1)
+insert into diff_test.t0 values (1,1);
+insert into diff_test.t1 values (1,1);

--- a/tests/sync_diff_inspector/table_skip/data.sql
+++ b/tests/sync_diff_inspector/table_skip/data.sql
@@ -1,5 +1,4 @@
-drop database if exists diff_test;
-create database diff_test;
+create database diff_test if not exists diff_test;
 create table diff_test.t0 (a int, b int, primary key(a));
 create table diff_test.t1 (a int, b int, primary key(a));
 insert into diff_test.t0 values (1,1);

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -31,12 +31,16 @@ check_contains "Comparing the table data of \`\`diff_test\`.\`t2\`\` ...skipped"
 check_contains "Comparing the table data of \`\`diff_test\`.\`t3\`\` ...skipped" $OUT_DIR/table_skip_diff.output
 check_contains "The data of \`diff_test\`.\`t2\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
 check_contains "The data of \`diff_test\`.\`t3\` does not exist in upstream database" $OUT_DIR/table_skip_diff.output
+check_contains "|      TABLE       | RESULT  | STRUCTURE EQUALITY | DATA DIFF ROWS | UPCOUNT | DOWNCOUNT |" $OUT_DIR/summary.txt
+check_contains "| \`diff_test\`.\`t2\` | skipped | false              | +1/-0          |       1 |         0 |" $OUT_DIR/summary.txt
+check_contains "| \`diff_test\`.\`t3\` | skipped | false              | +0/-1          |       0 |         1 |" $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
 
 echo "make some table data not equal"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t1 values (2,2);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
+check_contains "| \`diff_test\`.\`t1\` | succeed | true               | +0/-1          |       1 |         2 |" $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
 
 echo "make some table structure not equal"
@@ -45,6 +49,7 @@ mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t4 valu
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t4 (a int, b int, primary key(a));"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
+check_contains "| \`diff_test\`.\`t4\` | succeed | false              | +0/-0          |       0 |         0 |" $OUT_DIR/summary.txt
 check_contains "A total of 5 tables have been compared, 1 tables finished, 2 tables failed, 2 tables skipped" $OUT_DIR/table_skip_diff.output
 cat $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -21,11 +21,12 @@ sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || 
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 rm -rf $OUT_DIR/*
 
-echo "update data to make it different, and data should not be equal"
+echo "make some tables exist only upstream or downstream"
 mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t2 (a int, b int, primary key(a));"
 mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t2 values (1,1);"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, primary key(a));"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
+cat $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -55,8 +55,7 @@ cat $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
 
 echo "test router case"
-sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_router.toml | sed "s/3306#MYSQL_PORT/${MYSQL_PORT}/g" > ./config.toml
-sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
+sync_diff_inspector --config=./config_router.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
 check_contains "| \`diff_test\`.\`t5\` | skipped | false              | +3/-0          |       3 |         0 |" $OUT_DIR/summary.txt
 check_contains "The data of \`diff_test\`.\`t5\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -21,35 +21,35 @@ check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 rm -rf $OUT_DIR/*
 
 echo "make some tables exist only upstream or downstream"
-mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t2 (a int, b int, primary key(a));"
-mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t2 values (3,3);"
-mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, primary key(a));"
-mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t3 values (1,1);"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table skip_test.t2 (a int, b int, primary key(a));"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into skip_test.t2 values (3,3);"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "create table skip_test.t3 (a int, b int, primary key(a));"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into skip_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check pass" $OUT_DIR/sync_diff.log
-check_contains "Comparing the table data of \`\`diff_test\`.\`t2\`\` ...skipped" $OUT_DIR/table_skip_diff.output
-check_contains "Comparing the table data of \`\`diff_test\`.\`t3\`\` ...skipped" $OUT_DIR/table_skip_diff.output
-check_contains "The data of \`diff_test\`.\`t2\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
-check_contains "The data of \`diff_test\`.\`t3\` does not exist in upstream database" $OUT_DIR/table_skip_diff.output
+check_contains "Comparing the table data of \`\`skip_test\`.\`t2\`\` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "Comparing the table data of \`\`skip_test\`.\`t3\`\` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "The data of \`skip_test\`.\`t2\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
+check_contains "The data of \`skip_test\`.\`t3\` does not exist in upstream database" $OUT_DIR/table_skip_diff.output
 check_contains "|      TABLE       | RESULT  | STRUCTURE EQUALITY | DATA DIFF ROWS | UPCOUNT | DOWNCOUNT |" $OUT_DIR/summary.txt
-check_contains "| \`diff_test\`.\`t2\` | skipped | false              | +1/-0          |       1 |         0 |" $OUT_DIR/summary.txt
-check_contains "| \`diff_test\`.\`t3\` | skipped | false              | +0/-1          |       0 |         1 |" $OUT_DIR/summary.txt
+check_contains "| \`skip_test\`.\`t2\` | skipped | false              | +1/-0          |       1 |         0 |" $OUT_DIR/summary.txt
+check_contains "| \`skip_test\`.\`t3\` | skipped | false              | +0/-1          |       0 |         1 |" $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
 
 echo "make some table data not equal"
-mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t1 values (4,4);"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into skip_test.t1 values (4,4);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
-check_contains "| \`diff_test\`.\`t1\` | succeed | true               | +0/-1          |       1 |         2 |" $OUT_DIR/summary.txt
+check_contains "| \`skip_test\`.\`t1\` | succeed | true               | +0/-1          |       1 |         2 |" $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
 
 echo "make some table structure not equal"
-mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t4 (a int, b int, c int,primary key(a));"
-mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t4 values (1,1,1);"
-mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t4 (a int, b int, primary key(a));"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table skip_test.t4 (a int, b int, c int,primary key(a));"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into skip_test.t4 values (1,1,1);"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "create table skip_test.t4 (a int, b int, primary key(a));"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
-check_contains "| \`diff_test\`.\`t4\` | succeed | false              | +0/-0          |       0 |         0 |" $OUT_DIR/summary.txt
+check_contains "| \`skip_test\`.\`t4\` | succeed | false              | +0/-0          |       0 |         0 |" $OUT_DIR/summary.txt
 check_contains "A total of 5 tables have been compared, 1 tables finished, 2 tables failed, 2 tables skipped" $OUT_DIR/table_skip_diff.output
 cat $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
@@ -57,9 +57,9 @@ rm -rf $OUT_DIR/*
 echo "test router case"
 sync_diff_inspector --config=./config_router.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
-check_contains "| \`diff_test\`.\`t5\` | skipped | false              | +3/-0          |       3 |         0 |" $OUT_DIR/summary.txt
-check_contains "The data of \`diff_test\`.\`t5\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
-check_contains "A total of 2 tables have been compared, 0 tables finished, 1 tables failed, 1 tables skipped" $OUT_DIR/table_skip_diff.output
+check_contains "| \`skip_test\`.\`t5\` | skipped | false              | +3/-0          |       3 |         0 |" $OUT_DIR/summary.txt
+check_contains "The data of \`skip_test\`.\`t5\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
+check_contains "A total of 1 tables have been compared, 0 tables finished, 0 tables failed, 1 tables skipped" $OUT_DIR/table_skip_diff.output
 rm -rf $OUT_DIR/*
 
 echo "table_skip test passed"

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -17,7 +17,6 @@ sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_base.toml | sed "s
 
 echo "compare tables, check result should be pass"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
-
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 rm -rf $OUT_DIR/*
 
@@ -27,6 +26,22 @@ mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t2 valu
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, primary key(a));"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
+check_contains "check pass" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*
+
+echo "make some table data not equal"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t1 values (2,2);"
+sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
+check_contains "check failed" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*
+
+echo "make some table structure not equal"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t4 (a int, b int, c int,primary key(a));"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t4 values (1,1,1);"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t4 (a int, b int, primary key(a));"
+sync_diff_inspector --config=./config.toml #> $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
 cat $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
+
+echo "table_config test passed"

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -22,7 +22,7 @@ rm -rf $OUT_DIR/*
 
 echo "make some tables exist only upstream or downstream"
 mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t2 (a int, b int, primary key(a));"
-mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t2 values (1,1);"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t2 values (3,3);"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, primary key(a));"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
@@ -37,7 +37,7 @@ check_contains "| \`diff_test\`.\`t3\` | skipped | false              | +0/-1   
 rm -rf $OUT_DIR/*
 
 echo "make some table data not equal"
-mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t1 values (2,2);"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t1 values (4,4);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
 check_contains "| \`diff_test\`.\`t1\` | succeed | true               | +0/-1          |       1 |         2 |" $OUT_DIR/summary.txt
@@ -52,6 +52,15 @@ check_contains "check failed" $OUT_DIR/sync_diff.log
 check_contains "| \`diff_test\`.\`t4\` | succeed | false              | +0/-0          |       0 |         0 |" $OUT_DIR/summary.txt
 check_contains "A total of 5 tables have been compared, 1 tables finished, 2 tables failed, 2 tables skipped" $OUT_DIR/table_skip_diff.output
 cat $OUT_DIR/summary.txt
+rm -rf $OUT_DIR/*
+
+echo "test router case"
+sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_router.toml | sed "s/3306#MYSQL_PORT/${MYSQL_PORT}/g" > ./config.toml
+sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
+check_contains "check failed" $OUT_DIR/sync_diff.log
+check_contains "| \`diff_test\`.\`t5\` | skipped | false              | +3/-0          |       3 |         0 |" $OUT_DIR/summary.txt
+check_contains "The data of \`diff_test\`.\`t5\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
+check_contains "A total of 2 tables have been compared, 0 tables finished, 1 tables failed, 1 tables skipped" $OUT_DIR/table_skip_diff.output
 rm -rf $OUT_DIR/*
 
 echo "table_skip test passed"

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -41,6 +41,7 @@ mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t4 valu
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t4 (a int, b int, primary key(a));"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
+check_contains "A total of 5 tables have been compared, 1 tables finished, 2 tables failed, 2 tables skipped" $OUT_DIR/table_skip_diff.output
 cat $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
 

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$0")"
+
+OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
+rm -rf $OUT_DIR
+mkdir -p $OUT_DIR
+
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} < ./data.sql
+
+# tidb
+mysql -uroot -h 127.0.0.1 -P 4000 < ./data.sql
+
+sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_base.toml | sed "s/3306#MYSQL_PORT/${MYSQL_PORT}/g" > ./config.toml
+
+echo "compare tables, check result should be pass"
+sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
+
+check_contains "check pass!!!" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*
+
+echo "update data to make it different, and data should not be equal"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t2 (a int, b int, primary key(a));"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, primary key(a));"
+sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
+check_contains "check failed" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -39,9 +39,9 @@ echo "make some table structure not equal"
 mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t4 (a int, b int, c int,primary key(a));"
 mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t4 values (1,1,1);"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t4 (a int, b int, primary key(a));"
-sync_diff_inspector --config=./config.toml #> $OUT_DIR/table_skip_diff.output || true
+sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
 cat $OUT_DIR/summary.txt
 rm -rf $OUT_DIR/*
 
-echo "table_config test passed"
+echo "table_skip test passed"

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -27,10 +27,10 @@ mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, p
 mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check pass" $OUT_DIR/sync_diff.log
-check_contains "Comparing the table data of ``diff_test`.`t2`` ...skipped" $OUT_DIR/table_skip_diff.output
-check_contains "Comparing the table data of ``diff_test`.`t3`` ...skipped" $OUT_DIR/table_skip_diff.output
-check_contains "The data of `diff_test`.`t2` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
-check_contains "The data of `diff_test`.`t3` does not exist in upstream database" $OUT_DIR/table_skip_diff.output
+check_contains "Comparing the table data of \`\`diff_test\`.\`t2\`\` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "Comparing the table data of \`\`diff_test\`.\`t3\`\` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "The data of \`diff_test\`.\`t2\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
+check_contains "The data of \`diff_test\`.\`t3\` does not exist in upstream database" $OUT_DIR/table_skip_diff.output
 rm -rf $OUT_DIR/*
 
 echo "make some table data not equal"

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -56,7 +56,7 @@ rm -rf $OUT_DIR/*
 
 echo "test router case"
 sync_diff_inspector --config=./config_router.toml > $OUT_DIR/table_skip_diff.output || true
-check_contains "check failed" $OUT_DIR/sync_diff.log
+check_contains "check pass" $OUT_DIR/sync_diff.log
 check_contains "| \`skip_test\`.\`t5\` | skipped | false              | +3/-0          |       3 |         0 |" $OUT_DIR/summary.txt
 check_contains "The data of \`skip_test\`.\`t5\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
 check_contains "A total of 1 tables have been compared, 0 tables finished, 0 tables failed, 1 tables skipped" $OUT_DIR/table_skip_diff.output

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -27,6 +27,10 @@ mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, p
 mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check pass" $OUT_DIR/sync_diff.log
+check_contains "Comparing the table data of ``diff_test`.`t2`` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "Comparing the table data of ``diff_test`.`t3`` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "The data of `diff_test`.`t2` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
+check_contains "The data of `diff_test`.`t3` does not exist in upstream database" $OUT_DIR/table_skip_diff.output
 rm -rf $OUT_DIR/*
 
 echo "make some table data not equal"

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -23,7 +23,9 @@ rm -rf $OUT_DIR/*
 
 echo "update data to make it different, and data should not be equal"
 mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table diff_test.t2 (a int, b int, primary key(a));"
+mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "insert into diff_test.t2 values (1,1);"
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table diff_test.t3 (a int, b int, primary key(a));"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into diff_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
 rm -rf $OUT_DIR/*


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: ref #692

### What is changed and how it works?
- Add parameter `skip-non-existing-table`, which defaults to false.
- Record and skip validation for tables that exist only upstream or downstream.
- Show skipped information and row count comparison for missing tables in `summary.txt`.
<img width="672" alt="image" src="https://user-images.githubusercontent.com/80016792/210690272-8e2bb3c0-f714-47b2-8f51-c5cd08ebab77.png">

- Print progress information about skipped tables.
<img width="748" alt="image" src="https://user-images.githubusercontent.com/80016792/210691510-5fce6be2-e6d9-439e-86ba-ca626ec69d9b.png">


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
