### PR TITLE
Revert "sync_diff_inspector: use statically build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ dump_region:
 	$(GO) build -ldflags '$(LDFLAGS)' -o bin/dump_region ./dump_region
 
 sync_diff_inspector:
-	CGO_ENABLED=0 $(GO) build -ldflags '$(LDFLAGS)' -o bin/sync_diff_inspector ./sync_diff_inspector
+	$(GO) build -ldflags '$(LDFLAGS)' -o bin/sync_diff_inspector ./sync_diff_inspector
 
 ddl_checker:
 	$(GO) build -ldflags '$(LDFLAGS)' -o bin/ddl_checker ./ddl_checker


### PR DESCRIPTION
Reverts pingcap/tidb-tools#785

Issue Number: ref #782.

the builds for darwin amd64 and arm64 targets are failed.

```release-note-none
None
```