### PR TITLE
sync-diff-inspector: Fix double quoting

### DIFF
--- a/sync_diff_inspector/progress/progress.go
+++ b/sync_diff_inspector/progress/progress.go
@@ -196,17 +196,17 @@ func (tpp *TableProgressPrinter) PrintSummary() {
 		for p := tpp.tableFailList.Front(); p != nil; p = p.Next() {
 			tp := p.Value.(*TableProgress)
 			if tp.state&(TABLE_STATE_RESULT_FAIL_STRUCTURE_DONE|TABLE_STATE_RESULT_FAIL_STRUCTURE_CONTINUE) != 0 {
-				fixStr = fmt.Sprintf("%sThe structure of `%s` is not equal.\n", fixStr, tp.name)
+				fixStr = fmt.Sprintf("%sThe structure of %s is not equal.\n", fixStr, tp.name)
 			}
 			if tp.state&(TABLE_STATE_RESULT_DIFFERENT) != 0 {
-				fixStr = fmt.Sprintf("%sThe data of `%s` is not equal.\n", fixStr, tp.name)
+				fixStr = fmt.Sprintf("%sThe data of %s is not equal.\n", fixStr, tp.name)
 			}
 			if tp.state&(TABLE_STATE_NOT_EXSIT_DOWNSTREAM) != 0 {
-				fixStr = fmt.Sprintf("%sThe data of `%s` does not exist in downstream database.\n", fixStr, tp.name)
+				fixStr = fmt.Sprintf("%sThe data of %s does not exist in downstream database.\n", fixStr, tp.name)
 				SkippedNum++
 			}
 			if tp.state&(TABLE_STATE_NOT_EXSIT_UPSTREAM) != 0 {
-				fixStr = fmt.Sprintf("%sThe data of `%s` does not exist in upstream database.\n", fixStr, tp.name)
+				fixStr = fmt.Sprintf("%sThe data of %s does not exist in upstream database.\n", fixStr, tp.name)
 				SkippedNum++
 			}
 		}
@@ -352,20 +352,20 @@ func (tpp *TableProgressPrinter) flush(stateIsChanged bool) {
 			case TABLE_STATE_PRESTART:
 				switch tp.state & TABLE_STATE_RESULT_MASK {
 				case TABLE_STATE_RESULT_OK:
-					fixStr = fmt.Sprintf("%sComparing the table structure of `%s` ... equivalent\n", fixStr, tp.name)
-					dynStr = fmt.Sprintf("%sComparing the table data of `%s` ...\n", dynStr, tp.name)
+					fixStr = fmt.Sprintf("%sComparing the table structure of %s ... equivalent\n", fixStr, tp.name)
+					dynStr = fmt.Sprintf("%sComparing the table data of %s ...\n", dynStr, tp.name)
 					tpp.lines++
 					tpp.progressTableNums++
 					tp.state = TABLE_STATE_COMPARING
 				case TABLE_STATE_NOT_EXSIT_UPSTREAM, TABLE_STATE_NOT_EXSIT_DOWNSTREAM:
-					dynStr = fmt.Sprintf("%sComparing the table data of `%s` ...skipped\n", dynStr, tp.name)
+					dynStr = fmt.Sprintf("%sComparing the table data of %s ...skipped\n", dynStr, tp.name)
 					tpp.tableFailList.PushBack(tp)
 					preNode := p.Prev()
 					tpp.tableList.Remove(p)
 					p = preNode
 					tpp.finishTableNums++
 				case TABLE_STATE_RESULT_FAIL_STRUCTURE_DONE:
-					fixStr = fmt.Sprintf("%sComparing the table structure of `%s` ... failure\n", fixStr, tp.name)
+					fixStr = fmt.Sprintf("%sComparing the table structure of %s ... failure\n", fixStr, tp.name)
 					tpp.tableFailList.PushBack(tp)
 					// we have empty node as list head, so p is not nil
 					preNode := p.Prev()
@@ -373,26 +373,26 @@ func (tpp *TableProgressPrinter) flush(stateIsChanged bool) {
 					p = preNode
 					tpp.finishTableNums++
 				case TABLE_STATE_RESULT_FAIL_STRUCTURE_CONTINUE:
-					fixStr = fmt.Sprintf("%sComparing the table structure of `%s` ... failure\n", fixStr, tp.name)
-					dynStr = fmt.Sprintf("%sComparing the table data of `%s` ...\n", dynStr, tp.name)
+					fixStr = fmt.Sprintf("%sComparing the table structure of %s ... failure\n", fixStr, tp.name)
+					dynStr = fmt.Sprintf("%sComparing the table data of %s ...\n", dynStr, tp.name)
 					tpp.lines++
 					tpp.progressTableNums++
 					tp.state ^= TABLE_STATE_COMPARING | TABLE_STATE_PRESTART
 				case TABLE_STATE_RESULT_FAIL_STRUCTURE_PASS:
-					fixStr = fmt.Sprintf("%sComparing the table structure of `%s` ... skip\n", fixStr, tp.name)
-					dynStr = fmt.Sprintf("%sComparing the table data of `%s` ...\n", dynStr, tp.name)
+					fixStr = fmt.Sprintf("%sComparing the table structure of %s ... skip\n", fixStr, tp.name)
+					dynStr = fmt.Sprintf("%sComparing the table data of %s ...\n", dynStr, tp.name)
 					tpp.lines++
 					tpp.progressTableNums++
 					tp.state ^= TABLE_STATE_COMPARING | TABLE_STATE_PRESTART
 				}
 			case TABLE_STATE_COMPARING:
-				dynStr = fmt.Sprintf("%sComparing the table data of `%s` ...\n", dynStr, tp.name)
+				dynStr = fmt.Sprintf("%sComparing the table data of %s ...\n", dynStr, tp.name)
 				tpp.lines++
 			case TABLE_STATE_FINISH:
 				if tp.state&TABLE_STATE_RESULT_DIFFERENT == 0 {
-					fixStr = fmt.Sprintf("%sComparing the table data of `%s` ... equivalent\n", fixStr, tp.name)
+					fixStr = fmt.Sprintf("%sComparing the table data of %s ... equivalent\n", fixStr, tp.name)
 				} else {
-					fixStr = fmt.Sprintf("%sComparing the table data of `%s` ... failure\n", fixStr, tp.name)
+					fixStr = fmt.Sprintf("%sComparing the table data of %s ... failure\n", fixStr, tp.name)
 				}
 				if tp.state&TABLE_STATE_RESULT_MASK != 0 {
 					tpp.tableFailList.PushBack(tp)

--- a/sync_diff_inspector/progress/progress_test.go
+++ b/sync_diff_inspector/progress/progress_test.go
@@ -51,10 +51,10 @@ func TestProgress(t *testing.T) {
 	p.PrintSummary()
 	require.Equal(
 		t,
-		buffer.String(),
-		"\x1b[1A\x1b[J\nSummary:\n\nThe structure of `1` is not equal.\nThe structure of `2` is not equal.\nThe data of `4` is not equal.\nThe data of `5` does not exist in upstream database.\nThe data of `6` does not exist in downstream database.\n"+
+		"\x1b[1A\x1b[J\nSummary:\n\nThe structure of 1 is not equal.\nThe structure of 2 is not equal.\nThe data of 4 is not equal.\nThe data of 5 does not exist in upstream database.\nThe data of 6 does not exist in downstream database.\n"+
 			"\nThe rest of the tables are all equal.\nA total of 6 tables have been compared, 1 tables finished, 3 tables failed, 2 tables skipped.\nThe patch file has been generated to './output_dir/patch.sql'\n"+
 			"You can view the comparison details through './output_dir/sync_diff_inspector.log'\n\n",
+		buffer.String(),
 	)
 }
 
@@ -74,18 +74,18 @@ func TestTableError(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	require.Equal(
 		t,
-		buffer.String(),
-		"\x1b[0A\x1b[JComparing the table structure of `1` ... failure\n"+
+		"\x1b[0A\x1b[JComparing the table structure of 1 ... failure\n"+
 			"_____________________________________________________________________________\n"+
 			"Progress [===============>---------------------------------------------] 25% 0/0\n"+
-			"\x1b[2A\x1b[JComparing the table structure of `2` ... failure\n"+
+			"\x1b[2A\x1b[JComparing the table structure of 2 ... failure\n"+
 			"_____________________________________________________________________________\n"+
 			"Progress [==============================>------------------------------] 50% 0/0\n"+
-			"\x1b[2A\x1b[JComparing the table data of `3` ...skipped\n"+
+			"\x1b[2A\x1b[JComparing the table data of 3 ...skipped\n"+
 			"_____________________________________________________________________________\n"+
 			"Progress [=============================================>---------------] 75% 0/1\n"+
 			"\x1b[1A\x1b[J\nError in comparison process:\n[aaa]\n\n"+
 			"You can view the comparison details through './output_dir/sync_diff_inspector.log'\n",
+		buffer.String(),
 	)
 }
 

--- a/tests/sync_diff_inspector/table_skip/run.sh
+++ b/tests/sync_diff_inspector/table_skip/run.sh
@@ -27,8 +27,8 @@ mysql -uroot -h 127.0.0.1 -P 4000 -e "create table skip_test.t3 (a int, b int, p
 mysql -uroot -h 127.0.0.1 -P 4000 -e "insert into skip_test.t3 values (1,1);"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/table_skip_diff.output || true
 check_contains "check pass" $OUT_DIR/sync_diff.log
-check_contains "Comparing the table data of \`\`skip_test\`.\`t2\`\` ...skipped" $OUT_DIR/table_skip_diff.output
-check_contains "Comparing the table data of \`\`skip_test\`.\`t3\`\` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "Comparing the table data of \`skip_test\`.\`t2\` ...skipped" $OUT_DIR/table_skip_diff.output
+check_contains "Comparing the table data of \`skip_test\`.\`t3\` ...skipped" $OUT_DIR/table_skip_diff.output
 check_contains "The data of \`skip_test\`.\`t2\` does not exist in downstream database" $OUT_DIR/table_skip_diff.output
 check_contains "The data of \`skip_test\`.\`t3\` does not exist in upstream database" $OUT_DIR/table_skip_diff.output
 check_contains "|      TABLE       | RESULT  | STRUCTURE EQUALITY | DATA DIFF ROWS | UPCOUNT | DOWNCOUNT |" $OUT_DIR/summary.txt


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #795 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)



With this PR:
```
$ ./bin/sync_diff_inspector --config ./sync-diff.conf 
A total of 1 tables need to be compared

Comparing the table structure of `test`.`t1` ... equivalent
Comparing the table data of `test`.`t1` ... failure
_____________________________________________________________________________
Progress [============================================================>] 100% 0/0
The data of `test`.`t1` is not equal

The rest of tables are all equal.

A total of 1 tables have been compared, 0 tables finished, 1 tables failed, 0 tables skipped.
The patch file has been generated in 
	'output/fix-on-tidb0/'
You can view the comparision details through './output/sync_diff.log'
```