### PR TITLE
sync-diff-inspector: fix error when json column is NULL

### DIFF
--- a/sync_diff_inspector/utils/utils.go
+++ b/sync_diff_inspector/utils/utils.go
@@ -560,17 +560,19 @@ func CompareData(map1, map2 map[string]*dbutil.ColumnData, orderKeyCols, columns
 			if (str1 == str2) || (data1.IsNull && data2.IsNull) {
 				continue
 			}
-			var v1, v2 any
-			err := json.Unmarshal(data1.Data, &v1)
-			if err != nil {
-				return false, 0, errors.Errorf("unmarshal json %s failed, error %v", str1, err)
-			}
-			err = json.Unmarshal(data2.Data, &v2)
-			if err != nil {
-				return false, 0, errors.Errorf("unmarshal json %s failed, error %v", str2, err)
-			}
-			if reflect.DeepEqual(v1, v2) {
-				continue
+			if !data1.IsNull && !data2.IsNull {
+				var v1, v2 any
+				err := json.Unmarshal(data1.Data, &v1)
+				if err != nil {
+					return false, 0, errors.Errorf("unmarshal json %s failed, error %v", str1, err)
+				}
+				err = json.Unmarshal(data2.Data, &v2)
+				if err != nil {
+					return false, 0, errors.Errorf("unmarshal json %s failed, error %v", str2, err)
+				}
+				if reflect.DeepEqual(v1, v2) {
+					continue
+				}
 			}
 		} else {
 			if (str1 == str2) && (data1.IsNull == data2.IsNull) {

--- a/tests/sync_diff_inspector/json/run.sh
+++ b/tests/sync_diff_inspector/json/run.sh
@@ -26,3 +26,9 @@ mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into json_test.test values (5, '{\"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/json_diff.output || true
 check_contains "check failed" $OUT_DIR/sync_diff.log
 rm -rf $OUT_DIR/*
+
+echo "update data to make it different, and downstream json data is NULL"
+mysql -uroot -h 127.0.0.1 -P 4000 -e "replace into json_test.test values (5, NULL);"
+sync_diff_inspector --config=./config.toml > $OUT_DIR/json_diff.output || true
+check_contains "check failed" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #736 

### What is changed and how it works?
check whether the json column is NULL to avoid json unmarshal error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release Note

```
None
```


