### PR TITLE
sync_diff_inspector: Compare rows even if export-fix-sql is false

### DIFF
--- a/tests/sync_diff_inspector/json/run.sh
+++ b/tests/sync_diff_inspector/json/run.sh
@@ -15,7 +15,7 @@ mysql -uroot -h 127.0.0.1 -P 4000 < ./data.sql
 
 sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_base.toml | sed "s/3306#MYSQL_PORT/${MYSQL_PORT}/g" > ./config.toml
 cat config.toml | sed 's/export-fix-sql = true/export-fix-sql = false/' > config_nofix.toml
-diff config.toml config_nofix.toml
+diff config.toml config_nofix.toml || true
 
 echo "compare json tables, check result should be pass"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/json_diff.output

--- a/tests/sync_diff_inspector/json/run.sh
+++ b/tests/sync_diff_inspector/json/run.sh
@@ -14,9 +14,16 @@ mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} < ./data.sql
 mysql -uroot -h 127.0.0.1 -P 4000 < ./data.sql
 
 sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_base.toml | sed "s/3306#MYSQL_PORT/${MYSQL_PORT}/g" > ./config.toml
+cat config.toml | sed 's/export-fix-sql = true/export-fix-sql = false/' > config_nofix.toml
+diff config.toml config_nofix.toml
 
 echo "compare json tables, check result should be pass"
 sync_diff_inspector --config=./config.toml > $OUT_DIR/json_diff.output
+check_contains "check pass!!!" $OUT_DIR/sync_diff.log
+rm -rf $OUT_DIR/*
+
+echo "compare json tables without fixsql, check result should be pass"
+sync_diff_inspector --config=./config_nofix.toml > $OUT_DIR/json_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 rm -rf $OUT_DIR/*
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #830 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

Side effects

 - Possible performance regression: Comparing rows is slower than comparing checksums

Related changes

 - Need to be included in the release note


```release-note
Comparing JSON with export-fix-sql being enabled was failing when it shouldn't
```