### PR TITLE
sync-diff-inspector: Fix the indexColumns logic in random splitter to find matching index without sort

### DIFF
--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -65,6 +65,8 @@ func NewRandomIteratorWithCheckpoint(ctx context.Context, progressID string, tab
 	// Below logic is modified from BucketIterator
 	// It's used to find the index which can match the split fields in RandomIterator.
 	iFields := &indexFields{cols: fields, tableInfo: table.Info}
+	// The cols needs to be sorted first for comparison in MatchesIndex method below
+	sortColsInPlace(iFields.cols)
 	var indices = dbutil.FindAllIndex(table.Info)
 NEXTINDEX:
 	for _, index := range indices {

--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -64,9 +64,7 @@ func NewRandomIteratorWithCheckpoint(ctx context.Context, progressID string, tab
 
 	// Below logic is modified from BucketIterator
 	// It's used to find the index which can match the split fields in RandomIterator.
-	iFields := &indexFields{cols: fields, tableInfo: table.Info}
-	// The cols needs to be sorted first for comparison in MatchesIndex method below
-	sortColsInPlace(iFields.cols)
+	fieldNames := utils.GetColumnNames(fields)
 	var indices = dbutil.FindAllIndex(table.Info)
 NEXTINDEX:
 	for _, index := range indices {
@@ -84,8 +82,7 @@ NEXTINDEX:
 			continue
 		}
 
-		if !iFields.MatchesIndex(index) {
-			// We are enforcing user configured "index-fields" settings.
+		if !utils.IsIndexMatchingColumns(index, fieldNames) {
 			continue
 		}
 

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -997,6 +997,10 @@ func TestRandomSpliterHint(t *testing.T) {
 			[]model.CIStr{model.NewCIStr("a"), model.NewCIStr("b")},
 		},
 		{
+			"create table `test`.`test`(`a` int, `b` int, `c` int, primary key(`b`, `a`), unique key i1(`c`))",
+			[]model.CIStr{model.NewCIStr("b"), model.NewCIStr("a")},
+		},
+		{
 			"create table `test`.`test`(`a` int, `b` int, `c` int, unique key i1(`c`), key i2(`b`))",
 			[]model.CIStr{model.NewCIStr("c")},
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #858

### What is changed and how it works?
In random splitter when picking the index name for query hint, the iFields.MatchesIndex(index) sort the index cols before comparison, however we should use the exact index col order here, as the `fields` column list is already containing the ordered columns used for constructing the chunks.

This PR fixes this bug by not using MatchesIndex

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)


