### PR TITLE
Fix the iFields comparison in picking the index hint in random splitter

### DIFF
--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -65,6 +65,8 @@ func NewRandomIteratorWithCheckpoint(ctx context.Context, progressID string, tab
 	// Below logic is modified from BucketIterator
 	// It's used to find the index which can match the split fields in RandomIterator.
 	iFields := &indexFields{cols: fields, tableInfo: table.Info}
+	// The cols needs to be sorted first for comparison in MatchesIndex method below
+	sortColsInPlace(iFields.cols)
 	var indices = dbutil.FindAllIndex(table.Info)
 NEXTINDEX:
 	for _, index := range indices {

--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -64,9 +64,7 @@ func NewRandomIteratorWithCheckpoint(ctx context.Context, progressID string, tab
 
 	// Below logic is modified from BucketIterator
 	// It's used to find the index which can match the split fields in RandomIterator.
-	iFields := &indexFields{cols: fields, tableInfo: table.Info}
-	// The cols needs to be sorted first for comparison in MatchesIndex method below
-	sortColsInPlace(iFields.cols)
+	fieldNames := utils.GetColumnNames(fields)
 	var indices = dbutil.FindAllIndex(table.Info)
 NEXTINDEX:
 	for _, index := range indices {
@@ -84,8 +82,7 @@ NEXTINDEX:
 			continue
 		}
 
-		if !iFields.MatchesIndex(index) {
-			// We are enforcing user configured "index-fields" settings.
+		if !utils.IsIndexMatchingColumns(index, fieldNames) {
 			continue
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #xxx

In random splitter when picking the index name for query hint, the `iFields.MatchesIndex(index)` sort the index cols before comparison, however cols in the `iFields` was not sorted. Thus it may cause it can't find the matching index if the col ids doesn't match the col order in the index.

This PR fixes this bug by sorting the `iFields.cols` 


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
