### PR TITLE
sync_diff_inspector: fix return err when float/double is zero

### DIFF
--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -543,9 +543,6 @@ func CompareData(map1, map2 map[string]*dbutil.ColumnData, orderKeyCols, columns
 				if math.Abs(num1-num2) <= 1e-6 {
 					continue
 				}
-			} else {
-				equal = false
-				break
 			}
 		} else if column.FieldType.GetType() == mysql.TypeJSON {
 			if (str1 == str2) || (data1.IsNull && data2.IsNull) {

--- a/sync_diff_inspector/utils/utils_test.go
+++ b/sync_diff_inspector/utils/utils_test.go
@@ -138,11 +138,18 @@ func TestBasicTableUtilOperation(t *testing.T) {
 		"c": {Data: []byte(""), IsNull: true},
 		"d": {Data: []byte("sdf"), IsNull: false},
 	}
+	data9 := map[string]*dbutil.ColumnData{
+		"a": {Data: []byte("1"), IsNull: false},
+		"b": {Data: []byte("a"), IsNull: false},
+		"c": {Data: []byte("0"), IsNull: false},
+		"d": {Data: []byte("sdf"), IsNull: false},
+	}
 
 	columns := tableInfo.Columns
 
 	require.Equal(t, GenerateReplaceDML(data1, tableInfo, "schema"), "REPLACE INTO `schema`.`test`(`a`,`b`,`c`,`d`) VALUES (1,'a',1.22,'sdf');")
 	require.Equal(t, GenerateDeleteDML(data8, tableInfo, "schema"), "DELETE FROM `schema`.`test` WHERE `a` = 1 AND `b` = 'a' AND `c` is NULL AND `d` = 'sdf' LIMIT 1;")
+	require.Equal(t, GenerateDeleteDML(data9, tableInfo, "schema"), "DELETE FROM `schema`.`test` WHERE `a` = 1 AND `b` = 'a' AND `c` = 0 AND `d` = 'sdf' LIMIT 1;")
 	require.Equal(t, GenerateReplaceDMLWithAnnotation(data1, data2, tableInfo, "schema"),
 		"/*\n"+
 			"  DIFF COLUMNS ╏ `B` ╏ `C`   \n"+
@@ -224,6 +231,11 @@ func TestBasicTableUtilOperation(t *testing.T) {
 	require.False(t, equal)
 
 	equal, cmp, err = CompareData(data8, data1, orderKeyCols, columns)
+	require.NoError(t, err)
+	require.Equal(t, cmp, int32(0))
+	require.False(t, equal)
+
+	equal, cmp, err = CompareData(data8, data9, orderKeyCols, columns)
 	require.NoError(t, err)
 	require.Equal(t, cmp, int32(0))
 	require.False(t, equal)

--- a/sync_diff_inspector/utils/utils_test.go
+++ b/sync_diff_inspector/utils/utils_test.go
@@ -84,7 +84,7 @@ func TestBasicTableUtilOperation(t *testing.T) {
 	require.NoError(t, err)
 
 	query, orderKeyCols := GetTableRowsQueryFormat("test", "test", tableInfo, "123")
-	require.Equal(t, query, "SELECT /*!40001 SQL_NO_CACHE */ `a`, `b`, round(`c`, 5-floor(log10(abs(`c`)))) as `c`, `d` FROM `test`.`test` WHERE %s ORDER BY `a`,`b` COLLATE '123'")
+	require.Equal(t, query, "SELECT /*!40001 SQL_NO_CACHE */ `a`, `b`, `c`, `d` FROM `test`.`test` WHERE %s ORDER BY `a`,`b` COLLATE '123'")
 	expectName := []string{"a", "b"}
 	for i, col := range orderKeyCols {
 		require.Equal(t, col.Name.O, expectName[i])
@@ -126,17 +126,23 @@ func TestBasicTableUtilOperation(t *testing.T) {
 		"c": {Data: []byte("0.2221"), IsNull: false},
 		"d": {Data: []byte("asdf"), IsNull: false},
 	}
-
 	data7 := map[string]*dbutil.ColumnData{
 		"a": {Data: []byte("1"), IsNull: true},
 		"b": {Data: []byte("a"), IsNull: false},
 		"c": {Data: []byte("0.2221"), IsNull: false},
 		"d": {Data: []byte("asdf"), IsNull: false},
 	}
+	data8 := map[string]*dbutil.ColumnData{
+		"a": {Data: []byte("1"), IsNull: false},
+		"b": {Data: []byte("a"), IsNull: false},
+		"c": {Data: []byte(""), IsNull: true},
+		"d": {Data: []byte("sdf"), IsNull: false},
+	}
 
 	columns := tableInfo.Columns
 
 	require.Equal(t, GenerateReplaceDML(data1, tableInfo, "schema"), "REPLACE INTO `schema`.`test`(`a`,`b`,`c`,`d`) VALUES (1,'a',1.22,'sdf');")
+	require.Equal(t, GenerateDeleteDML(data8, tableInfo, "schema"), "DELETE FROM `schema`.`test` WHERE `a` = 1 AND `b` = 'a' AND `c` is NULL AND `d` = 'sdf' LIMIT 1;")
 	require.Equal(t, GenerateReplaceDMLWithAnnotation(data1, data2, tableInfo, "schema"),
 		"/*\n"+
 			"  DIFF COLUMNS ╏ `B` ╏ `C`   \n"+
@@ -211,6 +217,16 @@ func TestBasicTableUtilOperation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cmp, int32(0))
 	require.True(t, equal)
+
+	equal, cmp, err = CompareData(data1, data8, orderKeyCols, columns)
+	require.NoError(t, err)
+	require.Equal(t, cmp, int32(0))
+	require.False(t, equal)
+
+	equal, cmp, err = CompareData(data8, data1, orderKeyCols, columns)
+	require.NoError(t, err)
+	require.Equal(t, cmp, int32(0))
+	require.False(t, equal)
 
 	// Test ignore columns
 	createTableSQL = "create table `test`.`test`(`a` int, `c` float, `b` varchar(10), `d` datetime, `e` timestamp, primary key(`a`, `b`), key(`c`, `d`))"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #699

### What is changed and how it works?
When CompareData func compare real rows data. It's no need do anything about float/double type.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

