### PR TITLE
sync_diff_inspector: check rows.Err in TiDB iterator

### DIFF
--- a/sync_diff_inspector/source/source_test.go
+++ b/sync_diff_inspector/source/source_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -257,6 +258,26 @@ func TestTiDBSource(t *testing.T) {
 			"╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╋╍╍╍╍╍╋╍╍╍╍╍╋╍╍╍╍╍╋╍╍╍╍╍╍╍╋╍╍╍╍╍╍╍╍\n"+
 			"*/\n"+
 			"REPLACE INTO `source_test`.`test1`(`a`,`b`,`c`,`d`,`e`) VALUES (1,'a',1.2,x'aa',x'aa');")
+
+	rowIter.Close()
+
+	// Test RowIterator returns the underlying database/sql row-stream error instead of treating it as clean EOF.
+	rowsErr := errors.New("tidb row stream cancelled")
+	errorRows := sqlmock.NewRows(tableCase.rowColumns).
+		AddRow(tableCase.rows[0]...).
+		AddRow(tableCase.rows[1]...).
+		RowError(1, rowsErr)
+	mock.ExpectQuery(tableCase.rowQuery).WillReturnRows(errorRows)
+	rowIter, err = tidb.GetRowsIterator(ctx, tableCase.rangeInfo)
+	require.NoError(t, err)
+
+	columns, err := rowIter.Next()
+	require.NoError(t, err)
+	require.NotNil(t, columns)
+
+	columns, err = rowIter.Next()
+	require.ErrorIs(t, err, rowsErr)
+	require.Nil(t, columns)
 
 	rowIter.Close()
 

--- a/sync_diff_inspector/source/tidb.go
+++ b/sync_diff_inspector/source/tidb.go
@@ -79,6 +79,9 @@ func (s *TiDBRowsIterator) Next() (map[string]*dbutil.ColumnData, error) {
 	if s.rows.Next() {
 		return dbutil.ScanRow(s.rows)
 	}
+	if err := s.rows.Err(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #900

`sync-diff-inspector` can silently swallow TiDB row-stream errors during row comparison.

When `TiDBRowsIterator.Next()` sees `rows.Next() == false`, it currently returns `(nil, nil)` directly. However, per the `database/sql` contract, `rows.Next() == false` can mean either clean EOF or an iteration error. The caller must check `rows.Err()` to distinguish the two cases.

If the TiDB-side query is cancelled mid-stream, for example due to `tidb_mem_quota_query`, `sync-diff-inspector` can incorrectly treat the TiDB iterator as exhausted. This may produce false `+N/-0` diffs and bogus `REPLACE INTO` fix SQL instead of surfacing the original TiDB query error.


### What is changed and how it works?

This PR updates `TiDBRowsIterator.Next()` to check `s.rows.Err()` after `s.rows.Next()` returns false.

If `rows.Err()` is non-nil, the iterator now returns the error instead of treating it as clean EOF. The existing row comparison flow already propagates non-nil iterator errors, so the table comparison fails with the real TiDB error instead of generating false fix SQL.

A unit test was added to cover the row-stream error case and verify that `TiDBRowsIterator.Next()` returns the underlying `database/sql` error.

### Check List 

Tests 

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
