### PR TITLE
sync-diff-inspector: skip missing columns and indexes when fetch stats

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -576,8 +576,15 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 
 		if isIndex.Int64 == 1 {
 			// Index bucket (is_index = 1)
-			idxColumnTypes := indexColumnTypesMap[histID.Int64]
+			idxColumnTypes, ok := indexColumnTypesMap[histID.Int64]
 			indexName := indexNameMap[histID.Int64]
+			if !ok {
+				log.Warn("no index column info found for index bucket hist_id",
+					zap.String("schema", schema),
+					zap.String("table", table),
+					zap.Int64("histID", histID.Int64))
+				return nil, errors.New("index column types not found")
+			}
 
 			key = indexName
 
@@ -599,8 +606,16 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 			}
 		} else {
 			// Column bucket (is_index = 0)
-			columnName := columnNameMap[histID.Int64]
+			columnName, ok := columnNameMap[histID.Int64]
 			columnTypes := columnTypeMap[histID.Int64]
+
+			if !ok {
+				log.Warn("no column info found for column bucket hist_id",
+					zap.String("schema", schema),
+					zap.String("table", table),
+					zap.Int64("histID", histID.Int64))
+				return nil, errors.New("column types not found")
+			}
 
 			key = columnName
 

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -699,6 +699,12 @@ func TestBucketSpliter(t *testing.T) {
 	for i, bound := range chunk.Bounds {
 		require.Equal(t, bounds1[i].Upper, bound.Lower)
 	}
+
+	// Mock column a is ignored.
+	tableDiff.Info, _ = utils.ResetColumns(tableInfo, []string{"a"})
+	createFakeResultForBucketSplit(mock, testCases[0].aRandomValues, testCases[0].bRandomValues)
+	_, err = NewBucketIterator(ctx, "", tableDiff, db)
+	require.Error(t, err)
 }
 
 func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandomValues []interface{}) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #879

### What is changed and how it works?

Sometimes, the column ID from `mysql.stats_buckets` may not exist in table info, like:
- The column is removed in `ResetColumn`, as we remove ignored columns provided in the configuration.
- User executed some DDL on this table and generated a new column ID, for example, `MODIFY COLUMN`.

In such case, we should skip the decoding.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
