### PR TITLE
binlog-filter: log error instead of return

### DIFF
--- a/pkg/binlog-filter/filter.go
+++ b/pkg/binlog-filter/filter.go
@@ -18,7 +18,9 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	selector "github.com/pingcap/tidb-tools/pkg/table-rule-selector"
+	"go.uber.org/zap"
 )
 
 // ActionType indicates how to handle matched items
@@ -216,7 +218,7 @@ func NewBinlogEvent(caseSensitive bool, rules []*BinlogEventRule) (*BinlogEvent,
 
 	for _, rule := range rules {
 		if err := b.AddRule(rule); err != nil {
-			return nil, errors.Annotatef(err, "initial rule %+v in binlog event filter", rule)
+			log.Error("invalid binlog event rule", zap.Error(err))
 		}
 	}
 

--- a/pkg/binlog-filter/filter_test.go
+++ b/pkg/binlog-filter/filter_test.go
@@ -34,6 +34,7 @@ func (t *testFilterSuite) TestFilter(c *C) {
 		{"Test_1_*", "abc*", []EventType{DeleteEvent, InsertEvent, CreateIndex, DropIndex, DropView}, []string{"^DROP\\s+PROCEDURE", "^CREATE\\s+PROCEDURE"}, nil, Ignore},
 		{"xxx_*", "abc_*", []EventType{AllDML, NoneDDL}, nil, nil, Ignore},
 		{"yyy_*", "abc_*", []EventType{EventType("ALL DML")}, nil, nil, Do},
+		{"Test_1_*", "abc*", []EventType{"wrong event"}, []string{"^DROP\\s+PROCEDURE", "^CREATE\\s+PROCEDURE"}, nil, Ignore},
 	}
 
 	cases := []struct {
@@ -77,6 +78,7 @@ func (t *testFilterSuite) TestFilter(c *C) {
 	rules[0].Events = []EventType{}
 	rules[1].Action = Do
 	rules[2].Events = []EventType{"ALL DDL"}
+	rules = rules[:3]
 	for _, rule := range rules {
 		err = filter.UpdateRule(rule)
 		c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: ref https://github.com/pingcap/tiflow/issues/10282

### What is changed and how it works?
log the error instead of return

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
