### PR TITLE
schemacmp: allow latin1/utf8 < utf8mb4 charset/collation join

### DIFF
--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -1,0 +1,186 @@
+package schemacmp
+
+import (
+	"strings"
+
+	tidbcharset "github.com/pingcap/tidb/pkg/parser/charset"
+)
+
+type charsetLattice struct {
+	value string
+	kind  charsetKind
+}
+
+type charsetKind int
+
+const (
+	charsetKindEmpty charsetKind = iota
+	charsetKindUTF8
+	charsetKindUTF8MB4
+	charsetKindOther
+)
+
+// Charset is a lattice for comparing/joining character sets.
+// It supports the ordering: "" < utf8(utf8mb3) < utf8mb4.
+// Other charsets are only comparable when identical.
+func Charset(cs string) Lattice {
+	value := strings.ToLower(cs)
+	if value == tidbcharset.CharsetUTF8MB3 {
+		value = tidbcharset.CharsetUTF8
+	}
+
+	switch value {
+	case "":
+		return charsetLattice{value: value, kind: charsetKindEmpty}
+	case tidbcharset.CharsetUTF8:
+		return charsetLattice{value: value, kind: charsetKindUTF8}
+	case tidbcharset.CharsetUTF8MB4:
+		return charsetLattice{value: value, kind: charsetKindUTF8MB4}
+	default:
+		return charsetLattice{value: value, kind: charsetKindOther}
+	}
+}
+
+func (a charsetLattice) Unwrap() interface{} {
+	return a.value
+}
+
+func (a charsetLattice) Compare(other Lattice) (int, error) {
+	b, ok := other.(charsetLattice)
+	if !ok {
+		return 0, typeMismatchError(a, other)
+	}
+
+	if a.value == b.value {
+		return 0, nil
+	}
+
+	// Only utf8/utf8mb4 (plus empty) are ordered.
+	switch {
+	case a.kind == charsetKindEmpty && (b.kind == charsetKindUTF8 || b.kind == charsetKindUTF8MB4):
+		return -1, nil
+	case b.kind == charsetKindEmpty && (a.kind == charsetKindUTF8 || a.kind == charsetKindUTF8MB4):
+		return 1, nil
+	case a.kind == charsetKindUTF8 && b.kind == charsetKindUTF8MB4:
+		return -1, nil
+	case a.kind == charsetKindUTF8MB4 && b.kind == charsetKindUTF8:
+		return 1, nil
+	default:
+		return 0, distinctSingletonsErrors(a.value, b.value)
+	}
+}
+
+func (a charsetLattice) Join(other Lattice) (Lattice, error) {
+	b, ok := other.(charsetLattice)
+	if !ok {
+		return nil, typeMismatchError(a, other)
+	}
+
+	cmp, err := a.Compare(b)
+	if err != nil {
+		return nil, err
+	}
+	if cmp >= 0 {
+		return a, nil
+	}
+	return b, nil
+}
+
+type collationLattice struct {
+	value  string
+	kind   collationKind
+	suffix string
+}
+
+type collationKind int
+
+const (
+	collationKindEmpty collationKind = iota
+	collationKindUTF8
+	collationKindUTF8MB4
+	collationKindOther
+)
+
+// Collation is a lattice for comparing/joining collations.
+// It supports the ordering: utf8_<suffix> < utf8mb4_<suffix> (same suffix only).
+// Other collations are only comparable when identical.
+func Collation(co string) Lattice {
+	value := strings.ToLower(co)
+	if strings.HasPrefix(value, "utf8mb3_") {
+		value = "utf8_" + strings.TrimPrefix(value, "utf8mb3_")
+	}
+
+	switch {
+	case value == "":
+		return collationLattice{value: value, kind: collationKindEmpty}
+	case strings.HasPrefix(value, "utf8mb4_"):
+		return collationLattice{
+			value:  value,
+			kind:   collationKindUTF8MB4,
+			suffix: strings.TrimPrefix(value, "utf8mb4_"),
+		}
+	case strings.HasPrefix(value, "utf8_"):
+		return collationLattice{
+			value:  value,
+			kind:   collationKindUTF8,
+			suffix: strings.TrimPrefix(value, "utf8_"),
+		}
+	default:
+		return collationLattice{value: value, kind: collationKindOther}
+	}
+}
+
+func (a collationLattice) Unwrap() interface{} {
+	return a.value
+}
+
+func (a collationLattice) Compare(other Lattice) (int, error) {
+	b, ok := other.(collationLattice)
+	if !ok {
+		return 0, typeMismatchError(a, other)
+	}
+
+	if a.value == b.value {
+		return 0, nil
+	}
+
+	// Collation without explicit value is not ordered (it depends on charset).
+	if a.kind == collationKindEmpty || b.kind == collationKindEmpty {
+		return 0, distinctSingletonsErrors(a.value, b.value)
+	}
+
+	// Only utf8/utf8mb4 with the same suffix are ordered.
+	if (a.kind == collationKindUTF8 || a.kind == collationKindUTF8MB4) &&
+		(b.kind == collationKindUTF8 || b.kind == collationKindUTF8MB4) {
+		if a.suffix != b.suffix {
+			return 0, distinctSingletonsErrors(a.value, b.value)
+		}
+		switch {
+		case a.kind == collationKindUTF8 && b.kind == collationKindUTF8MB4:
+			return -1, nil
+		case a.kind == collationKindUTF8MB4 && b.kind == collationKindUTF8:
+			return 1, nil
+		default:
+			// Same kind but different value cannot happen because suffix differs is handled above.
+			return 0, distinctSingletonsErrors(a.value, b.value)
+		}
+	}
+
+	return 0, distinctSingletonsErrors(a.value, b.value)
+}
+
+func (a collationLattice) Join(other Lattice) (Lattice, error) {
+	b, ok := other.(collationLattice)
+	if !ok {
+		return nil, typeMismatchError(a, other)
+	}
+
+	cmp, err := a.Compare(b)
+	if err != nil {
+		return nil, err
+	}
+	if cmp >= 0 {
+		return a, nil
+	}
+	return b, nil
+}

--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -16,12 +16,6 @@ type charsetKind struct {
 	key    string
 }
 
-const (
-	charsetKeyLatin1  = tidbcharset.CharsetLatin1
-	charsetKeyUTF8    = tidbcharset.CharsetUTF8
-	charsetKeyUTF8MB4 = tidbcharset.CharsetUTF8MB4
-)
-
 type charsetFamily int
 
 const (
@@ -42,11 +36,11 @@ func Charset(cs string) Lattice {
 
 	switch normalized {
 	case tidbcharset.CharsetLatin1:
-		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyLatin1, key: charsetKeyLatin1}}
+		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyLatin1, key: tidbcharset.CharsetLatin1}}
 	case tidbcharset.CharsetUTF8:
-		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8, key: charsetKeyUTF8}}
+		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8, key: tidbcharset.CharsetUTF8}}
 	case tidbcharset.CharsetUTF8MB4:
-		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8MB4, key: charsetKeyUTF8MB4}}
+		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8MB4, key: tidbcharset.CharsetUTF8MB4}}
 	default:
 		// Caller should always pass an explicit charset. Unrecognized values are treated as "other".
 		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyOther, key: normalized}}

--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -11,44 +11,50 @@ type charsetLattice struct {
 	kind  charsetKind
 }
 
-type charsetKind int
+type charsetKind struct {
+	family charsetFamily
+	key    string
+}
 
 const (
-	charsetKindEmpty charsetKind = iota
-	charsetKindLatin1
-	charsetKindUTF8
-	charsetKindUTF8MB4
-	charsetKindOther
+	charsetKeyLatin1  = tidbcharset.CharsetLatin1
+	charsetKeyUTF8    = tidbcharset.CharsetUTF8
+	charsetKeyUTF8MB4 = tidbcharset.CharsetUTF8MB4
+)
+
+type charsetFamily int
+
+const (
+	charsetFamilyOther charsetFamily = iota
+	charsetFamilyLatin1
+	charsetFamilyUTF8
+	charsetFamilyUTF8MB4
 )
 
 // Charset is a lattice for comparing/joining character sets.
-// It supports the ordering:
-//   - "" < latin1 < utf8mb4
-//   - "" < utf8(utf8mb3) < utf8mb4
-//
+// It supports the ordering: latin1 < utf8mb4 and utf8(utf8mb3) < utf8mb4.
 // Other charsets are only comparable when identical.
 func Charset(cs string) Lattice {
-	value := strings.ToLower(cs)
-	if value == tidbcharset.CharsetUTF8MB3 {
-		value = tidbcharset.CharsetUTF8
+	normalized := strings.ToLower(cs)
+	if normalized == tidbcharset.CharsetUTF8MB3 {
+		normalized = tidbcharset.CharsetUTF8
 	}
 
-	switch value {
-	case "":
-		return charsetLattice{value: value, kind: charsetKindEmpty}
+	switch normalized {
 	case tidbcharset.CharsetLatin1:
-		return charsetLattice{value: value, kind: charsetKindLatin1}
+		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyLatin1, key: charsetKeyLatin1}}
 	case tidbcharset.CharsetUTF8:
-		return charsetLattice{value: value, kind: charsetKindUTF8}
+		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8, key: charsetKeyUTF8}}
 	case tidbcharset.CharsetUTF8MB4:
-		return charsetLattice{value: value, kind: charsetKindUTF8MB4}
+		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8MB4, key: charsetKeyUTF8MB4}}
 	default:
-		return charsetLattice{value: value, kind: charsetKindOther}
+		// Caller should always pass an explicit charset. Invalid/empty values are treated as "other".
+		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyOther, key: normalized}}
 	}
 }
 
 func (a charsetLattice) Unwrap() interface{} {
-	return a.value
+	return a.kind.key
 }
 
 func (a charsetLattice) Compare(other Lattice) (int, error) {
@@ -57,23 +63,18 @@ func (a charsetLattice) Compare(other Lattice) (int, error) {
 		return 0, typeMismatchError(a, other)
 	}
 
-	if a.value == b.value {
+	if a.kind == b.kind {
 		return 0, nil
 	}
 
-	// Only latin1/utf8/utf8mb4 (plus empty) are ordered.
 	switch {
-	case a.kind == charsetKindEmpty && (b.kind == charsetKindLatin1 || b.kind == charsetKindUTF8 || b.kind == charsetKindUTF8MB4):
+	case a.kind.family == charsetFamilyUTF8 && b.kind.family == charsetFamilyUTF8MB4:
 		return -1, nil
-	case b.kind == charsetKindEmpty && (a.kind == charsetKindLatin1 || a.kind == charsetKindUTF8 || a.kind == charsetKindUTF8MB4):
+	case a.kind.family == charsetFamilyUTF8MB4 && b.kind.family == charsetFamilyUTF8:
 		return 1, nil
-	case a.kind == charsetKindUTF8 && b.kind == charsetKindUTF8MB4:
+	case a.kind.family == charsetFamilyLatin1 && b.kind.family == charsetFamilyUTF8MB4:
 		return -1, nil
-	case a.kind == charsetKindUTF8MB4 && b.kind == charsetKindUTF8:
-		return 1, nil
-	case a.kind == charsetKindLatin1 && b.kind == charsetKindUTF8MB4:
-		return -1, nil
-	case a.kind == charsetKindUTF8MB4 && b.kind == charsetKindLatin1:
+	case a.kind.family == charsetFamilyUTF8MB4 && b.kind.family == charsetFamilyLatin1:
 		return 1, nil
 	default:
 		return 0, distinctSingletonsErrors(a.value, b.value)
@@ -97,19 +98,23 @@ func (a charsetLattice) Join(other Lattice) (Lattice, error) {
 }
 
 type collationLattice struct {
-	value  string
-	kind   collationKind
-	suffix string
+	value string
+	kind  collationKind
 }
 
-type collationKind int
+type collationKind struct {
+	family collationFamily
+	suffix string
+	key    string
+}
+
+type collationFamily int
 
 const (
-	collationKindEmpty collationKind = iota
-	collationKindLatin1
-	collationKindUTF8
-	collationKindUTF8MB4
-	collationKindOther
+	collationFamilyOther collationFamily = iota
+	collationFamilyLatin1
+	collationFamilyUTF8
+	collationFamilyUTF8MB4
 )
 
 // Collation is a lattice for comparing/joining collations.
@@ -120,39 +125,29 @@ const (
 // (same suffix only).
 // Other collations are only comparable when identical.
 func Collation(co string) Lattice {
-	value := strings.ToLower(co)
-	if strings.HasPrefix(value, "utf8mb3_") {
-		value = "utf8_" + strings.TrimPrefix(value, "utf8mb3_")
+	normalized := strings.ToLower(co)
+	if strings.HasPrefix(normalized, "utf8mb3_") {
+		normalized = "utf8_" + strings.TrimPrefix(normalized, "utf8mb3_")
 	}
 
 	switch {
-	case value == "":
-		return collationLattice{value: value, kind: collationKindEmpty}
-	case strings.HasPrefix(value, "utf8mb4_"):
-		return collationLattice{
-			value:  value,
-			kind:   collationKindUTF8MB4,
-			suffix: strings.TrimPrefix(value, "utf8mb4_"),
-		}
-	case strings.HasPrefix(value, "utf8_"):
-		return collationLattice{
-			value:  value,
-			kind:   collationKindUTF8,
-			suffix: strings.TrimPrefix(value, "utf8_"),
-		}
-	case strings.HasPrefix(value, "latin1_"):
-		return collationLattice{
-			value:  value,
-			kind:   collationKindLatin1,
-			suffix: strings.TrimPrefix(value, "latin1_"),
-		}
+	case strings.HasPrefix(normalized, "utf8mb4_"):
+		suffix := strings.TrimPrefix(normalized, "utf8mb4_")
+		return collationLattice{value: co, kind: collationKind{family: collationFamilyUTF8MB4, suffix: suffix, key: "utf8mb4_" + suffix}}
+	case strings.HasPrefix(normalized, "utf8_"):
+		suffix := strings.TrimPrefix(normalized, "utf8_")
+		return collationLattice{value: co, kind: collationKind{family: collationFamilyUTF8, suffix: suffix, key: "utf8_" + suffix}}
+	case strings.HasPrefix(normalized, "latin1_"):
+		suffix := strings.TrimPrefix(normalized, "latin1_")
+		return collationLattice{value: co, kind: collationKind{family: collationFamilyLatin1, suffix: suffix, key: "latin1_" + suffix}}
 	default:
-		return collationLattice{value: value, kind: collationKindOther}
+		// Caller should always pass an explicit collation. Invalid/empty values are treated as "other".
+		return collationLattice{value: co, kind: collationKind{family: collationFamilyOther, key: normalized}}
 	}
 }
 
 func (a collationLattice) Unwrap() interface{} {
-	return a.value
+	return a.kind.key
 }
 
 func (a collationLattice) Compare(other Lattice) (int, error) {
@@ -161,28 +156,28 @@ func (a collationLattice) Compare(other Lattice) (int, error) {
 		return 0, typeMismatchError(a, other)
 	}
 
-	if a.value == b.value {
+	if a.kind == b.kind {
 		return 0, nil
 	}
 
-	// Collation without explicit value is not ordered (it depends on charset).
-	if a.kind == collationKindEmpty || b.kind == collationKindEmpty {
+	// If caller passed an invalid/empty collation, treat it as "other" and make it incomparable with valid ones.
+	if a.kind.family == collationFamilyOther || b.kind.family == collationFamilyOther {
 		return 0, distinctSingletonsErrors(a.value, b.value)
 	}
 
 	// Only latin1/utf8/utf8mb4 with the same suffix are ordered.
-	if a.suffix != b.suffix {
+	if a.kind.suffix != b.kind.suffix {
 		return 0, distinctSingletonsErrors(a.value, b.value)
 	}
 
 	switch {
-	case a.kind == collationKindUTF8 && b.kind == collationKindUTF8MB4:
+	case a.kind.family == collationFamilyUTF8 && b.kind.family == collationFamilyUTF8MB4:
 		return -1, nil
-	case a.kind == collationKindUTF8MB4 && b.kind == collationKindUTF8:
+	case a.kind.family == collationFamilyUTF8MB4 && b.kind.family == collationFamilyUTF8:
 		return 1, nil
-	case a.kind == collationKindLatin1 && b.kind == collationKindUTF8MB4:
+	case a.kind.family == collationFamilyLatin1 && b.kind.family == collationFamilyUTF8MB4:
 		return -1, nil
-	case a.kind == collationKindUTF8MB4 && b.kind == collationKindLatin1:
+	case a.kind.family == collationFamilyUTF8MB4 && b.kind.family == collationFamilyLatin1:
 		return 1, nil
 	default:
 		return 0, distinctSingletonsErrors(a.value, b.value)

--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -48,7 +48,7 @@ func Charset(cs string) Lattice {
 	case tidbcharset.CharsetUTF8MB4:
 		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8MB4, key: charsetKeyUTF8MB4}}
 	default:
-		// Caller should always pass an explicit charset. Invalid/empty values are treated as "other".
+		// Caller should always pass an explicit charset. Unrecognized values are treated as "other".
 		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyOther, key: normalized}}
 	}
 }
@@ -141,7 +141,7 @@ func Collation(co string) Lattice {
 		suffix := strings.TrimPrefix(normalized, "latin1_")
 		return collationLattice{value: co, kind: collationKind{family: collationFamilyLatin1, suffix: suffix, key: "latin1_" + suffix}}
 	default:
-		// Caller should always pass an explicit collation. Invalid/empty values are treated as "other".
+		// Caller should always pass an explicit collation. Unrecognized values are treated as "other".
 		return collationLattice{value: co, kind: collationKind{family: collationFamilyOther, key: normalized}}
 	}
 }
@@ -160,7 +160,7 @@ func (a collationLattice) Compare(other Lattice) (int, error) {
 		return 0, nil
 	}
 
-	// If caller passed an invalid/empty collation, treat it as "other" and make it incomparable with valid ones.
+	// If caller passed an unrecognized collation, treat it as "other" and make it incomparable with valid ones.
 	if a.kind.family == collationFamilyOther || b.kind.family == collationFamilyOther {
 		return 0, distinctSingletonsErrors(a.value, b.value)
 	}

--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -7,13 +7,8 @@ import (
 )
 
 type charsetLattice struct {
-	value string
-	kind  charsetKind
-}
-
-type charsetKind struct {
+	value  string
 	family charsetFamily
-	key    string
 }
 
 type charsetFamily int
@@ -25,10 +20,12 @@ const (
 	charsetFamilyUTF8MB4
 )
 
-// Charset is a lattice for comparing/joining character sets.
-// It supports the ordering: latin1 < utf8mb4 and utf8(utf8mb3) < utf8mb4.
-// Other charsets are only comparable when identical.
+// Charset is a lattice for comparing/joining character sets. Currently it
+// supports the ordering: latin1 < utf8mb4 and utf8(utf8mb3) < utf8mb4. Other
+// charsets are only comparable when identical.
 func Charset(cs string) Lattice {
+	ret := charsetLattice{value: cs}
+
 	normalized := strings.ToLower(cs)
 	if normalized == tidbcharset.CharsetUTF8MB3 {
 		normalized = tidbcharset.CharsetUTF8
@@ -36,15 +33,16 @@ func Charset(cs string) Lattice {
 
 	switch normalized {
 	case tidbcharset.CharsetLatin1:
-		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyLatin1, key: tidbcharset.CharsetLatin1}}
+		ret.family = charsetFamilyLatin1
 	case tidbcharset.CharsetUTF8:
-		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8, key: tidbcharset.CharsetUTF8}}
+		ret.family = charsetFamilyUTF8
 	case tidbcharset.CharsetUTF8MB4:
-		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyUTF8MB4, key: tidbcharset.CharsetUTF8MB4}}
+		ret.family = charsetFamilyUTF8MB4
 	default:
 		// Caller should always pass an explicit charset. Unrecognized values are treated as "other".
-		return charsetLattice{value: cs, kind: charsetKind{family: charsetFamilyOther, key: normalized}}
+		ret.family = charsetFamilyOther
 	}
+	return ret
 }
 
 func (a charsetLattice) Unwrap() interface{} {
@@ -57,21 +55,21 @@ func (a charsetLattice) Compare(other Lattice) (int, error) {
 		return 0, typeMismatchError(a, other)
 	}
 
-	if a.kind == b.kind {
+	if a.family == b.family {
 		return 0, nil
 	}
 
 	switch {
-	case a.kind.family == charsetFamilyUTF8 && b.kind.family == charsetFamilyUTF8MB4:
+	case a.family == charsetFamilyUTF8 && b.family == charsetFamilyUTF8MB4:
 		return -1, nil
-	case a.kind.family == charsetFamilyUTF8MB4 && b.kind.family == charsetFamilyUTF8:
+	case a.family == charsetFamilyUTF8MB4 && b.family == charsetFamilyUTF8:
 		return 1, nil
-	case a.kind.family == charsetFamilyLatin1 && b.kind.family == charsetFamilyUTF8MB4:
+	case a.family == charsetFamilyLatin1 && b.family == charsetFamilyUTF8MB4:
 		return -1, nil
-	case a.kind.family == charsetFamilyUTF8MB4 && b.kind.family == charsetFamilyLatin1:
+	case a.family == charsetFamilyUTF8MB4 && b.family == charsetFamilyLatin1:
 		return 1, nil
 	default:
-		return 0, distinctSingletonsErrors(a.value, b.value)
+		return 0, incompatibleCharsetError(a.value, b.value)
 	}
 }
 
@@ -92,14 +90,11 @@ func (a charsetLattice) Join(other Lattice) (Lattice, error) {
 }
 
 type collationLattice struct {
-	value string
-	kind  collationKind
-}
-
-type collationKind struct {
+	value  string
 	family collationFamily
+	// suffix will be set to normalized value when family is collationFamilyOther for
+	// implementation simplicity.
 	suffix string
-	key    string
 }
 
 type collationFamily int
@@ -119,25 +114,34 @@ const (
 // (same suffix only).
 // Other collations are only comparable when identical.
 func Collation(co string) Lattice {
+	ret := collationLattice{value: co}
+
+	const (
+		utf8mb3Prefix = tidbcharset.CharsetUTF8MB3 + "_"
+		utf8mb4Prefix = tidbcharset.CharsetUTF8MB4 + "_"
+		utf8Prefix    = tidbcharset.CharsetUTF8 + "_"
+		latin1Prefix  = tidbcharset.CharsetLatin1 + "_"
+	)
+
 	normalized := strings.ToLower(co)
-	if strings.HasPrefix(normalized, "utf8mb3_") {
-		normalized = "utf8_" + strings.TrimPrefix(normalized, "utf8mb3_")
+	if after, ok := strings.CutPrefix(normalized, utf8mb3Prefix); ok {
+		normalized = utf8Prefix + after
 	}
 
-	switch {
-	case strings.HasPrefix(normalized, "utf8mb4_"):
-		suffix := strings.TrimPrefix(normalized, "utf8mb4_")
-		return collationLattice{value: co, kind: collationKind{family: collationFamilyUTF8MB4, suffix: suffix, key: "utf8mb4_" + suffix}}
-	case strings.HasPrefix(normalized, "utf8_"):
-		suffix := strings.TrimPrefix(normalized, "utf8_")
-		return collationLattice{value: co, kind: collationKind{family: collationFamilyUTF8, suffix: suffix, key: "utf8_" + suffix}}
-	case strings.HasPrefix(normalized, "latin1_"):
-		suffix := strings.TrimPrefix(normalized, "latin1_")
-		return collationLattice{value: co, kind: collationKind{family: collationFamilyLatin1, suffix: suffix, key: "latin1_" + suffix}}
-	default:
-		// Caller should always pass an explicit collation. Unrecognized values are treated as "other".
-		return collationLattice{value: co, kind: collationKind{family: collationFamilyOther, key: normalized}}
+	if after, ok := strings.CutPrefix(normalized, utf8mb4Prefix); ok {
+		ret.suffix = after
+		ret.family = collationFamilyUTF8MB4
+	} else if after, ok := strings.CutPrefix(normalized, utf8Prefix); ok {
+		ret.suffix = after
+		ret.family = collationFamilyUTF8
+	} else if after, ok := strings.CutPrefix(normalized, latin1Prefix); ok {
+		ret.suffix = after
+		ret.family = collationFamilyLatin1
+	} else {
+		ret.family = collationFamilyOther
+		ret.suffix = normalized
 	}
+	return ret
 }
 
 func (a collationLattice) Unwrap() interface{} {
@@ -150,31 +154,29 @@ func (a collationLattice) Compare(other Lattice) (int, error) {
 		return 0, typeMismatchError(a, other)
 	}
 
-	if a.kind == b.kind {
-		return 0, nil
-	}
-
-	// If caller passed an unrecognized collation, treat it as "other" and make it incomparable with valid ones.
-	if a.kind.family == collationFamilyOther || b.kind.family == collationFamilyOther {
-		return 0, distinctSingletonsErrors(a.value, b.value)
+	if a.family == b.family {
+		if a.suffix == b.suffix {
+			return 0, nil
+		}
+		return 0, incompatibleCollationError(a.value, b.value)
 	}
 
 	// Only latin1/utf8/utf8mb4 with the same suffix are ordered.
-	if a.kind.suffix != b.kind.suffix {
-		return 0, distinctSingletonsErrors(a.value, b.value)
+	if a.suffix != b.suffix {
+		return 0, incompatibleCollationError(a.value, b.value)
 	}
 
 	switch {
-	case a.kind.family == collationFamilyUTF8 && b.kind.family == collationFamilyUTF8MB4:
+	case a.family == collationFamilyUTF8 && b.family == collationFamilyUTF8MB4:
 		return -1, nil
-	case a.kind.family == collationFamilyUTF8MB4 && b.kind.family == collationFamilyUTF8:
+	case a.family == collationFamilyUTF8MB4 && b.family == collationFamilyUTF8:
 		return 1, nil
-	case a.kind.family == collationFamilyLatin1 && b.kind.family == collationFamilyUTF8MB4:
+	case a.family == collationFamilyLatin1 && b.family == collationFamilyUTF8MB4:
 		return -1, nil
-	case a.kind.family == collationFamilyUTF8MB4 && b.kind.family == collationFamilyLatin1:
+	case a.family == collationFamilyUTF8MB4 && b.family == collationFamilyLatin1:
 		return 1, nil
 	default:
-		return 0, distinctSingletonsErrors(a.value, b.value)
+		return 0, incompatibleCollationError(a.value, b.value)
 	}
 }
 

--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -15,13 +15,17 @@ type charsetKind int
 
 const (
 	charsetKindEmpty charsetKind = iota
+	charsetKindLatin1
 	charsetKindUTF8
 	charsetKindUTF8MB4
 	charsetKindOther
 )
 
 // Charset is a lattice for comparing/joining character sets.
-// It supports the ordering: "" < utf8(utf8mb3) < utf8mb4.
+// It supports the ordering:
+//   - "" < latin1 < utf8mb4
+//   - "" < utf8(utf8mb3) < utf8mb4
+//
 // Other charsets are only comparable when identical.
 func Charset(cs string) Lattice {
 	value := strings.ToLower(cs)
@@ -32,6 +36,8 @@ func Charset(cs string) Lattice {
 	switch value {
 	case "":
 		return charsetLattice{value: value, kind: charsetKindEmpty}
+	case tidbcharset.CharsetLatin1:
+		return charsetLattice{value: value, kind: charsetKindLatin1}
 	case tidbcharset.CharsetUTF8:
 		return charsetLattice{value: value, kind: charsetKindUTF8}
 	case tidbcharset.CharsetUTF8MB4:
@@ -55,15 +61,19 @@ func (a charsetLattice) Compare(other Lattice) (int, error) {
 		return 0, nil
 	}
 
-	// Only utf8/utf8mb4 (plus empty) are ordered.
+	// Only latin1/utf8/utf8mb4 (plus empty) are ordered.
 	switch {
-	case a.kind == charsetKindEmpty && (b.kind == charsetKindUTF8 || b.kind == charsetKindUTF8MB4):
+	case a.kind == charsetKindEmpty && (b.kind == charsetKindLatin1 || b.kind == charsetKindUTF8 || b.kind == charsetKindUTF8MB4):
 		return -1, nil
-	case b.kind == charsetKindEmpty && (a.kind == charsetKindUTF8 || a.kind == charsetKindUTF8MB4):
+	case b.kind == charsetKindEmpty && (a.kind == charsetKindLatin1 || a.kind == charsetKindUTF8 || a.kind == charsetKindUTF8MB4):
 		return 1, nil
 	case a.kind == charsetKindUTF8 && b.kind == charsetKindUTF8MB4:
 		return -1, nil
 	case a.kind == charsetKindUTF8MB4 && b.kind == charsetKindUTF8:
+		return 1, nil
+	case a.kind == charsetKindLatin1 && b.kind == charsetKindUTF8MB4:
+		return -1, nil
+	case a.kind == charsetKindUTF8MB4 && b.kind == charsetKindLatin1:
 		return 1, nil
 	default:
 		return 0, distinctSingletonsErrors(a.value, b.value)
@@ -96,13 +106,18 @@ type collationKind int
 
 const (
 	collationKindEmpty collationKind = iota
+	collationKindLatin1
 	collationKindUTF8
 	collationKindUTF8MB4
 	collationKindOther
 )
 
 // Collation is a lattice for comparing/joining collations.
-// It supports the ordering: utf8_<suffix> < utf8mb4_<suffix> (same suffix only).
+// It supports the ordering:
+//   - latin1_<suffix> < utf8mb4_<suffix>
+//   - utf8_<suffix> < utf8mb4_<suffix>
+//
+// (same suffix only).
 // Other collations are only comparable when identical.
 func Collation(co string) Lattice {
 	value := strings.ToLower(co)
@@ -124,6 +139,12 @@ func Collation(co string) Lattice {
 			value:  value,
 			kind:   collationKindUTF8,
 			suffix: strings.TrimPrefix(value, "utf8_"),
+		}
+	case strings.HasPrefix(value, "latin1_"):
+		return collationLattice{
+			value:  value,
+			kind:   collationKindLatin1,
+			suffix: strings.TrimPrefix(value, "latin1_"),
 		}
 	default:
 		return collationLattice{value: value, kind: collationKindOther}
@@ -149,24 +170,23 @@ func (a collationLattice) Compare(other Lattice) (int, error) {
 		return 0, distinctSingletonsErrors(a.value, b.value)
 	}
 
-	// Only utf8/utf8mb4 with the same suffix are ordered.
-	if (a.kind == collationKindUTF8 || a.kind == collationKindUTF8MB4) &&
-		(b.kind == collationKindUTF8 || b.kind == collationKindUTF8MB4) {
-		if a.suffix != b.suffix {
-			return 0, distinctSingletonsErrors(a.value, b.value)
-		}
-		switch {
-		case a.kind == collationKindUTF8 && b.kind == collationKindUTF8MB4:
-			return -1, nil
-		case a.kind == collationKindUTF8MB4 && b.kind == collationKindUTF8:
-			return 1, nil
-		default:
-			// Same kind but different value cannot happen because suffix differs is handled above.
-			return 0, distinctSingletonsErrors(a.value, b.value)
-		}
+	// Only latin1/utf8/utf8mb4 with the same suffix are ordered.
+	if a.suffix != b.suffix {
+		return 0, distinctSingletonsErrors(a.value, b.value)
 	}
 
-	return 0, distinctSingletonsErrors(a.value, b.value)
+	switch {
+	case a.kind == collationKindUTF8 && b.kind == collationKindUTF8MB4:
+		return -1, nil
+	case a.kind == collationKindUTF8MB4 && b.kind == collationKindUTF8:
+		return 1, nil
+	case a.kind == collationKindLatin1 && b.kind == collationKindUTF8MB4:
+		return -1, nil
+	case a.kind == collationKindUTF8MB4 && b.kind == collationKindLatin1:
+		return 1, nil
+	default:
+		return 0, distinctSingletonsErrors(a.value, b.value)
+	}
 }
 
 func (a collationLattice) Join(other Lattice) (Lattice, error) {

--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -48,7 +48,7 @@ func Charset(cs string) Lattice {
 }
 
 func (a charsetLattice) Unwrap() interface{} {
-	return a.kind.key
+	return a.value
 }
 
 func (a charsetLattice) Compare(other Lattice) (int, error) {
@@ -141,7 +141,7 @@ func Collation(co string) Lattice {
 }
 
 func (a collationLattice) Unwrap() interface{} {
-	return a.kind.key
+	return a.value
 }
 
 func (a collationLattice) Compare(other Lattice) (int, error) {

--- a/pkg/schemacmp/charset_collation.go
+++ b/pkg/schemacmp/charset_collation.go
@@ -56,6 +56,9 @@ func (a charsetLattice) Compare(other Lattice) (int, error) {
 	}
 
 	if a.family == b.family {
+		if a.family == charsetFamilyOther && a.value != b.value {
+			return 0, incompatibleCharsetError(a.value, b.value)
+		}
 		return 0, nil
 	}
 
@@ -154,16 +157,12 @@ func (a collationLattice) Compare(other Lattice) (int, error) {
 		return 0, typeMismatchError(a, other)
 	}
 
-	if a.family == b.family {
-		if a.suffix == b.suffix {
-			return 0, nil
-		}
+	if a.suffix != b.suffix {
 		return 0, incompatibleCollationError(a.value, b.value)
 	}
 
-	// Only latin1/utf8/utf8mb4 with the same suffix are ordered.
-	if a.suffix != b.suffix {
-		return 0, incompatibleCollationError(a.value, b.value)
+	if a.family == b.family {
+		return 0, nil
 	}
 
 	switch {

--- a/pkg/schemacmp/charset_collation_test.go
+++ b/pkg/schemacmp/charset_collation_test.go
@@ -1,0 +1,45 @@
+package schemacmp_test
+
+import (
+	. "github.com/pingcap/check"
+
+	. "github.com/pingcap/tidb-tools/pkg/schemacmp"
+)
+
+type charsetCollationSuite struct{}
+
+var _ = Suite(&charsetCollationSuite{})
+
+func (*charsetCollationSuite) TestCharsetCompareUsesKind(c *C) {
+	// Ensure Compare only depends on the normalized kind, not the original input string.
+	cmp, err := Charset("UTF8").Compare(Charset("utf8"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, 0)
+
+	cmp, err = Charset("UTF8MB3").Compare(Charset("utf8"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, 0)
+
+	// Ensure error messages keep the original values.
+	_, err = Charset("UTF8").Compare(Charset("GBK"))
+	c.Assert(err, ErrorMatches, `distinct singletons \(UTF8 vs GBK\)`)
+}
+
+func (*charsetCollationSuite) TestCollationCompareUsesKind(c *C) {
+	// Ensure Compare only depends on the normalized kind, not the original input string.
+	cmp, err := Collation("UTF8_BIN").Compare(Collation("utf8_bin"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, 0)
+
+	cmp, err = Collation("UTF8MB3_BIN").Compare(Collation("utf8_bin"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, 0)
+
+	cmp, err = Collation("LATIN1_BIN").Compare(Collation("utf8mb4_bin"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, -1)
+
+	// Ensure error messages keep the original values.
+	_, err = Collation("UTF8_BIN").Compare(Collation("GBK_BIN"))
+	c.Assert(err, ErrorMatches, `distinct singletons \(UTF8_BIN vs GBK_BIN\)`)
+}

--- a/pkg/schemacmp/charset_collation_test.go
+++ b/pkg/schemacmp/charset_collation_test.go
@@ -31,6 +31,9 @@ func (*charsetCollationSuite) TestCharsetCompareUsesFamily(c *C) {
 	cmp, err = Charset("utf8mb4").Compare(Charset("utf8mb3"))
 	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, 1)
+
+	_, err = Charset("other1").Compare(Charset("other2"))
+	c.Assert(err, ErrorMatches, `incompatible mysql charset \(other1 vs other2\)`)
 }
 
 func (*charsetCollationSuite) TestCollationCompareUsesFamily(c *C) {

--- a/pkg/schemacmp/charset_collation_test.go
+++ b/pkg/schemacmp/charset_collation_test.go
@@ -10,7 +10,7 @@ type charsetCollationSuite struct{}
 
 var _ = Suite(&charsetCollationSuite{})
 
-func (*charsetCollationSuite) TestCharsetCompareUsesKind(c *C) {
+func (*charsetCollationSuite) TestCharsetCompareUsesFamily(c *C) {
 	// Ensure Compare only depends on the normalized kind, not the original input string.
 	cmp, err := Charset("UTF8").Compare(Charset("utf8"))
 	c.Assert(err, IsNil)
@@ -21,11 +21,19 @@ func (*charsetCollationSuite) TestCharsetCompareUsesKind(c *C) {
 	c.Assert(cmp, Equals, 0)
 
 	// Ensure error messages keep the original values.
-	_, err = Charset("UTF8").Compare(Charset("GBK"))
-	c.Assert(err, ErrorMatches, `distinct singletons \(UTF8 vs GBK\)`)
+	_, err = Charset("uTF8").Compare(Charset("GBK"))
+	c.Assert(err, ErrorMatches, `incompatible mysql charset \(uTF8 vs GBK\)`)
+
+	cmp, err = Charset("latin1").Compare(Charset("utf8mb4"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, -1)
+
+	cmp, err = Charset("utf8mb4").Compare(Charset("utf8mb3"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, 1)
 }
 
-func (*charsetCollationSuite) TestCollationCompareUsesKind(c *C) {
+func (*charsetCollationSuite) TestCollationCompareUsesFamily(c *C) {
 	// Ensure Compare only depends on the normalized kind, not the original input string.
 	cmp, err := Collation("UTF8_BIN").Compare(Collation("utf8_bin"))
 	c.Assert(err, IsNil)
@@ -41,5 +49,15 @@ func (*charsetCollationSuite) TestCollationCompareUsesKind(c *C) {
 
 	// Ensure error messages keep the original values.
 	_, err = Collation("UTF8_BIN").Compare(Collation("GBK_BIN"))
-	c.Assert(err, ErrorMatches, `distinct singletons \(UTF8_BIN vs GBK_BIN\)`)
+	c.Assert(err, ErrorMatches, `incompatible mysql collation \(UTF8_BIN vs GBK_BIN\)`)
+
+	cmp, err = Collation("utf8mb4_general_ci").Compare(Collation("utf8_general_ci"))
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, 1)
+
+	_, err = Collation("utf8mb4_general_ci").Compare(Collation("utf8mb4_0900_ai_ci"))
+	c.Assert(err, ErrorMatches, `incompatible mysql collation \(utf8mb4_general_ci vs utf8mb4_0900_ai_ci\)`)
+
+	_, err = Collation("other_cs_bin").Compare(Collation("other_cs_ci"))
+	c.Assert(err, ErrorMatches, `incompatible mysql collation \(other_cs_bin vs other_cs_ci\)`)
 }

--- a/pkg/schemacmp/lattice.go
+++ b/pkg/schemacmp/lattice.go
@@ -30,6 +30,8 @@ const (
 	ErrMsgTupleLengthMismatch    = "tuple length mismatch (%d vs %d)"
 	ErrMsgDistinctSingletons     = "distinct singletons (%v vs %v)"
 	ErrMsgIncompatibleType       = "incompatible mysql type (%v vs %v)"
+	ErrMsgIncompatibleCharset    = "incompatible mysql charset (%v vs %v)"
+	ErrMsgIncompatibleCollation  = "incompatible mysql collation (%v vs %v)"
 	ErrMsgAtTupleIndex           = "at tuple index %d: %v"
 	ErrMsgAtMapKey               = "at map key %q: %v"
 	ErrMsgNonInclusiveBitSets    = "non-inclusive bit sets (%#x vs %#x)"
@@ -65,6 +67,20 @@ func distinctSingletonsErrors(a, b interface{}) *IncompatibleError {
 func incompatibleTypeError(a, b interface{}) *IncompatibleError {
 	return &IncompatibleError{
 		Msg:  ErrMsgIncompatibleType,
+		Args: []interface{}{a, b},
+	}
+}
+
+func incompatibleCharsetError(a, b interface{}) *IncompatibleError {
+	return &IncompatibleError{
+		Msg:  ErrMsgIncompatibleCharset,
+		Args: []interface{}{a, b},
+	}
+}
+
+func incompatibleCollationError(a, b interface{}) *IncompatibleError {
+	return &IncompatibleError{
+		Msg:  ErrMsgIncompatibleCollation,
 		Args: []interface{}{a, b},
 	}
 }

--- a/pkg/schemacmp/table.go
+++ b/pkg/schemacmp/table.go
@@ -267,8 +267,8 @@ func encodeTableInfoToLattice(ti *model.TableInfo) Tuple {
 	}
 
 	return Tuple{
-		Singleton(ti.Charset),
-		Singleton(ti.Collate),
+		Charset(ti.Charset),
+		Collation(ti.Collate),
 		Map(columns),
 		Map(indices),
 		// TODO ForeignKeys?

--- a/pkg/schemacmp/table_test.go
+++ b/pkg/schemacmp/table_test.go
@@ -194,11 +194,11 @@ func (s *tableSchema) TestJoinSchemas(c *C) {
 			join: "CREATE TABLE tb3 (a INT, b VARCHAR(10), col1 VARCHAR(10) CHARSET utf8 COLLATE utf8_bin)",
 		},
 		{
-			name:    "DM_040",
-			a:       "CREATE TABLE tb1 (a INT, b VARCHAR(10), col1 VARCHAR(10) CHARSET utf8 COLLATE utf8_bin)",
-			b:       "CREATE TABLE tb2 (a INT, b VARCHAR(10), col1 VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin)",
-			cmpErr:  `.*"col1".*distinct singletons.*`,
-			joinErr: `.*"col1".*distinct singletons.*`,
+			name: "DM_040",
+			a:    "CREATE TABLE tb1 (a INT, b VARCHAR(10), col1 VARCHAR(10) CHARSET utf8 COLLATE utf8_bin)",
+			b:    "CREATE TABLE tb2 (a INT, b VARCHAR(10), col1 VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin)",
+			cmp:  -1,
+			join: "CREATE TABLE tb3 (a INT, b VARCHAR(10), col1 VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin)",
 		},
 		{
 			name: "DM_041/1",
@@ -264,11 +264,11 @@ func (s *tableSchema) TestJoinSchemas(c *C) {
 			join:   "CREATE TABLE tb3 (a INT, b VARCHAR(10), c INT DEFAULT 1)",
 		},
 		{
-			name:    "DM_061",
-			a:       "CREATE TABLE tb1 (a INT, b VARCHAR(10))",
-			b:       "CREATE TABLE tb2 (a INT, b VARCHAR(10) CHARSET utf8)",
-			cmpErr:  `.*"b".*distinct singletons.*`,
-			joinErr: `.*"b".*distinct singletons.*`,
+			name: "DM_061",
+			a:    "CREATE TABLE tb1 (a INT, b VARCHAR(10))",
+			b:    "CREATE TABLE tb2 (a INT, b VARCHAR(10) CHARSET utf8)",
+			cmp:  1,
+			join: "CREATE TABLE tb3 (a INT, b VARCHAR(10))",
 		},
 		{
 			name: "DM_066",
@@ -534,4 +534,30 @@ func (s *tableSchema) TestTableString(c *C) {
 			c.Assert(err, IsNil)
 		}
 	}
+}
+
+func (s *tableSchema) TestJoinTableCharsetCollation(c *C) {
+	tiUTF8, err := s.toTableInfo("CREATE TABLE tb (a INT)")
+	c.Assert(err, IsNil)
+	tiUTF8.Charset = "utf8"
+	tiUTF8.Collate = "utf8_bin"
+
+	tiUTF8MB4, err := s.toTableInfo("CREATE TABLE tb (a INT)")
+	c.Assert(err, IsNil)
+	tiUTF8MB4.Charset = "utf8mb4"
+	tiUTF8MB4.Collate = "utf8mb4_bin"
+
+	a := Encode(tiUTF8)
+	b := Encode(tiUTF8MB4)
+
+	cmp, err := a.Compare(b)
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, -1)
+
+	joined, err := a.Join(b)
+	c.Assert(err, IsNil)
+	c.Assert(joined, DeepEquals, b)
+	sql := strings.ToLower(joined.String())
+	c.Assert(strings.Contains(sql, "charset utf8mb4"), IsTrue)
+	c.Assert(strings.Contains(sql, "collate utf8mb4_bin"), IsTrue)
 }

--- a/pkg/schemacmp/table_test.go
+++ b/pkg/schemacmp/table_test.go
@@ -201,6 +201,13 @@ func (s *tableSchema) TestJoinSchemas(c *C) {
 			join: "CREATE TABLE tb3 (a INT, b VARCHAR(10), col1 VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin)",
 		},
 		{
+			name: "latin1_to_utf8mb4",
+			a:    "CREATE TABLE tb1 (a INT, col1 VARCHAR(10) CHARSET latin1 COLLATE latin1_bin)",
+			b:    "CREATE TABLE tb2 (a INT, col1 VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin)",
+			cmp:  -1,
+			join: "CREATE TABLE tb3 (a INT, col1 VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin)",
+		},
+		{
 			name: "DM_041/1",
 			a:    "CREATE TABLE tb1 (a INT, b VARCHAR(10), new_col1 INT AS (a + 1))",
 			b:    "CREATE TABLE tb2 (a INT, b VARCHAR(10))",
@@ -560,4 +567,18 @@ func (s *tableSchema) TestJoinTableCharsetCollation(c *C) {
 	sql := strings.ToLower(joined.String())
 	c.Assert(strings.Contains(sql, "charset utf8mb4"), IsTrue)
 	c.Assert(strings.Contains(sql, "collate utf8mb4_bin"), IsTrue)
+
+	tiLatin1, err := s.toTableInfo("CREATE TABLE tb (a INT)")
+	c.Assert(err, IsNil)
+	tiLatin1.Charset = "latin1"
+	tiLatin1.Collate = "latin1_bin"
+
+	a = Encode(tiLatin1)
+	cmp, err = a.Compare(b)
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, -1)
+
+	joined, err = a.Join(b)
+	c.Assert(err, IsNil)
+	c.Assert(joined, DeepEquals, b)
 }

--- a/pkg/schemacmp/type.go
+++ b/pkg/schemacmp/type.go
@@ -85,8 +85,8 @@ func encodeFieldTypeToLattice(ft *types.FieldType) Tuple {
 		Byte(encodeAntiKeys(ft.GetFlag())),
 		defVal,
 
-		Singleton(ft.GetCharset()),
-		Singleton(ft.GetCollate()),
+		Charset(ft.GetCharset()),
+		Collation(ft.GetCollate()),
 		StringList(ft.GetElems()),
 	}
 }

--- a/pkg/schemacmp/type_test.go
+++ b/pkg/schemacmp/type_test.go
@@ -464,15 +464,15 @@ func (*typeSchema) TestTypeCompareJoin(c *C) {
 			// latin1 and utf8 are not comparable/joinable.
 			a:            typeVarchar10Latin1Bin,
 			b:            typeVarchar10UTF8Bin,
-			compareError: `at tuple index \d+: distinct singletons.*`,
-			joinError:    `at tuple index \d+: distinct singletons.*`,
+			compareError: `at tuple index \d+: incompatible mysql charset.*`,
+			joinError:    `at tuple index \d+: incompatible mysql charset.*`,
 		},
 		{
 			// Only collations with the same suffix can be ordered/joined.
 			a:            typeVarchar10UTF8GeneralCI,
 			b:            typeVarchar10UTF8MB4Bin,
-			compareError: `at tuple index \d+: distinct singletons.*`,
-			joinError:    `at tuple index \d+: distinct singletons.*`,
+			compareError: `at tuple index \d+: incompatible mysql collation.*`,
+			joinError:    `at tuple index \d+: incompatible mysql collation.*`,
 		},
 		{
 			// Cannot join DEFAULT NULL with AUTO_INCREMENT.

--- a/pkg/schemacmp/type_test.go
+++ b/pkg/schemacmp/type_test.go
@@ -156,6 +156,30 @@ func init() {
 	typeChar123.SetCharset(mysql.UTF8MB4Charset)
 	typeChar123.SetCollate(mysql.UTF8MB4DefaultCollation)
 
+	// VARCHAR(10) CHARSET utf8 COLLATE utf8_bin
+	typeVarchar10UTF8Bin = types.NewFieldType(mysql.TypeVarchar)
+	typeVarchar10UTF8Bin.SetFlag(0)
+	typeVarchar10UTF8Bin.SetFlen(10)
+	typeVarchar10UTF8Bin.SetDecimal(0)
+	typeVarchar10UTF8Bin.SetCharset(mysql.UTF8Charset)
+	typeVarchar10UTF8Bin.SetCollate("utf8_bin")
+
+	// VARCHAR(10) CHARSET utf8 COLLATE utf8_general_ci
+	typeVarchar10UTF8GeneralCI = types.NewFieldType(mysql.TypeVarchar)
+	typeVarchar10UTF8GeneralCI.SetFlag(0)
+	typeVarchar10UTF8GeneralCI.SetFlen(10)
+	typeVarchar10UTF8GeneralCI.SetDecimal(0)
+	typeVarchar10UTF8GeneralCI.SetCharset(mysql.UTF8Charset)
+	typeVarchar10UTF8GeneralCI.SetCollate("utf8_general_ci")
+
+	// VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin
+	typeVarchar10UTF8MB4Bin = types.NewFieldType(mysql.TypeVarchar)
+	typeVarchar10UTF8MB4Bin.SetFlag(0)
+	typeVarchar10UTF8MB4Bin.SetFlen(10)
+	typeVarchar10UTF8MB4Bin.SetDecimal(0)
+	typeVarchar10UTF8MB4Bin.SetCharset(mysql.UTF8MB4Charset)
+	typeVarchar10UTF8MB4Bin.SetCollate(mysql.UTF8MB4DefaultCollation)
+
 	// VARCHAR(65432) CHARSET ascii
 	typeVarchar65432CharsetASCII = types.NewFieldType(mysql.TypeVarchar)
 	typeVarchar65432CharsetASCII.SetFlag(0)
@@ -301,6 +325,15 @@ var (
 	// VARCHAR(65432) CHARSET ascii
 	typeVarchar65432CharsetASCII *types.FieldType
 
+	// VARCHAR(10) CHARSET utf8 COLLATE utf8_bin
+	typeVarchar10UTF8Bin *types.FieldType
+
+	// VARCHAR(10) CHARSET utf8 COLLATE utf8_general_ci
+	typeVarchar10UTF8GeneralCI *types.FieldType
+
+	// VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin
+	typeVarchar10UTF8MB4Bin *types.FieldType
+
 	// BINARY(69)
 	typeBinary69 *types.FieldType
 
@@ -350,6 +383,9 @@ func (*typeSchema) TestTypeUnwrap(c *C) {
 		typeTime6,
 		typeYear4,
 		typeChar123,
+		typeVarchar10UTF8Bin,
+		typeVarchar10UTF8GeneralCI,
+		typeVarchar10UTF8MB4Bin,
 		typeVarchar65432CharsetASCII,
 		typeBinary69,
 		typeVarBinary420,
@@ -397,6 +433,20 @@ func (*typeSchema) TestTypeCompareJoin(c *C) {
 			b:             typeIntNotNull,
 			compareResult: 1,
 			join:          typeInt,
+		},
+		{
+			// utf8 < utf8mb4 (both charset and collation are ordered).
+			a:             typeVarchar10UTF8Bin,
+			b:             typeVarchar10UTF8MB4Bin,
+			compareResult: -1,
+			join:          typeVarchar10UTF8MB4Bin,
+		},
+		{
+			// Only collations with the same suffix can be ordered/joined.
+			a:            typeVarchar10UTF8GeneralCI,
+			b:            typeVarchar10UTF8MB4Bin,
+			compareError: `at tuple index \d+: distinct singletons.*`,
+			joinError:    `at tuple index \d+: distinct singletons.*`,
 		},
 		{
 			// Cannot join DEFAULT NULL with AUTO_INCREMENT.

--- a/pkg/schemacmp/type_test.go
+++ b/pkg/schemacmp/type_test.go
@@ -180,6 +180,14 @@ func init() {
 	typeVarchar10UTF8MB4Bin.SetCharset(mysql.UTF8MB4Charset)
 	typeVarchar10UTF8MB4Bin.SetCollate(mysql.UTF8MB4DefaultCollation)
 
+	// VARCHAR(10) CHARSET latin1 COLLATE latin1_bin
+	typeVarchar10Latin1Bin = types.NewFieldType(mysql.TypeVarchar)
+	typeVarchar10Latin1Bin.SetFlag(0)
+	typeVarchar10Latin1Bin.SetFlen(10)
+	typeVarchar10Latin1Bin.SetDecimal(0)
+	typeVarchar10Latin1Bin.SetCharset("latin1")
+	typeVarchar10Latin1Bin.SetCollate("latin1_bin")
+
 	// VARCHAR(65432) CHARSET ascii
 	typeVarchar65432CharsetASCII = types.NewFieldType(mysql.TypeVarchar)
 	typeVarchar65432CharsetASCII.SetFlag(0)
@@ -334,6 +342,9 @@ var (
 	// VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_bin
 	typeVarchar10UTF8MB4Bin *types.FieldType
 
+	// VARCHAR(10) CHARSET latin1 COLLATE latin1_bin
+	typeVarchar10Latin1Bin *types.FieldType
+
 	// BINARY(69)
 	typeBinary69 *types.FieldType
 
@@ -386,6 +397,7 @@ func (*typeSchema) TestTypeUnwrap(c *C) {
 		typeVarchar10UTF8Bin,
 		typeVarchar10UTF8GeneralCI,
 		typeVarchar10UTF8MB4Bin,
+		typeVarchar10Latin1Bin,
 		typeVarchar65432CharsetASCII,
 		typeBinary69,
 		typeVarBinary420,
@@ -440,6 +452,20 @@ func (*typeSchema) TestTypeCompareJoin(c *C) {
 			b:             typeVarchar10UTF8MB4Bin,
 			compareResult: -1,
 			join:          typeVarchar10UTF8MB4Bin,
+		},
+		{
+			// latin1 < utf8mb4 (both charset and collation are ordered).
+			a:             typeVarchar10Latin1Bin,
+			b:             typeVarchar10UTF8MB4Bin,
+			compareResult: -1,
+			join:          typeVarchar10UTF8MB4Bin,
+		},
+		{
+			// latin1 and utf8 are not comparable/joinable.
+			a:            typeVarchar10Latin1Bin,
+			b:            typeVarchar10UTF8Bin,
+			compareError: `at tuple index \d+: distinct singletons.*`,
+			joinError:    `at tuple index \d+: distinct singletons.*`,
 		},
 		{
 			// Only collations with the same suffix can be ordered/joined.


### PR DESCRIPTION
### What problem does this PR solve?

DM optimistic shard DDL relies on `schemacmp.Table` join/compare to compute a compatible schema across shards. Previously, charset/collation were encoded as `Singleton(string)`, so any mismatch (e.g. `utf8` vs `utf8mb4`, `latin1` vs `utf8mb4`, `utf8_bin` vs `utf8mb4_bin`) became incompatible and could block DDLs like `ALTER TABLE ... DEFAULT/CONVERT TO CHARACTER SET ...`.

Issue Number: close #891

Refs: pingcap/tiflow#11696

### What is changed and how it works?

- Introduce a `Charset()` lattice.
- Introduce a `Collation()` lattice.
- Wire both into table/column encoding:
- Update/add unit tests to cover the behavior:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test (`go test ./pkg/schemacmp`)

Code changes

- [x] Has exported function/method change

Side effects

- [ ] Increased code complexity

Related changes

- [ ] Need to be included in the release note

```release-note
None
```
