### PR TITLE
Allow max-execution-time parameter for SyncDiffInspector

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -73,7 +73,8 @@ type DBConfig struct {
 
 	Schema string `toml:"schema" json:"schema"`
 
-	Snapshot string `toml:"snapshot" json:"snapshot"`
+	Snapshot         string `toml:"snapshot" json:"snapshot"`
+	MaxExecutionTime int    `toml:"max-execution-time" json:"max-execution-time"`
 }
 
 // String returns native format of database configuration

--- a/sync_diff_inspector/config/config.go
+++ b/sync_diff_inspector/config/config.go
@@ -114,7 +114,7 @@ type DataSource struct {
 	Password         utils.SecretString `toml:"password" json:"password"`
 	SqlMode          string             `toml:"sql-mode" json:"sql-mode"`
 	Snapshot         string             `toml:"snapshot" json:"snapshot"`
-	MaxExecutionTime int                `toml:"max-execution-time" json:"max-execution-time"`
+	MaxExecutionTime int                `toml:"max-execution-time" json:"max-execution-time,omitempty"`
 
 	Security *Security `toml:"security" json:"security"`
 

--- a/sync_diff_inspector/config/config.toml
+++ b/sync_diff_inspector/config/config.toml
@@ -27,6 +27,7 @@ check-struct-only = false
     port = 4000
     user = "root"
     password = ""
+    max-execution-time = 5
 
 # Support tls connection
     # security.ca-path = "..."

--- a/sync_diff_inspector/config/config_test.go
+++ b/sync_diff_inspector/config/config_test.go
@@ -34,6 +34,7 @@ func TestParseConfig(t *testing.T) {
 	require.Nil(t, cfg.Parse([]string{"--config", "config.toml"}))
 	require.Nil(t, cfg.Init())
 	require.Nil(t, cfg.Task.Init(cfg.DataSources, cfg.TableConfigs))
+	require.Equal(t, cfg.Task.TargetInstance.MaxExecutionTime, 5)
 
 	require.Nil(t, cfg.Parse([]string{"--config", "config_sharding.toml"}))
 	// we change the config from config.toml to config_sharding.toml


### PR DESCRIPTION
Allows passing max-execution-time to sync-diff-inspector to allow it to override a stricter cluster level max-execution-time.

The default remains the same that no max-execution-time will be set if the config file lacks this parameter. It's backwards compatible.

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
Issue Number: close #844

### What is changed and how it works?
New argument for sync-diff-inspector to set session level max_execution_time value.

### Check List

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - New cli argument available w/ backwards compatible default

Related changes

 - Need to update the documentation

# QUESTIONS
- [ ] I'm unsure how / where to update docs, please advise.
- [ ] I added the field check to an existing test, advise if you want it in new test
- [ ] I marked the field as `omitempty` to avoid backwards compatibility break if users are strictly parsing json output logs. Advise if you want to break existing interface of that log by outputting max-execution-time arg