### PR TITLE
sync_diff_inspector: fix 'occured' -> 'occurred' typos in error messages

### DIFF
--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -104,7 +104,7 @@ func checkSyncState(ctx context.Context, cfg *config.Config) bool {
 
 	d, err := NewDiff(ctx, cfg)
 	if err != nil {
-		fmt.Printf("An error occured while initializing diff: %s, please check log info in %s for full details\n",
+		fmt.Printf("An error occurred while initializing diff: %s, please check log info in %s for full details\n",
 			err, filepath.Join(cfg.Task.OutputDir, config.LogFileName))
 		log.Fatal("failed to initialize diff process", zap.Error(err))
 		return false
@@ -114,7 +114,7 @@ func checkSyncState(ctx context.Context, cfg *config.Config) bool {
 	if !cfg.CheckDataOnly {
 		err = d.StructEqual(ctx)
 		if err != nil {
-			fmt.Printf("An error occured while comparing table structure: %s, please check log info in %s for full details\n",
+			fmt.Printf("An error occurred while comparing table structure: %s, please check log info in %s for full details\n",
 				err, filepath.Join(cfg.Task.OutputDir, config.LogFileName))
 			log.Fatal("failed to check structure difference", zap.Error(err))
 			return false
@@ -128,7 +128,7 @@ func checkSyncState(ctx context.Context, cfg *config.Config) bool {
 
 		err = d.Equal(ctx)
 		if err != nil {
-			fmt.Printf("An error occured while comparing table data: %s, please check log info in %s for full details\n",
+			fmt.Printf("An error occurred while comparing table data: %s, please check log info in %s for full details\n",
 				err, filepath.Join(cfg.Task.OutputDir, config.LogFileName))
 			log.Fatal("failed to check data difference", zap.Error(err))
 			return false


### PR DESCRIPTION
Three `fmt.Printf` messages in `sync_diff_inspector/main.go` (lines 107, 117, 131) read `An error occured while initializing diff / comparing table structure / comparing table data`. User-visible in the `sync_diff_inspector` binary's stdout. String-literal-only change.