### PR TITLE
sync-diff-inspector: Fix GetBucketsInfo decoding for mysql.stats_buckets histogram bounds

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -30,8 +30,11 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	tmysql "github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/codec"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"go.uber.org/zap"
@@ -508,18 +511,37 @@ type Bucket struct {
 	UpperBound string
 }
 
-// GetBucketsInfo select from stats_buckets in TiDB.
 func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string, tableInfo *model.TableInfo) (map[string][]Bucket, error) {
 	buckets := make(map[string][]Bucket)
 
 	indices := FindAllIndex(tableInfo)
-	indexMap := make(map[int64]string, len(indices))
+	// Pre-build lightweight maps for indices: index ID -> index name / column types.
+	indexColumnTypesMap := make(map[int64][]byte, len(indices))
+	indexNameMap := make(map[int64]string, len(indices))
 	for _, idx := range indices {
-		indexMap[idx.ID] = idx.Name.O
+		indexNameMap[idx.ID] = idx.Name.O
+
+		// Build column types array for this index
+		idxColumnTypes := make([]byte, 0, len(idx.Columns))
+		for _, idxCol := range idx.Columns {
+			for _, col := range tableInfo.Columns {
+				if col.Name.L == idxCol.Name.L {
+					idxColumnTypes = append(idxColumnTypes, col.GetType())
+					break
+				}
+			}
+		}
+		if len(idxColumnTypes) > 0 {
+			indexColumnTypesMap[idx.ID] = idxColumnTypes
+		}
 	}
-	columnMap := make(map[int64]string, len(tableInfo.Columns))
+
+	// Pre-build lightweight maps for columns: column ID -> name / FieldType.
+	columnTypeMap := make(map[int64]*types.FieldType, len(tableInfo.Columns))
+	columnNameMap := make(map[int64]string, len(tableInfo.Columns))
 	for _, col := range tableInfo.Columns {
-		columnMap[col.ID] = col.Name.O
+		columnNameMap[col.ID] = col.Name.O
+		columnTypeMap[col.ID] = &col.FieldType
 	}
 
 	// Use a single query with subquery to get all table_ids (main table + partitions) at once
@@ -542,22 +564,75 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 
 	for rows.Next() {
 		var isIndex, histID, bucketID, count sql.NullInt64
-		var lowerBound, upperBound sql.NullString
-		if err := rows.Scan(&isIndex, &histID, &bucketID, &count, &lowerBound, &upperBound); err != nil {
+		var lowerBoundBytes, upperBoundBytes []byte
+
+		if err := rows.Scan(&isIndex, &histID, &bucketID, &count, &lowerBoundBytes, &upperBoundBytes); err != nil {
 			return nil, errors.Trace(err)
+		}
+
+		var key string
+		var lowerBoundStr, upperBoundStr string
+		var decodeErr error
+
+		if isIndex.Int64 == 1 {
+			// Index bucket (is_index = 1)
+			idxColumnTypes := indexColumnTypesMap[histID.Int64]
+			indexName := indexNameMap[histID.Int64]
+
+			key = indexName
+
+			// Decode index bound using pre-computed column types
+			lowerBoundStr, decodeErr = decodeIndexBound(lowerBoundBytes, idxColumnTypes)
+			if decodeErr != nil {
+				log.Warn("Failed to decode lower_bound for index",
+					zap.Error(decodeErr),
+					zap.Int64("histID", histID.Int64))
+				lowerBoundStr = fmt.Sprintf("0x%x", lowerBoundBytes)
+			}
+
+			upperBoundStr, decodeErr = decodeIndexBound(upperBoundBytes, idxColumnTypes)
+			if decodeErr != nil {
+				log.Warn("Failed to decode upper_bound for index",
+					zap.Error(decodeErr),
+					zap.Int64("histID", histID.Int64))
+				upperBoundStr = fmt.Sprintf("0x%x", upperBoundBytes)
+			}
+		} else {
+			// Column bucket (is_index = 0)
+			columnName := columnNameMap[histID.Int64]
+			columnTypes := columnTypeMap[histID.Int64]
+
+			key = columnName
+
+			lowerBoundStr, decodeErr = decodeColumnBound(lowerBoundBytes, columnTypes)
+			if decodeErr != nil {
+				log.Warn("Failed to decode lower_bound for column",
+					zap.Error(decodeErr),
+					zap.Int64("histID", histID.Int64))
+				lowerBoundStr = fmt.Sprintf("0x%x", lowerBoundBytes)
+			}
+
+			upperBoundStr, decodeErr = decodeColumnBound(upperBoundBytes, columnTypes)
+			if decodeErr != nil {
+				log.Warn("Failed to decode upper_bound for column",
+					zap.Error(decodeErr),
+					zap.Int64("histID", histID.Int64))
+				upperBoundStr = fmt.Sprintf("0x%x", upperBoundBytes)
+			}
+		}
+
+		if key == "" {
+			// If cannot determine key, skip this record
+			log.Warn("Skipping bucket with unknown key",
+				zap.Int64("histID", histID.Int64),
+				zap.Bool("isIndex", isIndex.Int64 == 1))
+			continue
 		}
 
 		b := Bucket{
 			Count:      count.Int64,
-			LowerBound: lowerBound.String,
-			UpperBound: upperBound.String,
-		}
-
-		var key string
-		if isIndex.Int64 == 1 {
-			key = indexMap[histID.Int64]
-		} else {
-			key = columnMap[histID.Int64]
+			LowerBound: lowerBoundStr,
+			UpperBound: upperBoundStr,
 		}
 
 		buckets[key] = append(buckets[key], b)
@@ -638,6 +713,108 @@ func DecodeTimeInBucket(packedStr string) (string, error) {
 	}
 
 	return t.String(), nil
+}
+
+// decodeColumnBound decodes column bound values (is_index=0) using FieldType only
+func decodeColumnBound(boundBytes []byte, originalFt *types.FieldType) (string, error) {
+	if len(boundBytes) == 0 {
+		return "", nil
+	}
+
+	ctx := statistics.UTCWithAllowInvalidDateCtx
+
+	// Here we directly create KindBytes type Datum, then convert to TypeBlob
+	blobDatum := types.NewBytesDatum(boundBytes)
+
+	// First convert to TypeBlob (simulate GetDatum behavior)
+	blobFt := types.NewFieldType(tmysql.TypeBlob)
+	blobFt.SetCharset(charset.CharsetBin)
+	blobFt.SetCollate(charset.CollationBin)
+	blobTypeDatum, err := blobDatum.ConvertTo(ctx, blobFt)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// For string types, need special handling (because may store collate key)
+	// Reference: pkg/statistics/handle/storage/read.go
+	// First convert to TypeBlob type (bypass charset/collation check), then convert back to original type
+	var targetFt *types.FieldType
+	if types.EvalType(originalFt.GetType()) == types.ETString &&
+		originalFt.GetType() != tmysql.TypeEnum &&
+		originalFt.GetType() != tmysql.TypeSet {
+		targetFt = types.NewFieldType(tmysql.TypeBlob)
+		targetFt.SetCharset(charset.CharsetBin)
+		targetFt.SetCollate(charset.CollationBin)
+	} else {
+		targetFt = originalFt
+	}
+
+	// Use convertBoundFromBlob logic (reference: pkg/statistics/handle/storage/read.go:918-946)
+	var convertedDatum types.Datum
+	if originalFt.GetType() == tmysql.TypeBit {
+		// BIT type special handling (reference: convertBoundFromBlob)
+		// Simplified: first convert to TypeBlob, then convert back to BIT
+		convertedDatum, err = blobTypeDatum.ConvertTo(ctx, targetFt)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		// Then convert back to BIT type
+		convertedDatum, err = convertedDatum.ConvertTo(ctx, originalFt)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	} else {
+		// Other types: convert from TypeBlob to target type
+		convertedDatum, err = blobTypeDatum.ConvertTo(ctx, targetFt)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		// If string type, need to convert back to original type (restore correct charset/collation)
+		if types.EvalType(originalFt.GetType()) == types.ETString &&
+			originalFt.GetType() != tmysql.TypeEnum &&
+			originalFt.GetType() != tmysql.TypeSet {
+			convertedDatum, err = convertedDatum.ConvertTo(ctx, originalFt)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+		}
+	}
+
+	return convertedDatum.ToString()
+}
+
+// decodeIndexBound decodes index bound values (is_index=1) using pre-computed column types
+func decodeIndexBound(boundBytes []byte, idxColumnTypes []byte) (string, error) {
+	if len(boundBytes) == 0 {
+		return "", nil
+	}
+
+	// If cannot get column types, use default value (single column index)
+	if len(idxColumnTypes) == 0 {
+		idxColumnTypes = []byte{tmysql.TypeVarchar}
+	}
+
+	// Decode encoded values
+	numCols := len(idxColumnTypes)
+	if numCols == 0 {
+		numCols = 1
+	}
+
+	decodedVals, remained, err := codec.DecodeRange(
+		boundBytes,
+		numCols,
+		idxColumnTypes,
+		time.UTC,
+	)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	if len(remained) > 0 {
+		decodedVals = append(decodedVals, types.NewBytesDatum(remained))
+	}
+
+	return types.DatumsToString(decodedVals, true)
 }
 
 // GetTidbLatestTSO returns tidb's current TSO.

--- a/pkg/dbutil/common_test.go
+++ b/pkg/dbutil/common_test.go
@@ -26,6 +26,8 @@ import (
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	pmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
+	ttypes "github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/codec"
 )
 
 func (*testDBSuite) TestReplacePlaceholder(c *C) {
@@ -256,14 +258,41 @@ func (*testDBSuite) TestGetBucketsInfo(c *C) {
 
 	ctx := context.Background()
 
-	// Create test table info
+	// Create test table info with proper field types
+	ftID := types.NewFieldType(pmysql.TypeLonglong)
+	ftID.SetFlen(20)
+	ftID.SetFlag(pmysql.NotNullFlag | pmysql.PriKeyFlag)
+
+	ftName := types.NewFieldType(pmysql.TypeVarchar)
+	ftName.SetFlen(255)
+	ftName.SetCharset("utf8mb4")
+	ftName.SetCollate("utf8mb4_bin")
+
+	ftAge := types.NewFieldType(pmysql.TypeLong)
+	ftAge.SetFlen(11)
+
 	tableInfo := &model.TableInfo{
 		ID:   1001,
 		Name: pmodel.NewCIStr("test_table"),
 		Columns: []*model.ColumnInfo{
-			{ID: 1, Name: pmodel.NewCIStr("id"), Offset: 0},
-			{ID: 2, Name: pmodel.NewCIStr("name"), Offset: 1},
-			{ID: 3, Name: pmodel.NewCIStr("age"), Offset: 2},
+			{
+				ID:        1,
+				Name:      pmodel.NewCIStr("id"),
+				Offset:    0,
+				FieldType: *ftID,
+			},
+			{
+				ID:        2,
+				Name:      pmodel.NewCIStr("name"),
+				Offset:    1,
+				FieldType: *ftName,
+			},
+			{
+				ID:        3,
+				Name:      pmodel.NewCIStr("age"),
+				Offset:    2,
+				FieldType: *ftAge,
+			},
 		},
 		Indices: []*model.IndexInfo{
 			{
@@ -288,17 +317,25 @@ func (*testDBSuite) TestGetBucketsInfo(c *C) {
 	// Mock query with subquery to get all table_ids (main table + partitions) at once
 	expectedSQL := "SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id"
 
+	// Encode index values using TiDB's codec
+	encodeIndexValue := func(value interface{}) []byte {
+		datum := ttypes.NewDatum(value)
+		encoded, encodeErr := codec.EncodeKey(time.UTC, nil, datum)
+		c.Assert(encodeErr, IsNil)
+		return encoded
+	}
+
 	// Create mock rows for stats_buckets query
 	rows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"}).
-		// PRIMARY index statistics (is_index=1, hist_id=1 maps to index ID 1)
-		AddRow(1, 1, 0, 100, "1", "50").
-		AddRow(1, 1, 1, 200, "51", "100").
-		// idx_name index statistics (is_index=1, hist_id=2 maps to index ID 2)
-		AddRow(1, 2, 0, 150, "alice", "john").
-		AddRow(1, 2, 1, 300, "kate", "zoe").
-		// Column statistics (is_index=0, hist_id=3 maps to column ID 3 = "age")
-		AddRow(0, 3, 0, 80, "18", "30").
-		AddRow(0, 3, 1, 120, "31", "60")
+		// PRIMARY index statistics (is_index=1, hist_id=1 maps to index ID 1) - use encoded BLOB
+		AddRow(1, 1, 0, 100, encodeIndexValue(int64(1)), encodeIndexValue(int64(50))).
+		AddRow(1, 1, 1, 200, encodeIndexValue(int64(51)), encodeIndexValue(int64(100))).
+		// idx_name index statistics (is_index=1, hist_id=2 maps to index ID 2) - use encoded BLOB
+		AddRow(1, 2, 0, 150, encodeIndexValue("alice"), encodeIndexValue("john")).
+		AddRow(1, 2, 1, 300, encodeIndexValue("kate"), encodeIndexValue("zoe")).
+		// Column statistics (is_index=0, hist_id=3 maps to column ID 3 = "age") - use raw bytes
+		AddRow(0, 3, 0, 80, []byte("18"), []byte("30")).
+		AddRow(0, 3, 1, 120, []byte("31"), []byte("60"))
 
 	mock.ExpectQuery(expectedSQL).WithArgs("test_db", "test_table", "test_db", "test_table").WillReturnRows(rows)
 
@@ -378,12 +415,21 @@ func (*testDBSuite) TestGetBucketsInfoPartitionedTable(c *C) {
 
 	ctx := context.Background()
 
-	// Create test partitioned table info
+	// Create test partitioned table info with proper field types
+	ftID := types.NewFieldType(pmysql.TypeLonglong)
+	ftID.SetFlen(20)
+	ftID.SetFlag(pmysql.NotNullFlag | pmysql.PriKeyFlag)
+
 	tableInfo := &model.TableInfo{
 		ID:   1003,
 		Name: pmodel.NewCIStr("partitioned_table"),
 		Columns: []*model.ColumnInfo{
-			{ID: 1, Name: pmodel.NewCIStr("id"), Offset: 0},
+			{
+				ID:        1,
+				Name:      pmodel.NewCIStr("id"),
+				Offset:    0,
+				FieldType: *ftID,
+			},
 			{ID: 2, Name: pmodel.NewCIStr("name"), Offset: 1},
 		},
 		Indices: []*model.IndexInfo{
@@ -408,17 +454,25 @@ func (*testDBSuite) TestGetBucketsInfoPartitionedTable(c *C) {
 	// Mock query with subquery to get all table_ids (main table + partitions) at once
 	expectedSQL := "SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id"
 
+	// Encode index values using TiDB's codec
+	encodeIndexValue := func(value interface{}) []byte {
+		datum := ttypes.NewDatum(value)
+		encoded, encodeErr := codec.EncodeKey(time.UTC, nil, datum)
+		c.Assert(encodeErr, IsNil)
+		return encoded
+	}
+
 	// Create mock rows for stats_buckets query - includes main table and partitions
 	rows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"}).
-		// Main table statistics
-		AddRow(1, 1, 0, 50, "1", "25").   // PRIMARY index from main table
-		AddRow(1, 1, 1, 100, "26", "50"). // PRIMARY index from main table
+		// Main table statistics (PRIMARY index) - use encoded BLOB
+		AddRow(1, 1, 0, 50, encodeIndexValue(int64(1)), encodeIndexValue(int64(25))).   // PRIMARY index from main table
+		AddRow(1, 1, 1, 100, encodeIndexValue(int64(26)), encodeIndexValue(int64(50))). // PRIMARY index from main table
 		// Partition p0 statistics
-		AddRow(1, 1, 0, 30, "1", "15").  // PRIMARY index from p0
-		AddRow(1, 1, 1, 60, "16", "30"). // PRIMARY index from p0
+		AddRow(1, 1, 0, 30, encodeIndexValue(int64(1)), encodeIndexValue(int64(15))).  // PRIMARY index from p0
+		AddRow(1, 1, 1, 60, encodeIndexValue(int64(16)), encodeIndexValue(int64(30))). // PRIMARY index from p0
 		// Partition p1 statistics
-		AddRow(1, 1, 0, 20, "31", "40"). // PRIMARY index from p1
-		AddRow(1, 1, 1, 40, "41", "50")  // PRIMARY index from p1
+		AddRow(1, 1, 0, 20, encodeIndexValue(int64(31)), encodeIndexValue(int64(40))). // PRIMARY index from p1
+		AddRow(1, 1, 1, 40, encodeIndexValue(int64(41)), encodeIndexValue(int64(50)))  // PRIMARY index from p1
 
 	mock.ExpectQuery(expectedSQL).WithArgs("test_db", "partitioned_table", "test_db", "partitioned_table").WillReturnRows(rows)
 
@@ -433,6 +487,138 @@ func (*testDBSuite) TestGetBucketsInfoPartitionedTable(c *C) {
 	primaryBuckets, exists := buckets["PRIMARY"]
 	c.Assert(exists, Equals, true)
 	c.Assert(len(primaryBuckets), Equals, 6) // 2 from main table + 2 from p0 + 2 from p1
+
+	// Verify all expectations were met
+	c.Assert(mock.ExpectationsWereMet(), IsNil)
+}
+
+func (*testDBSuite) TestGetBucketsInfoWithBlobDecoding(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Create test table info with proper field types
+	ftID := types.NewFieldType(pmysql.TypeLonglong)
+	ftID.SetFlen(20)
+	ftID.SetFlag(pmysql.NotNullFlag | pmysql.PriKeyFlag)
+
+	ftName := types.NewFieldType(pmysql.TypeVarchar)
+	ftName.SetFlen(255)
+	ftName.SetCharset("utf8mb4")
+	ftName.SetCollate("utf8mb4_bin")
+
+	ftAge := types.NewFieldType(pmysql.TypeLong)
+	ftAge.SetFlen(11)
+
+	tableInfo := &model.TableInfo{
+		ID:   1004,
+		Name: pmodel.NewCIStr("blob_test_table"),
+		Columns: []*model.ColumnInfo{
+			{
+				ID:        1,
+				Name:      pmodel.NewCIStr("id"),
+				Offset:    0,
+				FieldType: *ftID,
+			},
+			{
+				ID:        2,
+				Name:      pmodel.NewCIStr("name"),
+				Offset:    1,
+				FieldType: *ftName,
+			},
+			{
+				ID:        3,
+				Name:      pmodel.NewCIStr("age"),
+				Offset:    2,
+				FieldType: *ftAge,
+			},
+		},
+		Indices: []*model.IndexInfo{
+			{
+				ID:   1,
+				Name: pmodel.NewCIStr("PRIMARY"),
+				Columns: []*model.IndexColumn{
+					{Name: pmodel.NewCIStr("id"), Offset: 0},
+				},
+				Primary: true,
+			},
+			{
+				ID:   2,
+				Name: pmodel.NewCIStr("idx_name"),
+				Columns: []*model.IndexColumn{
+					{Name: pmodel.NewCIStr("name"), Offset: 1},
+				},
+			},
+		},
+	}
+
+	// Encode index values using TiDB's codec
+	// For index bounds, we use codec.EncodeKey to encode values
+	encodeIndexValue := func(value interface{}) []byte {
+		datum := ttypes.NewDatum(value)
+		encoded, encodeErr := codec.EncodeKey(time.UTC, nil, datum)
+		c.Assert(encodeErr, IsNil)
+		return encoded
+	}
+
+	// For column bounds, we use the raw bytes representation
+	// Create encoded index bounds for PRIMARY key (integer)
+	primaryLowerEncoded := encodeIndexValue(int64(1))
+	primaryUpperEncoded := encodeIndexValue(int64(100))
+
+	// Create encoded index bounds for idx_name (string)
+	nameLowerEncoded := encodeIndexValue("alice")
+	nameUpperEncoded := encodeIndexValue("zoe")
+
+	// Mock query
+	expectedSQL := "SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id"
+
+	// Create mock rows: index statistics use BLOB ([]byte), column statistics use string
+	rows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"}).
+		// PRIMARY index statistics (is_index=1, hist_id=1 maps to index ID 1) - use BLOB
+		AddRow(1, 1, 0, 100, primaryLowerEncoded, primaryUpperEncoded).
+		// idx_name index statistics (is_index=1, hist_id=2 maps to index ID 2) - use BLOB
+		AddRow(1, 2, 0, 150, nameLowerEncoded, nameUpperEncoded).
+		// Column statistics (is_index=0, hist_id=3 maps to column ID 3 = "age") - use string
+		AddRow(0, 3, 0, 80, "18", "60")
+
+	mock.ExpectQuery(expectedSQL).WithArgs("test_db", "blob_test_table", "test_db", "blob_test_table").WillReturnRows(rows)
+
+	// Execute the function
+	buckets, err := GetBucketsInfo(ctx, db, "test_db", "blob_test_table", tableInfo)
+	c.Assert(err, IsNil)
+
+	// Verify results
+	c.Assert(len(buckets), Equals, 3)
+
+	// Check PRIMARY index buckets - should decode to integer values
+	primaryBuckets, exists := buckets["PRIMARY"]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(primaryBuckets), Equals, 1)
+	c.Assert(primaryBuckets[0].Count, Equals, int64(100))
+	// Decoded values should be strings representing the integers
+	c.Assert(primaryBuckets[0].LowerBound, Equals, "1")
+	c.Assert(primaryBuckets[0].UpperBound, Equals, "100")
+
+	// Check idx_name index buckets - should decode to string values
+	nameBuckets, exists := buckets["idx_name"]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(nameBuckets), Equals, 1)
+	c.Assert(nameBuckets[0].Count, Equals, int64(150))
+	// Decoded values should be the original strings
+	c.Assert(nameBuckets[0].LowerBound, Equals, "alice")
+	c.Assert(nameBuckets[0].UpperBound, Equals, "zoe")
+
+	// Check age column buckets - should decode to string values
+	ageBuckets, exists := buckets["age"]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(ageBuckets), Equals, 1)
+	c.Assert(ageBuckets[0].Count, Equals, int64(80))
+	// Column values are stored as raw bytes, should decode correctly
+	c.Assert(ageBuckets[0].LowerBound, Equals, "18")
+	c.Assert(ageBuckets[0].UpperBound, Equals, "60")
 
 	// Verify all expectations were met
 	c.Assert(mock.ExpectationsWereMet(), IsNil)

--- a/pkg/diff/spliter_test.go
+++ b/pkg/diff/spliter_test.go
@@ -15,11 +15,14 @@ package diff
 
 import (
 	"fmt"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb-tools/pkg/dbutil"
 	"github.com/pingcap/tidb/pkg/parser"
+	ttypes "github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/codec"
 )
 
 var _ = Suite(&testSpliterSuite{})
@@ -454,7 +457,17 @@ func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandom
 	// Mock query with subquery to get all table_ids (main table + partitions) at once
 	statsRows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"})
 	for i := 0; i < 5; i++ {
-		statsRows.AddRow(1, 1, i, (i+1)*64, fmt.Sprintf("(%d, %d)", i*64, i*12), fmt.Sprintf("(%d, %d)", (i+1)*64-1, (i+1)*12-1))
+		// Encode index bounds as real encoded keys: PRIMARY(a, b) where both a and b are integers.
+		lowerA, lowerB := i*64, i*12
+		upperA, upperB := (i+1)*64-1, (i+1)*12-1
+
+		lowerDatums := []ttypes.Datum{ttypes.NewIntDatum(int64(lowerA)), ttypes.NewStringDatum(fmt.Sprintf("%d", lowerB))}
+		upperDatums := []ttypes.Datum{ttypes.NewIntDatum(int64(upperA)), ttypes.NewStringDatum(fmt.Sprintf("%d", upperB))}
+
+		lowerEncoded, _ := codec.EncodeKey(time.UTC, nil, lowerDatums...)
+		upperEncoded, _ := codec.EncodeKey(time.UTC, nil, upperDatums...)
+
+		statsRows.AddRow(1, 1, i, (i+1)*64, lowerEncoded, upperEncoded)
 	}
 	mock.ExpectQuery("SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
GetBucketsInfo incorrectly decodes `mysql.stats_buckets.lower_bound` / `upper_bound` for histograms , treating encoded index keys as plain strings and producing garbled output instead of the original key values.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #876 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

### Release note

```release-note
NA
```