### PR TITLE
sync_diff_inspector: fix the timezone difference

### DIFF
--- a/go.mod1
+++ b/go.mod1
@@ -12,6 +12,7 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20220423142525-ae43b7f4e5c3
 	github.com/pingcap/kvproto v0.0.0-20220913025519-586cff113d10
 	github.com/pingcap/log v1.1.0
+	github.com/pingcap/parser v0.0.0-20210415081931-48e7f467fd74
 	github.com/pingcap/tidb v1.1.0-beta.0.20220918132100-29f83a0b2592
 	github.com/pingcap/tidb/parser v0.0.0-20220918132100-29f83a0b2592
 	github.com/pingcap/tiflow v0.0.0-20220905041455-ca31feec87f5

--- a/go.sum1
+++ b/go.sum1
@@ -731,6 +731,7 @@ github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuR
 github.com/pingcap/log v0.0.0-20211215031037-e024ba4eb0ee/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.0 h1:ELiPxACz7vdo1qAvvaWJg1NrYFoY6gqAh/+Uo6aXdD8=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
+github.com/pingcap/parser v0.0.0-20210415081931-48e7f467fd74 h1:FkVEC3Fck3fD16hMObMl/IWs72jR9FmqPn0Bdf728Sk=
 github.com/pingcap/parser v0.0.0-20210415081931-48e7f467fd74/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
 github.com/pingcap/sysutil v0.0.0-20220114020952-ea68d2dbf5b4 h1:HYbcxtnkN3s5tqrZ/z3eJS4j3Db8wMphEm1q10lY/TM=
 github.com/pingcap/sysutil v0.0.0-20220114020952-ea68d2dbf5b4/go.mod h1:sDCsM39cGiv2vwunZkaFA917vVkqDTGSPbbV7z4Oops=

--- a/pkg/dbutil/table.go
+++ b/pkg/dbutil/table.go
@@ -18,17 +18,21 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	_ "github.com/pingcap/tidb/planner/core" // to setup expression.EvalAstExpr. See: https://github.com/pingcap/tidb/blob/a94cff903cd1e7f3b050db782da84273ef5592f4/planner/core/optimizer.go#L202
+	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	_ "github.com/pingcap/tidb/types/parser_driver" // for parser driver
 	"github.com/pingcap/tidb/util/collate"
+	"github.com/pingcap/tidb/util/mock"
 )
 
 const (
@@ -110,7 +114,10 @@ func GetTableInfoWithVersion(ctx context.Context, db QueryExecutor, schemaName s
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return GetTableInfoBySQL(createTableSQL, parser2)
+	sctx := mock.NewContext()
+	// unify the timezone to UTC +0:00
+	sctx.GetSessionVars().TimeZone = time.UTC
+	return GetTableInfoBySQLWithSessionContext(sctx, createTableSQL, parser2)
 }
 
 // GetTableInfo returns table information.
@@ -128,7 +135,16 @@ func GetTableInfo(ctx context.Context, db QueryExecutor, schemaName string, tabl
 }
 
 // GetTableInfoBySQL returns table information by given create table sql.
+func GetTableInfoBySQLWithSessionContext(ctx sessionctx.Context, createTableSQL string, parser2 *parser.Parser) (table *model.TableInfo, err error) {
+	return getTableInfoBySQL(ctx, createTableSQL, parser2)
+}
+
+// GetTableInfoBySQL returns table information by given create table sql.
 func GetTableInfoBySQL(createTableSQL string, parser2 *parser.Parser) (table *model.TableInfo, err error) {
+	return getTableInfoBySQL(mock.NewContext(), createTableSQL, parser2)
+}
+
+func getTableInfoBySQL(ctx sessionctx.Context, createTableSQL string, parser2 *parser.Parser) (table *model.TableInfo, err error) {
 	stmt, err := parser2.ParseOneStmt(createTableSQL, "", "")
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -136,7 +152,7 @@ func GetTableInfoBySQL(createTableSQL string, parser2 *parser.Parser) (table *mo
 
 	s, ok := stmt.(*ast.CreateTableStmt)
 	if ok {
-		table, err := ddl.BuildTableInfoFromAST(s)
+		table, err := ddl.BuildSessionTemporaryTableInfo(ctx, nil, s, mysql.DefaultCharset, "", nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/dbutil/table.go
+++ b/pkg/dbutil/table.go
@@ -152,7 +152,7 @@ func getTableInfoBySQL(ctx sessionctx.Context, createTableSQL string, parser2 *p
 
 	s, ok := stmt.(*ast.CreateTableStmt)
 	if ok {
-		table, err := ddl.BuildSessionTemporaryTableInfo(ctx, nil, s, mysql.DefaultCharset, "", nil)
+		table, err := ddl.BuildTableInfoWithStmt(ctx, s, mysql.DefaultCharset, "", nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/dbutil/table.go
+++ b/pkg/dbutil/table.go
@@ -117,6 +117,7 @@ func GetTableInfoWithVersion(ctx context.Context, db QueryExecutor, schemaName s
 	sctx := mock.NewContext()
 	// unify the timezone to UTC +0:00
 	sctx.GetSessionVars().TimeZone = time.UTC
+	sctx.GetSessionVars().StrictSQLMode = false
 	return GetTableInfoBySQLWithSessionContext(sctx, createTableSQL, parser2)
 }
 


### PR DESCRIPTION
Signed-off-by: Leavrth <jianjun.liao@outlook.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #694 

### What is changed and how it works?
Because sync_diff_inspector currently set time_zone to UTC +0:00 as default, it is necessary to use an sessionCtx with UTC time_zone to parse the table info.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - No code
