### PR TITLE
sync_diff_inspector: Improve startup errors

### DIFF
--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -116,7 +116,8 @@ func checkSyncState(ctx context.Context, cfg *config.Config) bool {
 
 	d, err := NewDiff(ctx, cfg)
 	if err != nil {
-		fmt.Printf("There is something error when initialize diff, please check log info in %s\n", filepath.Join(cfg.Task.OutputDir, config.LogFileName))
+		fmt.Printf("An error occured while initializing diff: %s, please check log info in %s for full details\n",
+			err, filepath.Join(cfg.Task.OutputDir, config.LogFileName))
 		log.Fatal("failed to initialize diff process", zap.Error(err))
 		return false
 	}
@@ -125,7 +126,8 @@ func checkSyncState(ctx context.Context, cfg *config.Config) bool {
 	if !cfg.CheckDataOnly {
 		err = d.StructEqual(ctx)
 		if err != nil {
-			fmt.Printf("There is something error when compare structure of table, please check log info in %s\n", filepath.Join(cfg.Task.OutputDir, config.LogFileName))
+			fmt.Printf("An error occured while comparing table structure: %s, please check log info in %s for full details\n",
+				err, filepath.Join(cfg.Task.OutputDir, config.LogFileName))
 			log.Fatal("failed to check structure difference", zap.Error(err))
 			return false
 		}
@@ -135,7 +137,8 @@ func checkSyncState(ctx context.Context, cfg *config.Config) bool {
 	if !cfg.CheckStructOnly {
 		err = d.Equal(ctx)
 		if err != nil {
-			fmt.Printf("There is something error when compare data of table, please check log info in %s\n", filepath.Join(cfg.Task.OutputDir, config.LogFileName))
+			fmt.Printf("An error occured while comparing table data: %s, please check log info in %s for full details\n",
+				err, filepath.Join(cfg.Task.OutputDir, config.LogFileName))
 			log.Fatal("failed to check data difference", zap.Error(err))
 			return false
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #792 

### What is changed and how it works?

Before:
```
$ ./bin/sync_diff_inspector --config ./sync-diff.conf 
There is something error when initialize diff, please check log info in output/sync_diff.log
```

After:
```
$ ./bin/sync_diff_inspector --config ./sync-diff.conf 
An error occured while initializing diff: no table need to be compared, please check log info in output/sync_diff.log for full details
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
