### PR TITLE
dbutil: keep column and index buckets apart when names collide

### DIFF
--- a/pkg/dbutil/common.go
+++ b/pkg/dbutil/common.go
@@ -512,7 +512,13 @@ type Bucket struct {
 }
 
 func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string, tableInfo *model.TableInfo) (map[string][]Bucket, error) {
-	buckets := make(map[string][]Bucket)
+	// Column stats (is_index=0) and index stats (is_index=1) are collected
+	// separately and merged at the end: an index may share its name with a
+	// column (e.g. KEY `contentid` (`contentid`, ...)), and appending both
+	// bucket sequences under one key produced scalar column bounds where the
+	// caller expected index tuple bounds ("analyze value ... failed", #904).
+	columnBuckets := make(map[string][]Bucket)
+	indexBuckets := make(map[string][]Bucket)
 
 	indices := FindAllIndex(tableInfo)
 	// Pre-build lightweight maps for indices: index ID -> index name / column types.
@@ -562,6 +568,7 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 	}
 	defer rows.Close()
 
+	var buckets map[string][]Bucket
 	for rows.Next() {
 		var isIndex, histID, bucketID, count sql.NullInt64
 		var lowerBoundBytes, upperBoundBytes []byte
@@ -586,6 +593,7 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 			}
 
 			key = indexName
+			buckets = indexBuckets
 
 			// Decode index bound using pre-computed column types
 			lowerBoundStr, decodeErr = decodeIndexBound(lowerBoundBytes, idxColumnTypes)
@@ -616,6 +624,7 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 			}
 
 			key = columnName
+			buckets = columnBuckets
 			lowerBoundStr, decodeErr = decodeColumnBound(lowerBoundBytes, columnTypes)
 			if decodeErr != nil {
 				log.Warn("Failed to decode lower_bound for column",
@@ -646,21 +655,37 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 		return nil, errors.Trace(err)
 	}
 
+	// Merge: an index sharing its name with a column wins that key — lookups
+	// by index name must get the index statistics.
+	buckets = make(map[string][]Bucket, len(columnBuckets)+len(indexBuckets))
+	for k, v := range columnBuckets {
+		buckets[k] = v
+	}
+	for k, v := range indexBuckets {
+		buckets[k] = v
+	}
+
 	for _, index := range indices {
 		if index.Name.O != "PRIMARY" {
 			continue
 		}
-		_, ok := buckets[index.Name.O]
-		if !ok && len(index.Columns) == 1 {
-			if _, ok := buckets[index.Columns[0].Name.O]; !ok {
+		if _, ok := indexBuckets[index.Name.O]; ok {
+			continue
+		}
+		if len(index.Columns) == 1 {
+			pkColBuckets, ok := columnBuckets[index.Columns[0].Name.O]
+			if !ok {
 				log.Warn("GetBucketsInfo: No primary key buckets found, returning empty buckets",
 					zap.String("schema", schema),
 					zap.String("table", table),
 					zap.String("primary_key_column", index.Columns[0].Name.O))
 				return buckets, nil
 			}
-			buckets[index.Name.O] = buckets[index.Columns[0].Name.O]
-			delete(buckets, index.Columns[0].Name.O)
+			buckets[index.Name.O] = pkColBuckets
+			// Keep the column entry when an index owns that name now.
+			if _, isIndex := indexBuckets[index.Columns[0].Name.O]; !isIndex {
+				delete(buckets, index.Columns[0].Name.O)
+			}
 		}
 	}
 

--- a/pkg/dbutil/common_test.go
+++ b/pkg/dbutil/common_test.go
@@ -623,3 +623,83 @@ func (*testDBSuite) TestGetBucketsInfoWithBlobDecoding(c *C) {
 	// Verify all expectations were met
 	c.Assert(mock.ExpectationsWereMet(), IsNil)
 }
+
+// Regression for #904: an index may share its name with a column
+// (KEY `contentid` (`contentid`,`flag`,`datetime`)). Both column stats
+// (is_index=0, scalar bounds) and index stats (is_index=1, tuple bounds)
+// exist for that name; they must not be merged under one key.
+func (*testDBSuite) TestGetBucketsInfoIndexNameCollidesWithColumn(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	ftContentID := types.NewFieldType(pmysql.TypeLong)
+	ftContentID.SetFlen(8)
+
+	ftFlag := types.NewFieldType(pmysql.TypeTiny)
+	ftFlag.SetFlen(1)
+
+	ftDatetime := types.NewFieldType(pmysql.TypeLong)
+	ftDatetime.SetFlen(10)
+
+	tableInfo := &model.TableInfo{
+		ID:   2001,
+		Name: pmodel.NewCIStr("cmstop_digg_log"),
+		Columns: []*model.ColumnInfo{
+			{ID: 1, Name: pmodel.NewCIStr("contentid"), Offset: 0, FieldType: *ftContentID},
+			{ID: 2, Name: pmodel.NewCIStr("flag"), Offset: 1, FieldType: *ftFlag},
+			{ID: 3, Name: pmodel.NewCIStr("datetime"), Offset: 2, FieldType: *ftDatetime},
+		},
+		Indices: []*model.IndexInfo{
+			{
+				ID:     11,
+				Name:   pmodel.NewCIStr("contentid"),
+				Columns: []*model.IndexColumn{
+					{Name: pmodel.NewCIStr("contentid"), Offset: 0},
+					{Name: pmodel.NewCIStr("flag"), Offset: 1},
+					{Name: pmodel.NewCIStr("datetime"), Offset: 2},
+				},
+			},
+		},
+	}
+
+	expectedSQL := "SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id"
+
+	encodeIndexValue := func(values ...interface{}) []byte {
+		data := ttypes.MakeDatums(values...)
+		encoded, encodeErr := codec.EncodeKey(time.UTC, nil, data...)
+		c.Assert(encodeErr, IsNil)
+		return encoded
+	}
+
+	// Column stats for column contentid (hist_id=1 = column ID): scalar bounds.
+	// Index stats for index contentid (hist_id=11 = index ID): tuple bounds.
+	rows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"}).
+		AddRow(0, 1, 0, 50, []byte("1683800"), []byte("1683857")).
+		AddRow(0, 1, 1, 100, []byte("1683858"), []byte("1683900")).
+		AddRow(1, 11, 0, 150, encodeIndexValue(int64(882000), int64(0), int64(1585105600)), encodeIndexValue(int64(882856), int64(1), int64(1585105711))).
+		AddRow(1, 11, 1, 300, encodeIndexValue(int64(882857), int64(1), int64(1585105712)), encodeIndexValue(int64(883000), int64(1), int64(1585105800)))
+
+	mock.ExpectQuery(expectedSQL).WithArgs("test_db", "cmstop_digg_log", "test_db", "cmstop_digg_log").WillReturnRows(rows)
+
+	buckets, err := GetBucketsInfo(ctx, db, "test_db", "cmstop_digg_log", tableInfo)
+	c.Assert(err, IsNil)
+
+	// The index lookup must get ONLY the index buckets (tuple bounds), never
+	// the scalar column sequence — under the bug both were appended and
+	// AnalyzeValuesFromBuckets failed with "analyze value 1683857 failed".
+	idxBuckets, exists := buckets["contentid"]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(idxBuckets), Equals, 2)
+	c.Assert(idxBuckets[0].Count, Equals, int64(150))
+	c.Assert(idxBuckets[0].UpperBound, Equals, "(882856, 1, 1585105711)")
+	c.Assert(idxBuckets[1].Count, Equals, int64(300))
+
+	// Column-name lookups no longer collide with the index entry.
+	_, hasColumnEntry := buckets["flag"]
+	c.Assert(hasColumnEntry, Equals, false)
+
+	c.Assert(mock.ExpectationsWereMet(), IsNil)
+}


### PR DESCRIPTION
Issue Number: close #904

### What problem does this PR solve?

`GetBucketsInfo` merged column statistics and index statistics under bare names, so an index sharing its name with a column (e.g. `KEY \`contentid\` (\`contentid\`,\`flag\`,\`datetime\`)`) produced one bucket sequence mixing scalar column bounds with tuple index bounds — chunk splitting then failed with `analyze value 1683857 failed` (#904).

### What is changed and how it works?

Column (`is_index=0`) and index (`is_index=1`) buckets are collected into separate maps during the scan and merged at the end, with the index entry winning its own name: lookups by index name must return the index statistics. The `PRIMARY` fallback reads from the column map directly so a PK column named like another index keeps its own entry.

### Check List

- [x] Manual test: `TestGetBucketsInfoIndexNameCollidesWithColumn` (sqlmock) reproduces the report's table shape and asserts only the tuple buckets are returned under the index name; differential on unpatched code fails with the merged-sequence behavior.
- Full `./pkg/dbutil/` bucket tests pass.

```release-note
sync-diff-inspector: fix "analyze value ... failed" when an index shares its name with a column (column and index statistics no longer merge under one key)
```
